### PR TITLE
devops: add Promethean promotion deploy workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      - staging
   push:
     branches:
       - main
+      - staging
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,42 @@
+name: Deploy Knoxx Production
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: knoxx-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy Knoxx production
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Configure SSH
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "${{ secrets.PROMETHEAN_SSH_PRIVATE_KEY }}" > ~/.ssh/promethean
+          chmod 600 ~/.ssh/promethean
+          ssh-keyscan -H "${{ vars.PROMETHEAN_SSH_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Deploy
+        env:
+          DEPLOY_ENV: production
+          PROMETHEAN_SSH_HOST: ${{ vars.PROMETHEAN_SSH_HOST }}
+          PROMETHEAN_SSH_USER: ${{ vars.PROMETHEAN_SSH_USER }}
+          PROMETHEAN_SSH_KEY_PATH: ~/.ssh/promethean
+          KNOXX_REMOTE_SOURCE_PATH: ${{ vars.KNOXX_REMOTE_SOURCE_PATH }}
+          OPENPLANNER_SERVICE_PATH: ${{ vars.OPENPLANNER_SERVICE_PATH }}
+          KNOXX_COMPOSE_PROJECT: ${{ vars.KNOXX_COMPOSE_PROJECT }}
+          KNOXX_BACKEND_PORT: ${{ vars.KNOXX_BACKEND_PORT }}
+          KNOXX_PUBLIC_BASE_URL: ${{ vars.KNOXX_PUBLIC_BASE_URL }}
+        run: scripts/deploy-promethean-knoxx.sh

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,42 @@
+name: Deploy Knoxx Staging
+
+on:
+  push:
+    branches: [staging]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: knoxx-staging
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy Knoxx staging
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Configure SSH
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "${{ secrets.PROMETHEAN_SSH_PRIVATE_KEY }}" > ~/.ssh/promethean
+          chmod 600 ~/.ssh/promethean
+          ssh-keyscan -H "${{ vars.PROMETHEAN_SSH_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Deploy
+        env:
+          DEPLOY_ENV: staging
+          PROMETHEAN_SSH_HOST: ${{ vars.PROMETHEAN_SSH_HOST }}
+          PROMETHEAN_SSH_USER: ${{ vars.PROMETHEAN_SSH_USER }}
+          PROMETHEAN_SSH_KEY_PATH: ~/.ssh/promethean
+          KNOXX_REMOTE_SOURCE_PATH: ${{ vars.KNOXX_REMOTE_SOURCE_PATH }}
+          OPENPLANNER_SERVICE_PATH: ${{ vars.OPENPLANNER_SERVICE_PATH }}
+          KNOXX_COMPOSE_PROJECT: ${{ vars.KNOXX_COMPOSE_PROJECT }}
+          KNOXX_BACKEND_PORT: ${{ vars.KNOXX_BACKEND_PORT }}
+          KNOXX_PUBLIC_BASE_URL: ${{ vars.KNOXX_PUBLIC_BASE_URL }}
+        run: scripts/deploy-promethean-knoxx.sh

--- a/.github/workflows/ingestion-ci.yml
+++ b/.github/workflows/ingestion-ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - staging
     paths:
       - 'ingestion/**'
       - 'contracts/**'
@@ -11,6 +12,7 @@ on:
   push:
     branches:
       - main
+      - staging
     paths:
       - 'ingestion/**'
       - 'contracts/**'

