### PR TITLE
fix: cap gpt-5.5 agent output tokens

### DIFF
--- a/contracts/models/gpt_5_5.edn
+++ b/contracts/models/gpt_5_5.edn
@@ -7,5 +7,5 @@
  :model/default-thinking :minimal
  :model/thinking-levels [:off :minimal :low :medium :high :xhigh]
  :model/context-window 256000
- :model/max-tokens 128000
+ :model/max-tokens 8192
  :model/input [:text :image :audio]}


### PR DESCRIPTION
Caps the Knoxx gpt-5.5 model contract max tokens at 8192. Production verification showed the previous 128000 contract projected to very large Proxx/OpenAI Responses requests, causing bridge timeouts for Knoxx agent turns even while direct Proxx gpt-5.5 calls were healthy. EDN parse validation passed locally. Operational hotfix already applied on the Promethean host and verified with a public Knoxx direct agent response using gpt-5.5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated gpt-5.5 model maximum token limit from 128,000 to 8,192.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->