### PR TITLE
fix(frontend): bump tsconfig target/lib to ES2022

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "Bundler",


### PR DESCRIPTION
staging-preflight now reaches frontend typecheck (backend green after #33/#34) and fails on a latent error: `mediaEmbeds.ts(43,16) TS2550: Property 'at' does not exist on type 'string[]'` — `.at()` needs the es2022 lib. Bump target/lib ES2020 → ES2022 (runtime is Node 22 / modern browsers). Verified in a clean standalone clone: `tsc --noEmit` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)