--- a/scripts/deploy-promethean-knoxx.sh
+++ b/scripts/deploy-promethean-knoxx.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${PROMETHEAN_SSH_HOST:?PROMETHEAN_SSH_HOST is required}"
+: "${PROMETHEAN_SSH_USER:=error}"
+: "${PROMETHEAN_SSH_KEY_PATH:?PROMETHEAN_SSH_KEY_PATH is required}"
+: "${KNOXX_REMOTE_SOURCE_PATH:?KNOXX_REMOTE_SOURCE_PATH is required}"
+: "${OPENPLANNER_SERVICE_PATH:?OPENPLANNER_SERVICE_PATH is required}"
+: "${KNOXX_COMPOSE_PROJECT:?KNOXX_COMPOSE_PROJECT is required}"
+: "${KNOXX_BACKEND_PORT:?KNOXX_BACKEND_PORT is required}"
+: "${KNOXX_PUBLIC_BASE_URL:?KNOXX_PUBLIC_BASE_URL is required}"
+: "${DEPLOY_ENV:?DEPLOY_ENV is required}"
+
+rsync -az --delete \
+  --exclude '.git' \
+  --exclude 'node_modules' \
+  --exclude '.shadow-cljs' \
+  --exclude 'target' \
+  --exclude 'coverage' \
+  -e "ssh -i ${PROMETHEAN_SSH_KEY_PATH}" \
+  ./ "${PROMETHEAN_SSH_USER}@${PROMETHEAN_SSH_HOST}:${KNOXX_REMOTE_SOURCE_PATH}/"
+
+ssh -i "${PROMETHEAN_SSH_KEY_PATH}" "${PROMETHEAN_SSH_USER}@${PROMETHEAN_SSH_HOST}" \
+  DEPLOY_ENV="$DEPLOY_ENV" \
+  KNOXX_BACKEND_PORT="$KNOXX_BACKEND_PORT" \
+  KNOXX_COMPOSE_PROJECT="$KNOXX_COMPOSE_PROJECT" \
+  KNOXX_PUBLIC_BASE_URL="$KNOXX_PUBLIC_BASE_URL" \
+  KNOXX_REMOTE_SOURCE_PATH="$KNOXX_REMOTE_SOURCE_PATH" \
+  OPENPLANNER_SERVICE_PATH="$OPENPLANNER_SERVICE_PATH" \
+  'bash -s' <<'REMOTE'
+set -euo pipefail
+cd "$OPENPLANNER_SERVICE_PATH"
+ENV_FILE=".env.vps"
+if [ "$DEPLOY_ENV" = "staging" ]; then
+  ENV_FILE=".env.staging"
+  if [ ! -f "$ENV_FILE" ]; then cp .env.vps "$ENV_FILE"; fi
+fi
+prod_token=$(docker exec proxx-production-federation-proxx-a1-1 printenv PROXY_AUTH_TOKEN)
+python3 - "$prod_token" "$ENV_FILE" <<'PYREMOTE'
+from pathlib import Path
+import secrets, sys
+prod_token, env_file = sys.argv[1], sys.argv[2]
+p=Path(env_file)
+vals={}
+lines=p.read_text().splitlines() if p.exists() else []
+for line in lines:
+    if '=' in line and not line.lstrip().startswith('#'):
+        k,v=line.split('=',1); vals[k]=v
+updates={
+    'PROXX_BASE_URL':'https://proxx.promethean.rest',
+    'PROXX_AUTH_TOKEN':prod_token,
+    'PROXX_DEFAULT_MODEL':'gpt-5.5',
+    'KNOXX_API_KEY_USER_EMAIL': vals.get('KNOXX_API_KEY_USER_EMAIL') or vals.get('KNOXX_BOOTSTRAP_SYSTEM_ADMIN_EMAIL') or 'foamy125@gmail.com',
+}
+if not vals.get('KNOXX_API_KEY'):
+    updates['KNOXX_API_KEY']='knoxx-dev-'+secrets.token_urlsafe(32)
+out=[]; seen=set()
+for line in lines:
+    if '=' in line and not line.lstrip().startswith('#'):
+        k=line.split('=',1)[0]
+        if k in updates:
+            out.append(f'{k}={updates[k]}'); seen.add(k); continue
+    out.append(line)
+for k,v in updates.items():
+    if k not in seen: out.append(f'{k}={v}')
+p.write_text('\n'.join(out)+'\n')
+PYREMOTE
+unset prod_token
+cat > "deploy.knoxx.${DEPLOY_ENV}.override.yml" <<YAML
+services:
+  knoxx-postgres:
+    ports: !reset []
+  knoxx-redis:
+    ports: !reset []
+  backend:
+    build:
+      context: ${KNOXX_REMOTE_SOURCE_PATH}/backend
+      dockerfile: Dockerfile
+    env_file:
+      - path: ${KNOXX_REMOTE_SOURCE_PATH}/.env
+        required: false
+    environment:
+      PROXX_BASE_URL: \${PROXX_BASE_URL:-https://proxx.promethean.rest}
+      PROXX_AUTH_TOKEN: \${PROXX_AUTH_TOKEN:?PROXX_AUTH_TOKEN is required}
+      PROXX_DEFAULT_MODEL: \${PROXX_DEFAULT_MODEL:-gpt-5.5}
+      KNOXX_API_KEY: \${KNOXX_API_KEY:?KNOXX_API_KEY is required}
+      KNOXX_API_KEY_USER_EMAIL: \${KNOXX_API_KEY_USER_EMAIL:-foamy125@gmail.com}
+      KNOXX_PUBLIC_BASE_URL: ${KNOXX_PUBLIC_BASE_URL}
+    ports: !reset
+      - "127.0.0.1:${KNOXX_BACKEND_PORT}:8000"
+    volumes:
+      - knoxx-workspace:/app/workspace
+      - knoxx-runs:/runs/knoxx-agent
+      - /var/run/docker.sock:/var/run/docker.sock
+      - \${KNOXX_SANDBOX_ROOT_DIR:-/home/error/devel/services/openplanner/runtime/knoxx-sandboxes}:\${KNOXX_SANDBOX_ROOT_DIR:-/home/error/devel/services/openplanner/runtime/knoxx-sandboxes}
+      - ${KNOXX_REMOTE_SOURCE_PATH}/contracts:/app/contracts:ro
+      - ./cloud/github-app-key.pem:/run/secrets/github-app-key.pem:ro
+  frontend:
+    build:
+      context: ${KNOXX_REMOTE_SOURCE_PATH}/frontend
+      dockerfile: Dockerfile
+  knoxx-ingestion:
+    build:
+      context: ${KNOXX_REMOTE_SOURCE_PATH}/ingestion
+      dockerfile: Dockerfile
+YAML
+docker compose --env-file "$ENV_FILE" --project-name "$KNOXX_COMPOSE_PROJECT" -f docker-compose.knoxx.yml -f "deploy.knoxx.${DEPLOY_ENV}.override.yml" up -d --build backend
+for _ in $(seq 1 30); do
+  status=$(docker inspect -f '{{.State.Health.Status}}' "${KNOXX_COMPOSE_PROJECT}-backend-1" 2>/dev/null || docker inspect -f '{{.State.Health.Status}}' knoxx-backend-1 2>/dev/null || echo none)
+  [ "$status" = healthy ] && break
+  sleep 6
+done
+key=$(grep -E '^KNOXX_API_KEY=' "$ENV_FILE" | tail -1 | cut -d= -f2-)
+curl -fsS -H "x-api-key: ${key}" "http://127.0.0.1:${KNOXX_BACKEND_PORT}/api/knoxx/health" >/tmp/knoxx-health.json
+REMOTE


### PR DESCRIPTION
Adds staging and production GitHub Actions deploy workflows for the Promethean Knoxx stack, plus a reusable SSH/rsync deploy script. Updates CI triggers to include staging so the branch promotion path is branch -> PR -> staging -> deploy -> PR -> main -> production deploy. Secrets/vars are configured in GitHub environments; no secret values are committed.