### PR TITLE
ci: pin PUPPETEER_EXECUTABLE_PATH to runner Chrome

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ on:
 permissions:
   contents: read
 
+env:
+  # ubuntu runners ship a snap-wrapper /usr/bin/chromium-browser that hangs
+  # under CI; point puppeteer-core at the real Chrome binary instead.
+  PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
+
 jobs:
   knoxx:
     name: knoxx (backend + frontend)

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -8,6 +8,11 @@ on:
 permissions:
   contents: read
 
+env:
+  # ubuntu runners ship a snap-wrapper /usr/bin/chromium-browser that hangs
+  # under CI; point puppeteer-core at the real Chrome binary instead.
+  PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
+
 concurrency:
   group: knoxx-production
   cancel-in-progress: false

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -8,6 +8,11 @@ on:
 permissions:
   contents: read
 
+env:
+  # ubuntu runners ship a snap-wrapper /usr/bin/chromium-browser that hangs
+  # under CI; point puppeteer-core at the real Chrome binary instead.
+  PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
+
 concurrency:
   group: knoxx-staging
   cancel-in-progress: true

--- a/.github/workflows/deploy-testing.yml
+++ b/.github/workflows/deploy-testing.yml
@@ -19,6 +19,11 @@ permissions:
   contents: read
   pull-requests: read
 
+env:
+  # ubuntu runners ship a snap-wrapper /usr/bin/chromium-browser that hangs
+  # under CI; point puppeteer-core at the real Chrome binary instead.
+  PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
+
 concurrency:
   group: knoxx-staging
   cancel-in-progress: false


### PR DESCRIPTION
staging-preflight failed with exactly one test red: `svg->png-renders-browser-svg-features` — `TimeoutError: Timed out after 30000 ms while waiting for the WS endpoint URL`.

`svg_render`'s chromium candidate list tries `/usr/bin/chromium-browser` before `/usr/bin/google-chrome`; on ubuntu runners the former is the snap wrapper, which hangs headless in CI. Pin `PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome` (always present on GitHub runners) at workflow level in ci/deploy-staging/deploy-production/deploy-testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)