### PR TITLE
feat: garden management with theme selection and preview

### DIFF
--- a/frontend/src/pages/GardensPage.tsx
+++ b/frontend/src/pages/GardensPage.tsx
@@ -32,7 +32,7 @@ export default function GardensPage() {
 
   useEffect(() => {
     let cancelled = false;
-    fetch("/api/query/gardens")
+    fetch("/api/openplanner/v1/gardens")
       .then((resp) => {
         if (!resp.ok) throw new Error(`Failed to load gardens: ${resp.status}`);
         return resp.json() as Promise<GardensResponse>;

--- a/frontend/src/pages/GardensPage.tsx
+++ b/frontend/src/pages/GardensPage.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
-import { Button, Card } from '@open-hax/uxx';
+import { Button, Card, Input } from '@open-hax/uxx';
+
+type GardenTheme = 'monokai' | 'night-owl' | 'proxy-console';
 
 type Garden = {
   garden_id: string;
@@ -7,6 +9,14 @@ type Garden = {
   description: string;
   domain: string;
   status: string;
+  theme?: GardenTheme;
+  nav?: {
+    items: Array<{
+      label: string;
+      path: string;
+      children?: Array<{ label: string; path: string }>;
+    }>;
+  };
   source_filter?: { projects?: string[] };
   target_languages?: string[];
   auto_translate?: boolean;
@@ -18,6 +28,24 @@ type GardensResponse = {
   gardens: Garden[];
 };
 
+const THEMES: Array<{ value: GardenTheme; label: string; colors: { bg: string; text: string; accent: string } }> = [
+  { 
+    value: 'monokai', 
+    label: 'Monokai', 
+    colors: { bg: '#272822', text: '#f8f8f2', accent: '#a6e22e' } 
+  },
+  { 
+    value: 'night-owl', 
+    label: 'Night Owl', 
+    colors: { bg: '#011627', text: '#d6deeb', accent: '#82aaff' } 
+  },
+  { 
+    value: 'proxy-console', 
+    label: 'Proxy Console', 
+    colors: { bg: '#0a0a0a', text: '#e0e0e0', accent: '#00d4ff' } 
+  },
+];
+
 const gardenLinks: Record<string, string> = {
   "devel-deps-garden": "http://127.0.0.1:8798/",
   "truth-workbench": "http://127.0.0.1:8790/workbench",
@@ -25,40 +53,198 @@ const gardenLinks: Record<string, string> = {
   ingestion: "/ingestion",
 };
 
+function ThemeBadge({ theme }: { theme?: GardenTheme }) {
+  const themeInfo = THEMES.find(t => t.value === theme);
+  if (!themeInfo) return null;
+  
+  return (
+    <span 
+      className="rounded px-2 py-0.5 text-xs font-medium"
+      style={{ 
+        backgroundColor: themeInfo.colors.bg, 
+        color: themeInfo.colors.accent,
+        border: `1px solid ${themeInfo.colors.accent}40`
+      }}
+    >
+      {themeInfo.label}
+    </span>
+  );
+}
+
+function ThemePreview({ theme }: { theme: GardenTheme }) {
+  const themeInfo = THEMES.find(t => t.value === theme);
+  if (!themeInfo) return null;
+  
+  return (
+    <div 
+      className="rounded-lg p-4 text-sm"
+      style={{ 
+        backgroundColor: themeInfo.colors.bg, 
+        color: themeInfo.colors.text,
+        fontFamily: 'monospace'
+      }}
+    >
+      <div style={{ color: themeInfo.colors.accent }}># Preview</div>
+      <p className="mt-2 opacity-80">
+        This is how your garden will look with the {themeInfo.label} theme.
+      </p>
+      <pre className="mt-2 rounded p-2 opacity-90" style={{ background: 'rgba(255,255,255,0.05)' }}>
+{`const greeting = "Hello";
+console.log(greeting);`}
+      </pre>
+    </div>
+  );
+}
+
 export default function GardensPage() {
   const [data, setData] = useState<GardensResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [editingGarden, setEditingGarden] = useState<Garden | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+  
+  // Form state
+  const [formGardenId, setFormGardenId] = useState('');
+  const [formTitle, setFormTitle] = useState('');
+  const [formDescription, setFormDescription] = useState('');
+  const [formTheme, setFormTheme] = useState<GardenTheme>('monokai');
+  const [formDomain, setFormDomain] = useState('general');
+  const [formStatus, setFormStatus] = useState('active');
 
   useEffect(() => {
-    let cancelled = false;
-    fetch("/api/openplanner/v1/gardens")
-      .then((resp) => {
-        if (!resp.ok) throw new Error(`Failed to load gardens: ${resp.status}`);
-        return resp.json() as Promise<GardensResponse>;
-      })
-      .then((body) => {
-        if (!cancelled) setData(body);
-      })
-      .catch((err) => {
-        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
+    loadGardens();
   }, []);
+
+  async function loadGardens() {
+    setLoading(true);
+    setError(null);
+    try {
+      const resp = await fetch("/api/openplanner/v1/gardens");
+      if (!resp.ok) throw new Error(`Failed to load gardens: ${resp.status}`);
+      const body = await resp.json() as GardensResponse;
+      setData(body);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function resetForm() {
+    setFormGardenId('');
+    setFormTitle('');
+    setFormDescription('');
+    setFormTheme('monokai');
+    setFormDomain('general');
+    setFormStatus('active');
+    setEditingGarden(null);
+    setShowCreateForm(false);
+  }
+
+  function startEdit(garden: Garden) {
+    setEditingGarden(garden);
+    setFormGardenId(garden.garden_id);
+    setFormTitle(garden.title);
+    setFormDescription(garden.description);
+    setFormTheme(garden.theme || 'monokai');
+    setFormDomain(garden.domain);
+    setFormStatus(garden.status);
+    setShowCreateForm(true);
+  }
+
+  async function handleSave() {
+    if (!formGardenId.trim() || !formTitle.trim()) {
+      setError('Garden ID and title are required');
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    setNotice(null);
+
+    try {
+      const body = {
+        title: formTitle,
+        description: formDescription,
+        theme: formTheme,
+        domain: formDomain,
+        status: formStatus,
+      };
+
+      const resp = await fetch(`/api/openplanner/v1/gardens/${encodeURIComponent(formGardenId)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      if (!resp.ok) {
+        const text = await resp.text();
+        throw new Error(text || `Failed to save garden: ${resp.status}`);
+      }
+
+      setNotice(`Garden "${formTitle}" saved successfully`);
+      resetForm();
+      await loadGardens();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(gardenId: string) {
+    if (!confirm(`Are you sure you want to delete garden "${gardenId}"?`)) {
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      const resp = await fetch(`/api/openplanner/v1/gardens/${encodeURIComponent(gardenId)}`, {
+        method: 'DELETE',
+      });
+
+      if (!resp.ok) {
+        throw new Error(`Failed to delete garden: ${resp.status}`);
+      }
+
+      setNotice(`Garden "${gardenId}" deleted`);
+      await loadGardens();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
 
   return (
     <div className="space-y-4">
-      <div>
-        <h1 className="text-2xl font-bold">Gardens</h1>
-        <p className="mt-1 text-sm text-slate-500">
-          Publishable operator views over the same OpenPlanner runtime.
-        </p>
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Gardens</h1>
+          <p className="mt-1 text-sm text-slate-500">
+            Publishable operator views with themed markdown rendering.
+          </p>
+        </div>
+        <Button
+          variant="primary"
+          onClick={() => {
+            resetForm();
+            setShowCreateForm(true);
+          }}
+        >
+          + New Garden
+        </Button>
       </div>
+
+      {notice ? (
+        <div className="rounded-lg border border-green-200 bg-green-50 p-4 text-sm text-green-700 dark:border-green-900/40 dark:bg-green-950/30 dark:text-green-300">
+          {notice}
+        </div>
+      ) : null}
 
       {loading ? (
         <Card variant="default" padding="md">
@@ -72,10 +258,104 @@ export default function GardensPage() {
         </div>
       ) : null}
 
+      {showCreateForm ? (
+        <Card variant="elevated" padding="lg">
+          <div className="flex items-start justify-between mb-4">
+            <h2 className="text-lg font-semibold">
+              {editingGarden ? 'Edit Garden' : 'Create Garden'}
+            </h2>
+            <Button variant="ghost" size="sm" onClick={resetForm}>✕</Button>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <label className="mb-1 block text-sm font-medium">Garden ID</label>
+              <Input
+                value={formGardenId}
+                onChange={(e) => setFormGardenId(e.target.value)}
+                placeholder="my-garden-id"
+                disabled={!!editingGarden}
+              />
+              <p className="mt-1 text-xs text-slate-500">
+                Unique identifier (slug format, cannot be changed after creation)
+              </p>
+            </div>
+
+            <div>
+              <label className="mb-1 block text-sm font-medium">Title</label>
+              <Input
+                value={formTitle}
+                onChange={(e) => setFormTitle(e.target.value)}
+                placeholder="My Garden"
+              />
+            </div>
+
+            <div className="md:col-span-2">
+              <label className="mb-1 block text-sm font-medium">Description</label>
+              <textarea
+                value={formDescription}
+                onChange={(e) => setFormDescription(e.target.value)}
+                placeholder="Brief description of this garden"
+                rows={2}
+                className="w-full rounded-lg border border-slate-300 p-2 text-sm dark:border-slate-600 dark:bg-slate-800"
+              />
+            </div>
+
+            <div>
+              <label className="mb-1 block text-sm font-medium">Theme</label>
+              <select
+                value={formTheme}
+                onChange={(e) => setFormTheme(e.target.value as GardenTheme)}
+                className="w-full rounded-lg border border-slate-300 p-2 text-sm dark:border-slate-600 dark:bg-slate-800"
+              >
+                {THEMES.map(theme => (
+                  <option key={theme.value} value={theme.value}>{theme.label}</option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label className="mb-1 block text-sm font-medium">Status</label>
+              <select
+                value={formStatus}
+                onChange={(e) => setFormStatus(e.target.value)}
+                className="w-full rounded-lg border border-slate-300 p-2 text-sm dark:border-slate-600 dark:bg-slate-800"
+              >
+                <option value="active">Active</option>
+                <option value="inactive">Inactive</option>
+              </select>
+            </div>
+
+            <div>
+              <label className="mb-1 block text-sm font-medium">Domain</label>
+              <Input
+                value={formDomain}
+                onChange={(e) => setFormDomain(e.target.value)}
+                placeholder="general"
+              />
+            </div>
+
+            <div className="md:col-span-2">
+              <label className="mb-1 block text-sm font-medium">Theme Preview</label>
+              <ThemePreview theme={formTheme} />
+            </div>
+          </div>
+
+          <div className="mt-6 flex gap-2">
+            <Button variant="primary" onClick={handleSave} loading={saving}>
+              {editingGarden ? 'Save Changes' : 'Create Garden'}
+            </Button>
+            <Button variant="ghost" onClick={resetForm}>
+              Cancel
+            </Button>
+          </div>
+        </Card>
+      ) : null}
+
       <div className="grid gap-4 md:grid-cols-2">
         {data?.gardens?.map((garden) => {
-          const href = gardenLinks[garden.garden_id];
-          const projects = garden.source_filter?.projects || [];
+          const gardenHtmlUrl = `/api/openplanner/v1/public/gardens/${garden.garden_id}/html`;
+          
           return (
             <Card
               key={garden.garden_id}
@@ -89,58 +369,63 @@ export default function GardensPage() {
                     {garden.description}
                   </p>
                 </div>
-                <span className="rounded-full bg-slate-100 px-2 py-1 text-xs font-medium text-slate-700 dark:bg-slate-700 dark:text-slate-200">
-                  {garden.garden_id}
-                </span>
-              </div>
-
-              <div className="mt-4 space-y-3 text-sm">
-                {projects.length > 0 ? (
-                  <div>
-                    <div className="mb-1 font-medium text-slate-700 dark:text-slate-200">Projects</div>
-                    <div className="flex flex-wrap gap-2">
-                      {projects.map((project) => (
-                        <span key={project} className="rounded bg-slate-100 px-2 py-0.5 text-xs dark:bg-slate-700">
-                          {project}
-                        </span>
-                      ))}
-                    </div>
-                  </div>
-                ) : null}
-
-                {garden.target_languages && garden.target_languages.length > 0 ? (
-                  <div>
-                    <div className="mb-1 font-medium text-slate-700 dark:text-slate-200">Languages</div>
-                    <div className="text-slate-600 dark:text-slate-300">{garden.target_languages.join(", ")}</div>
-                  </div>
-                ) : null}
-
-                <div>
-                  <div className="mb-1 font-medium text-slate-700 dark:text-slate-200">Domain</div>
-                  <div className="text-slate-600 dark:text-slate-300">{garden.domain}</div>
+                <div className="flex items-center gap-2">
+                  <ThemeBadge theme={garden.theme} />
+                  <span className="rounded-full bg-slate-100 px-2 py-1 text-xs font-medium text-slate-700 dark:bg-slate-700 dark:text-slate-200">
+                    {garden.garden_id}
+                  </span>
                 </div>
               </div>
 
+              <div className="mt-4 flex items-center gap-4 text-sm">
+                <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                  garden.status === 'active' 
+                    ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300' 
+                    : 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300'
+                }`}>
+                  {garden.status}
+                </span>
+                <span className="text-slate-600 dark:text-slate-400">
+                  Domain: {garden.domain}
+                </span>
+              </div>
+
               <div className="mt-5 flex gap-2">
-                {href ? (
-                  <Button
-                    onClick={() => {
-                      if (href.startsWith('http')) {
-                        window.open(href, '_blank', 'noopener,noreferrer');
-                      } else {
-                        window.location.assign(href);
-                      }
-                    }}
-                    variant="primary"
-                  >
-                    Open Garden
-                  </Button>
-                ) : null}
+                <Button
+                  onClick={() => window.open(gardenHtmlUrl, '_blank')}
+                  variant="primary"
+                  size="sm"
+                >
+                  View Garden
+                </Button>
+                <Button
+                  onClick={() => startEdit(garden)}
+                  variant="secondary"
+                  size="sm"
+                >
+                  Edit
+                </Button>
+                <Button
+                  onClick={() => handleDelete(garden.garden_id)}
+                  variant="ghost"
+                  size="sm"
+                >
+                  Delete
+                </Button>
               </div>
             </Card>
           );
         })}
       </div>
+
+      {data?.gardens?.length === 0 && !loading ? (
+        <Card variant="default" padding="lg" className="text-center">
+          <p className="text-slate-500">No gardens yet.</p>
+          <p className="mt-1 text-sm text-slate-400">
+            Create a garden to start publishing markdown documents with themes.
+          </p>
+        </Card>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/pages/GardensPage.tsx
+++ b/frontend/src/pages/GardensPage.tsx
@@ -4,11 +4,12 @@ import { Button, Card } from '@open-hax/uxx';
 type Garden = {
   garden_id: string;
   title: string;
-  purpose: string;
-  lakes: string[];
-  views: string[];
-  actions: string[];
-  outputs: string[];
+  description: string;
+  domain: string;
+  status: string;
+  source_filter?: { projects?: string[] };
+  target_languages?: string[];
+  auto_translate?: boolean;
 };
 
 type GardensResponse = {
@@ -74,6 +75,7 @@ export default function GardensPage() {
       <div className="grid gap-4 md:grid-cols-2">
         {data?.gardens?.map((garden) => {
           const href = gardenLinks[garden.garden_id];
+          const projects = garden.source_filter?.projects || [];
           return (
             <Card
               key={garden.garden_id}
@@ -84,7 +86,7 @@ export default function GardensPage() {
                 <div>
                   <h2 className="text-lg font-semibold">{garden.title}</h2>
                   <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-                    {garden.purpose}
+                    {garden.description}
                   </p>
                 </div>
                 <span className="rounded-full bg-slate-100 px-2 py-1 text-xs font-medium text-slate-700 dark:bg-slate-700 dark:text-slate-200">
@@ -93,25 +95,29 @@ export default function GardensPage() {
               </div>
 
               <div className="mt-4 space-y-3 text-sm">
-                <div>
-                  <div className="mb-1 font-medium text-slate-700 dark:text-slate-200">Lakes</div>
-                  <div className="flex flex-wrap gap-2">
-                    {garden.lakes.map((lake) => (
-                      <span key={lake} className="rounded bg-slate-100 px-2 py-0.5 text-xs dark:bg-slate-700">
-                        {lake}
-                      </span>
-                    ))}
+                {projects.length > 0 ? (
+                  <div>
+                    <div className="mb-1 font-medium text-slate-700 dark:text-slate-200">Projects</div>
+                    <div className="flex flex-wrap gap-2">
+                      {projects.map((project) => (
+                        <span key={project} className="rounded bg-slate-100 px-2 py-0.5 text-xs dark:bg-slate-700">
+                          {project}
+                        </span>
+                      ))}
+                    </div>
                   </div>
-                </div>
+                ) : null}
+
+                {garden.target_languages && garden.target_languages.length > 0 ? (
+                  <div>
+                    <div className="mb-1 font-medium text-slate-700 dark:text-slate-200">Languages</div>
+                    <div className="text-slate-600 dark:text-slate-300">{garden.target_languages.join(", ")}</div>
+                  </div>
+                ) : null}
 
                 <div>
-                  <div className="mb-1 font-medium text-slate-700 dark:text-slate-200">Views</div>
-                  <div className="text-slate-600 dark:text-slate-300">{garden.views.join(", ")}</div>
-                </div>
-
-                <div>
-                  <div className="mb-1 font-medium text-slate-700 dark:text-slate-200">Actions</div>
-                  <div className="text-slate-600 dark:text-slate-300">{garden.actions.join(", ")}</div>
+                  <div className="mb-1 font-medium text-slate-700 dark:text-slate-200">Domain</div>
+                  <div className="text-slate-600 dark:text-slate-300">{garden.domain}</div>
                 </div>
               </div>
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+// Backend URL for Vite dev server proxy
+// Use VITE_KNOXX_BACKEND_URL env var, or default to container service name
+const VITE_BACKEND_URL = process.env.VITE_KNOXX_BACKEND_URL || "http://knoxx-backend:8000";
+
 export default defineConfig({
   plugins: [react()],
   server: {
@@ -9,17 +13,17 @@ export default defineConfig({
     strictPort: true,
     proxy: {
       "/api": {
-        target: "http://127.0.0.1:8001",
-        changeOrigin: true
+        target: VITE_BACKEND_URL,
+        changeOrigin: true,
       },
       "/ws": {
-        target: "ws://127.0.0.1:8001",
-        ws: true
+        target: VITE_BACKEND_URL.replace("http://", "ws://").replace("https://", "wss://"),
+        ws: true,
       },
       "/health": {
-        target: "http://127.0.0.1:8001",
-        changeOrigin: true
-      }
-    }
-  }
+        target: VITE_BACKEND_URL,
+        changeOrigin: true,
+      },
+    },
+  },
 });

--- a/specs/simple-markdown-gardens.md
+++ b/specs/simple-markdown-gardens.md
@@ -1,0 +1,218 @@
+# Simple Markdown Gardens
+
+**Status:** Draft
+**Created:** 2026-04-11
+**Owner:** CMS/Gardens
+
+## Overview
+
+Gardens are CMS-managed publication targets that render markdown documents with a selectable uxx theme. Each garden is a simple static-ish site: a collection of markdown documents with consistent styling.
+
+## Problem
+
+Current "gardens" are hardcoded workbenches (query, ingestion, truth-workbench) that:
+- Are independent web applications, not CMS-managed
+- Have no connection to document content
+- Cannot be styled or themed
+- Cannot be created by users
+
+We need gardens that:
+- Are created and managed through CMS
+- Render markdown documents from the document store
+- Support selectable themes from the uxx design system
+- Are simple static sites, not complex applications
+
+## Simplified Data Model
+
+### Garden Document (MongoDB `gardens` collection)
+
+```typescript
+interface Garden {
+  _id: ObjectId;
+  garden_id: string;           // URL-safe slug, unique
+  title: string;               // Display name
+  description?: string;        // Optional description
+  
+  // Theme configuration
+  theme: string;               // uxx theme name (default, monokai, etc.)
+  
+  // Publication settings  
+  default_language: string;    // Primary language (e.g., "en")
+  target_languages?: string[]; // Optional translation targets (future)
+  
+  // Content filtering - which documents belong to this garden
+  source_filter: {
+    project?: string;          // e.g., "devel"
+    kind?: string;             // e.g., "docs"
+    domain?: string;           // Content domain filter
+    path_prefix?: string;      // Path prefix filter
+  };
+  
+  // Navigation
+  nav?: {
+    items: {
+      label: string;
+      path: string;
+      children?: { label: string; path: string }[];
+    }[];
+  };
+  
+  // Metadata
+  owner_id: string;
+  created_by: string;
+  created_at: Date;
+  updated_at: Date;
+  status: "draft" | "active" | "archived";
+}
+```
+
+### Key Changes from Previous Model
+
+1. **Removed translation complexity** - No auto_translate, translation_status, etc.
+2. **Removed domain routing** - Gardens live at `/gardens/:garden_id/*`
+3. **Added theme selection** - Simple string field for uxx theme
+4. **Simplified source_filter** - Just project/kind/domain/path_prefix
+5. **Added navigation config** - Custom nav structure for the garden
+
+## API Surface
+
+### Garden Management (existing, unchanged)
+
+- `GET /v1/gardens` - List gardens
+- `POST /v1/gardens` - Create garden
+- `GET /v1/gardens/:id` - Get garden details
+- `PATCH /v1/gardens/:id` - Update garden
+- `DELETE /v1/gardens/:id` - Archive garden
+
+### Garden Documents (existing, unchanged)
+
+- `GET /v1/gardens/:id/documents` - List documents in garden
+- `GET /v1/public/gardens/:garden_id` - Public garden landing
+- `GET /v1/public/gardens/:garden_id/documents` - Public document list
+- `GET /v1/public/gardens/:garden_id/documents/:doc_id` - Single document
+
+## Rendering
+
+### Theme Application
+
+Each garden renders documents using its selected theme. The uxx package provides:
+
+- `default` - Light theme with blue accents
+- `monokai` - Dark theme (workspace default)
+- `minimal` - Clean, minimal styling
+
+### Markdown Rendering
+
+Documents are stored as markdown content. Rendering flow:
+
+```
+GET /v1/public/gardens/:garden_id/documents/:doc_id
+         │
+         ▼
+┌─────────────────────────────────────┐
+│ 1. Load garden config (theme, etc)  │
+│ 2. Load document content            │
+│ 3. Apply source_filter to verify    │
+└─────────────────────────────────────┘
+         │
+         ▼
+┌─────────────────────────────────────┐
+│ 4. Render markdown to HTML          │
+│ 5. Apply garden theme CSS           │
+│ 6. Add garden navigation            │
+└─────────────────────────────────────┘
+         │
+         ▼
+┌─────────────────────────────────────┐
+│ 7. Return HTML or JSON (content-neg)│
+└─────────────────────────────────────┘
+```
+
+## Frontend Components
+
+### Garden List Page (`/gardens`)
+
+Shows all gardens the user can access with:
+- Garden title and description
+- Theme preview
+- Document count
+- Links to view/manage
+
+### Garden View Page (`/gardens/:garden_id`)
+
+Renders the garden as a public site:
+- Applies selected theme
+- Shows navigation
+- Lists documents
+- Renders individual documents
+
+### Garden Admin Page (`/admin/gardens`)
+
+For managing gardens:
+- Create/edit/delete gardens
+- Configure theme
+- Set source filters
+- Customize navigation
+
+## Implementation Plan
+
+### Phase 1: Simplify Model
+- Remove translation-related fields from garden schema
+- Add `theme` field with default value
+- Simplify `source_filter` structure
+- Add `nav` configuration
+
+### Phase 2: Theme Integration
+- Import uxx themes into garden rendering
+- Create theme selection UI in admin
+- Apply theme CSS to rendered documents
+
+### Phase 3: Navigation
+- Implement nav configuration
+- Auto-generate nav from document structure
+- Support custom nav overrides
+
+### Phase 4: Public Views
+- Build garden landing page component
+- Document list with theme
+- Single document view with theme
+- Syntax highlighting for code blocks
+
+## Example Garden
+
+```json
+{
+  "garden_id": "knoxx-docs",
+  "title": "Knoxx Documentation",
+  "description": "User guide and API reference for Knoxx",
+  "theme": "monokai",
+  "default_language": "en",
+  "source_filter": {
+    "project": "knoxx",
+    "kind": "docs"
+  },
+  "nav": {
+    "items": [
+      { "label": "Getting Started", "path": "/getting-started" },
+      { "label": "API Reference", "path": "/api" },
+      { 
+        "label": "Guides", 
+        "path": "/guides",
+        "children": [
+          { "label": "Chat", "path": "/guides/chat" },
+          { "label": "CMS", "path": "/guides/cms" }
+        ]
+      }
+    ]
+  },
+  "status": "active"
+}
+```
+
+## Success Criteria
+
+- Gardens can be created/managed via CMS UI
+- Each garden has a selectable theme
+- Documents are rendered with applied theme
+- Navigation reflects garden structure
+- Public views work without authentication


### PR DESCRIPTION
## Summary

Cherry-picked garden feature commits onto main:

### Garden Management UI
- Added create/edit garden forms with theme selection
- Added theme preview component showing how garden will look
- Added delete garden functionality
- Show theme badges and status indicators
- Added 'View Garden' button linking to rendered HTML
- Support for monokai, night-owl, and proxy-console themes

### Bug Fixes
- Fixed vite proxy to use `VITE_KNOXX_BACKEND_URL` env var
- Updated GardensPage to match API schema
- Added simple markdown gardens spec

## Test plan

- [x] Verified garden create/edit/delete in UI
- [x] Tested theme selection and preview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced full create/edit/delete workflows for gardens with intuitive form interface.
  * Redesigned garden management cards to display theme, status, and domain information.
  * Added theme picker and preview functionality for garden customization.
  * Replaced legacy garden attributes with new configuration model.

* **Documentation**
  * Added specification document for Simple Markdown Gardens feature, including API surface and rendering workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->