### PR TITLE
refactor(backend lint): async/await — ingesters, discord, voice, media

### DIFF
--- a/backend/src/cljs/knoxx/backend/domain/discord/discord_io.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/discord/discord_io.cljs
@@ -30,53 +30,49 @@
   [messages]
   (sort-by :timestamp #(compare %2 %1) messages))
 
-(defn read-channel!
+(defn ^:async read-channel!
   "Fetch up to `limit` messages from `channel-id` (max 100).
    Returns Promise<[{:id :channelId :content :authorId :authorUsername :authorIsBot :timestamp}]>."
   [channel-id & [limit]]
-  (-> (discord-rest/channel-messages! (discord-client) channel-id {:limit (max 1 (min 100 (or limit 25)))})
-      (.then (fn [payload]
-               (->> (or payload [])
-                    (map map-message)
-                    sort-newest-first
-                    vec)))))
+  (let [payload (await (discord-rest/channel-messages! (discord-client) channel-id {:limit (max 1 (min 100 (or limit 25)))}))]
+    (->> (or payload [])
+         (map map-message)
+         sort-newest-first
+         vec)))
 
-(defn search-channel!
+(defn ^:async search-channel!
   "Return messages in `channel-id` whose content contains `query`
    (case-insensitive). Scans up to 100 messages, returns up to `limit`."
   [channel-id query & [limit]]
-  (-> (read-channel! channel-id 100)
-      (.then (fn [messages]
-               (let [needle (str/lower-case (str (or query "")))]
-                 (->> messages
-                      (filter (fn [message]
-                                (str/includes? (str/lower-case (:content message)) needle)))
-                      (take (or limit 25))
-                      vec))))))
+  (let [messages (await (read-channel! channel-id 100))
+        needle (str/lower-case (str (or query "")))]
+    (->> messages
+         (filter (fn [message]
+                   (str/includes? (str/lower-case (:content message)) needle)))
+         (take (or limit 25))
+         vec)))
 
-(defn list-guilds!
+(defn ^:async list-guilds!
   "List guilds the bot is a member of."
   []
-  (-> (discord-rest/current-user-guilds! (discord-client))
-      (.then (fn [payload]
-               (->> (or payload [])
-                    (mapv (fn [guild]
-                            {:id (:id guild)
-                             :name (:name guild)})))))))
+  (let [payload (await (discord-rest/current-user-guilds! (discord-client)))]
+    (->> (or payload [])
+         (mapv (fn [guild]
+                 {:id (:id guild)
+                  :name (:name guild)})))))
 
-(defn list-channels!
+(defn ^:async list-channels!
   "List channels in `guild-id` (types 0, 5, 11, 12 only)."
   [guild-id]
-  (-> (discord-rest/guild-channels! (discord-client) guild-id)
-      (.then (fn [payload]
-               (->> (or payload [])
-                    (filter (fn [channel]
-                              (contains? #{0 5 11 12} (:type channel))))
-                    (mapv (fn [channel]
-                            {:id (:id channel)
-                             :guildId guild-id
-                             :name (or (:name channel) "")
-                             :type (:type channel)})))))))
+  (let [payload (await (discord-rest/guild-channels! (discord-client) guild-id))]
+    (->> (or payload [])
+         (filter (fn [channel]
+                   (contains? #{0 5 11 12} (:type channel))))
+         (mapv (fn [channel]
+                 {:id (:id channel)
+                  :guildId guild-id
+                  :name (or (:name channel) "")
+                  :type (:type channel)})))))
 
 (def ^:private default-discord-tool-policies
   [{:toolId "discord.read" :effect "allow"}
@@ -86,7 +82,7 @@
    {:toolId "memory_search" :effect "allow"}
    {:toolId "graph_query" :effect "allow"}])
 
-(defn start-agent-session!
+(defn ^:async start-agent-session!
   "Launch a normal Knoxx direct-mode turn for a Discord-triggered payload.
    `opts` map accepts :channelId :channelName :authorUsername :content :reason."
   [config job {:keys [channelId channelName authorUsername content reason]}]
@@ -136,11 +132,11 @@
                          (:model job-agent-spec)
                          (:proxx-default-model config)
                          "glm-5")}]
-    (-> (agents-runner/spawn-direct! config body)
-        (.then (fn [result]
-                 (println "[discord-io] queued agent run" run-id "for job" (:id job))
-                 result))
-        (.catch (fn [err]
-                  (println "[discord-io] failed to queue agent run for job" (:id job)
-                           ":" (.-message err))
-                  nil)))))
+    (try
+      (let [result (await (agents-runner/spawn-direct! config body))]
+        (println "[discord-io] queued agent run" run-id "for job" (:id job))
+        result)
+      (catch :default err
+        (println "[discord-io] failed to queue agent run for job" (:id job)
+                 ":" (.-message err))
+        nil))))

--- a/backend/src/cljs/knoxx/backend/domain/discord/discord_reaction_labels.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/discord/discord_reaction_labels.cljs
@@ -69,6 +69,18 @@
               (= quality "good") (assoc-in [:openplanner_labels :explicit_meaning] "good output")
               (= quality "bad") (assoc-in [:openplanner_labels :explicit_meaning] "bad output"))}))
 
+(defn- ^:async ingest-reaction-events!
+  [client record-id event emoji user-id]
+  (try
+    (await (openplanner-client/events! client [event]))
+    (await (openplanner-client/record-reaction! client record-id
+                                                {:emoji emoji
+                                                 :source "discord-gateway-reaction"
+                                                 :user_id user-id}))
+    (catch :default err
+      (.warn js/console "[discord-reaction-labels] failed to ingest reaction" err)
+      {:ok false :error (.-message err)})))
+
 (defn ingest-reaction!
   [config reaction]
   (let [message (js-get reaction "message")
@@ -81,15 +93,7 @@
         (js/Promise.resolve {:ok false :skipped true})
         (let [record-id (discord-record-id channel-id message-id)
               event (message->openplanner-event config message emoji user-id)]
-          (-> (openplanner-client/events! client [event])
-              (.then (fn [_]
-                       (openplanner-client/record-reaction! client record-id
-                                                            {:emoji emoji
-                                                             :source "discord-gateway-reaction"
-                                                             :user_id user-id})))
-              (.catch (fn [err]
-                        (.warn js/console "[discord-reaction-labels] failed to ingest reaction" err)
-                        {:ok false :error (.-message err)})))))))
+          (ingest-reaction-events! client record-id event emoji user-id)))))
 
 (defn bind!
   [config]

--- a/backend/src/cljs/knoxx/backend/domain/discord/source.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/discord/source.cljs
@@ -115,79 +115,75 @@
           (.error js/console "[event runtimes.discord] OpenPlanner label lookup failed; failing closed to avoid surfacing crossed/bad Discord context" error)
           [])))))
 
-(defn- fetch-channel-from-gateway-entries!
+(defn- ^:async fetch-channel-from-gateway-entries!
   [entries channel-id opts]
   (if-let [[actor-id manager] (first entries)]
-    (-> (.fetchChannelMessages manager channel-id opts)
-        (.catch (fn [err]
-                  (errors/log-warning! :discord-source/fetch-channel-fallback
-                                       {:actor/id actor-id
-                                        :channel/id channel-id
-                                        :error (errors/error-message err)})
-                  (fetch-channel-from-gateway-entries! (rest entries) channel-id opts))))
+    (try
+      (await (.fetchChannelMessages manager channel-id opts))
+      (catch :default err
+        (errors/log-warning! :discord-source/fetch-channel-fallback
+                             {:actor/id actor-id
+                              :channel/id channel-id
+                              :error (errors/error-message err)})
+        (await (fetch-channel-from-gateway-entries! (rest entries) channel-id opts))))
     (js/Promise.reject (js/Error. (str "No active Discord actor gateway can read channel " channel-id)))))
 
-(defn read-channel!
+(defn ^:async read-channel!
   [config channel-id limit]
   (if-let [entries (seq (active-gateway-entries))]
-    (-> (fetch-channel-from-gateway-entries! entries channel-id (clj->js {:limit (max 1 (min 100 (or limit 25)))}))
-        (.then (fn [messages]
-                 (->> (js->clj messages :keywordize-keys true)
-                      sort-newest-first
-                      vec)))
-        (.then (fn [messages]
-                 (attach-openplanner-labels! config messages))))
+    (let [raw (await (fetch-channel-from-gateway-entries! entries channel-id (clj->js {:limit (max 1 (min 100 (or limit 25)))})))
+          messages (->> (js->clj raw :keywordize-keys true)
+                        sort-newest-first
+                        vec)]
+      (await (attach-openplanner-labels! config messages)))
     (let [token (bot-token config)]
       (if (str/blank? token)
         (js/Promise.reject (js/Error. "Discord bot token not configured"))
-        (-> (discord-rest/channel-messages! (discord-rest/client token) channel-id {:limit (max 1 (min 100 (or limit 25)))})
-            (.then (fn [payload]
-                     (->> (or payload [])
-                          (map map-message)
-                          sort-newest-first
-                          vec)))
-            (.then (fn [messages]
-                     (attach-openplanner-labels! config messages))))))))
+        (let [payload (await (discord-rest/channel-messages! (discord-rest/client token) channel-id {:limit (max 1 (min 100 (or limit 25)))}))
+              messages (->> (or payload [])
+                            (map map-message)
+                            sort-newest-first
+                            vec)]
+          (await (attach-openplanner-labels! config messages)))))))
 
-(defn list-channels!
+(defn ^:async list-channels!
   []
   (let [entries (active-gateway-entries)]
     (if (seq entries)
-      (-> (js/Promise.all
-           (clj->js
-            (mapv (fn [[actor-id manager]]
-                    (-> (.listChannels manager nil)
-                        (.catch (fn [err]
-                                  (errors/log-warning! :discord-source/list-channels-failed
-                                                       {:actor/id actor-id
-                                                        :error (errors/error-message err)})
-                                  #js []))))
-                  entries)))
-          (.then (fn [results]
-                   (->> (js/Array.from results)
-                        (mapcat #(js/Array.from %))
-                        (map #(js->clj % :keywordize-keys true))
-                        (group-by :id)
-                        vals
-                        (map first)
-                        clj->js))))
+      (let [results (await (js/Promise.all
+                            (clj->js
+                             (mapv (^:async fn [[actor-id manager]]
+                                     (try
+                                       (await (.listChannels manager nil))
+                                       (catch :default err
+                                         (errors/log-warning! :discord-source/list-channels-failed
+                                                              {:actor/id actor-id
+                                                               :error (errors/error-message err)})
+                                         #js [])))
+                                   entries))))]
+        (->> (js/Array.from results)
+             (mapcat #(js/Array.from %))
+             (map #(js->clj % :keywordize-keys true))
+             (group-by :id)
+             vals
+             (map first)
+             clj->js))
       (or (dg/list-channels)
           (js/Promise.resolve #js [])))))
 
-(defn resolve-channel-ids!
+(defn ^:async resolve-channel-ids!
   [{:keys [explicit-channels guild-ids]}]
   (cond
     (seq guild-ids)
-    (-> (list-channels!)
-        (.then (fn [channels]
-                 (let [rows (js->clj channels :keywordize-keys true)
-                       guild-id-set (set guild-ids)]
-                   (->> rows
-                        (filter (fn [channel]
-                                  (contains? guild-id-set (:guildId channel))))
-                        (map :id)
-                        distinct
-                        vec)))))
+    (let [channels (await (list-channels!))
+          rows (js->clj channels :keywordize-keys true)
+          guild-id-set (set guild-ids)]
+      (->> rows
+           (filter (fn [channel]
+                     (contains? guild-id-set (:guildId channel))))
+           (map :id)
+           distinct
+           vec))
 
     :else
     ;; Publish channels are output sinks, not read sources. Never infer scan
@@ -215,28 +211,28 @@
     (if (seq channel-ids)
       (js/Promise.all
        (clj->js
-        (mapv (fn [channel-id]
-                (-> (read-channel! config channel-id limit)
-                    (.then (fn [messages]
-                             (let [fresh (unseen-messages channel-id messages)]
-                               (doseq [message fresh]
-                                 (when-let [kind (match-kind message)]
-                                   (observe-boundary!
-                                    :discord-source/patrol-dispatch
-                                    {:channel/id channel-id
-                                     :event/type kind
-                                     :message/id (:id message)}
-                                    #(dispatch-message! message kind))))
-                               (remember-latest! channel-id messages)
-                               {:channelId channel-id
-                                :fetched (count messages)
-                                :fresh (count fresh)})))
-                    (.catch (fn [err]
-                              (errors/log-error! :discord-source/patrol-channel
-                                                 {:channel/id channel-id}
-                                                 err)
-                              {:channelId channel-id
-                               :error true}))))
+        (mapv (^:async fn [channel-id]
+                (try
+                  (let [messages (await (read-channel! config channel-id limit))
+                        fresh (unseen-messages channel-id messages)]
+                    (doseq [message fresh]
+                      (when-let [kind (match-kind message)]
+                        (observe-boundary!
+                         :discord-source/patrol-dispatch
+                         {:channel/id channel-id
+                          :event/type kind
+                          :message/id (:id message)}
+                         #(dispatch-message! message kind))))
+                    (remember-latest! channel-id messages)
+                    {:channelId channel-id
+                     :fetched (count messages)
+                     :fresh (count fresh)})
+                  (catch :default err
+                    (errors/log-error! :discord-source/patrol-channel
+                                       {:channel/id channel-id}
+                                       err)
+                    {:channelId channel-id
+                     :error true})))
               channel-ids)))
       (js/Promise.resolve nil))))
 
@@ -270,82 +266,79 @@
        (take 8)
        vec))
 
-(defn execute-synthesis!
+(defn ^:async execute-synthesis!
   [{:keys [config channel-ids limit dispatch-summary!]}]
   (if-not (seq channel-ids)
     (js/Promise.resolve nil)
-    (let [fetch-row! (fn [channel-id]
-                       (-> (read-channel! config channel-id limit)
-                           (.then (fn [messages]
-                                    {:channelId channel-id
-                                     :messages messages}))
-                           (.catch (fn [err]
-                                     (errors/log-warning! :discord-source/synthesis-channel-empty
-                                                          {:channel/id channel-id
-                                                           :error (errors/error-message err)})
-                                     {:channelId channel-id
-                                      :messages []}))))]
-      (-> (js/Promise.all (clj->js (mapv fetch-row! channel-ids)))
-          (.then (fn [results]
-                   (dispatch-summary! (js->clj results :keywordize-keys true))))))))
+    (let [fetch-row! (^:async fn [channel-id]
+                       (try
+                         (let [messages (await (read-channel! config channel-id limit))]
+                           {:channelId channel-id
+                            :messages messages})
+                         (catch :default err
+                           (errors/log-warning! :discord-source/synthesis-channel-empty
+                                                {:channel/id channel-id
+                                                 :error (errors/error-message err)})
+                           {:channelId channel-id
+                            :messages []})))
+          results (await (js/Promise.all (clj->js (mapv fetch-row! channel-ids))))]
+      (dispatch-summary! (js->clj results :keywordize-keys true)))))
 
-(defn bind-gateways!
+(defn ^:async bind-gateways!
   [{:keys [policy-db on-message! on-voice-state!]}]
   (when-let [unsubscribe @gateway-unsubscribe*]
     (unsubscribe)
     (reset! gateway-unsubscribe* nil))
   (if policy-db
-    (-> (policy-db/list-actor-credentials! (policy-db/context-pool policy-db) "discord_bot")
-        (.then (fn [result]
-                 (dg/start-actor-gateways! (or (:credentials result) []))))
-         (.then
-          (fn [_started]
-            (let [managers (dg/gateway-managers)
-                  _ (js/console.log "[discord-source] binding gateways for actors:" (pr-str (keys managers)))
-                  unsubscribes
-                  (->> managers
-                       (mapcat
-                        (fn [[actor-id manager]]
-                          (let [status (.status manager)
-                                bot-user-id (some-> (aget status "userId") str str/trim not-empty)
-                                _ (js/console.log "[discord-source] binding actor:" actor-id "bot:" bot-user-id)
-                                msg-unsub (.onMessage manager
-                                                      (fn [mapped _raw]
-                                                        (let [msg (assoc (js->clj mapped :keywordize-keys true)
-                                                                         :gatewayActorId actor-id
-                                                                         :gatewayBotUserId bot-user-id)]
-                                                          (observe-boundary!
-                                                           :discord-source/gateway-message-dispatch
-                                                           {:actor/id actor-id
-                                                            :bot/user-id bot-user-id
-                                                            :message/id (:id msg)
-                                                            :channel/id (:channelId msg)}
-                                                           #(on-message! msg)))))
-                               voice-unsub (.onVoiceStateUpdate manager
-                                                                 (fn [mapped _old _new]
-                                                                   (let [state (assoc (js->clj mapped :keywordize-keys true)
-                                                                                      :gatewayActorId actor-id
-                                                                                      :gatewayBotUserId bot-user-id)]
-                                                                     (observe-boundary!
-                                                                      :discord-source/gateway-voice-state-dispatch
-                                                                      {:actor/id actor-id
-                                                                       :bot/user-id bot-user-id
-                                                                       :user/id (:userId state)
-                                                                       :channel/id (:channelId state)}
-                                                                      #(on-voice-state! state)))))]
-                           [msg-unsub voice-unsub])))
-                      vec)]
-             (println "[event runtimes] bound" (/ (count unsubscribes) 2) "Discord actor gateway(s)")
-             (reset! gateway-unsubscribe*
-                     (fn []
-                       (doseq [unsubscribe unsubscribes]
-                         (observe-boundary!
-                          :discord-source/gateway-unsubscribe
-                          {}
-                          unsubscribe)))))))
-        (.catch (fn [err]
-                  (errors/log-error! :discord-source/bind-gateways {} err)
-                  nil)))
+    (try
+      (let [result (await (policy-db/list-actor-credentials! (policy-db/context-pool policy-db) "discord_bot"))
+            _started (await (dg/start-actor-gateways! (or (:credentials result) [])))
+            managers (dg/gateway-managers)
+            _ (js/console.log "[discord-source] binding gateways for actors:" (pr-str (keys managers)))
+            unsubscribes
+            (->> managers
+                 (mapcat
+                  (fn [[actor-id manager]]
+                    (let [status (.status manager)
+                          bot-user-id (some-> (aget status "userId") str str/trim not-empty)
+                          _ (js/console.log "[discord-source] binding actor:" actor-id "bot:" bot-user-id)
+                          msg-unsub (.onMessage manager
+                                                (fn [mapped _raw]
+                                                  (let [msg (assoc (js->clj mapped :keywordize-keys true)
+                                                                   :gatewayActorId actor-id
+                                                                   :gatewayBotUserId bot-user-id)]
+                                                    (observe-boundary!
+                                                     :discord-source/gateway-message-dispatch
+                                                     {:actor/id actor-id
+                                                      :bot/user-id bot-user-id
+                                                      :message/id (:id msg)
+                                                      :channel/id (:channelId msg)}
+                                                     #(on-message! msg)))))
+                          voice-unsub (.onVoiceStateUpdate manager
+                                                           (fn [mapped _old _new]
+                                                             (let [state (assoc (js->clj mapped :keywordize-keys true)
+                                                                                :gatewayActorId actor-id
+                                                                                :gatewayBotUserId bot-user-id)]
+                                                               (observe-boundary!
+                                                                :discord-source/gateway-voice-state-dispatch
+                                                                {:actor/id actor-id
+                                                                 :bot/user-id bot-user-id
+                                                                 :user/id (:userId state)
+                                                                 :channel/id (:channelId state)}
+                                                                #(on-voice-state! state)))))]
+                      [msg-unsub voice-unsub])))
+                 vec)]
+        (println "[event runtimes] bound" (/ (count unsubscribes) 2) "Discord actor gateway(s)")
+        (reset! gateway-unsubscribe*
+                (fn []
+                  (doseq [unsubscribe unsubscribes]
+                    (observe-boundary!
+                     :discord-source/gateway-unsubscribe
+                     {}
+                     unsubscribe)))))
+      (catch :default err
+        (errors/log-error! :discord-source/bind-gateways {} err)
+        nil))
     (println "[event runtimes] policy DB unavailable; Discord actor gateways not bound")))
 
 (defn stop!

--- a/backend/src/cljs/knoxx/backend/domain/discord/voice_tools.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/discord/voice_tools.cljs
@@ -88,7 +88,7 @@
    [:channel_id {:description "Discord voice channel ID to join."} :string]
    [:guild_id {:optional true :description "Guild ID with an active voice connection."} :string]])
 
-(defn voice-join-execute [_runtime _config _tool-call-id params a b c]
+(defn ^:async voice-join-execute [_runtime _config _tool-call-id params a b c]
   (let [on-update (or (when (fn? a) a) (when (fn? b) b) (when (fn? c) c))
         m (gw)
         ch (or (aget params "channel_id") (aget params "channelId") "")
@@ -101,10 +101,9 @@
     (when (and m (seq sid) (seq cid))
       (aset m "__voiceSessionContext" #js {:sessionId sid :conversationId cid}))
     (maybe-tool-update! on-update (str "Joining voice " ch "…"))
-    (-> (.joinVoice m ch)
-        (.then (fn [r]
-                 (js/console.log "[voice:tool] joined voice, result:" (js/JSON.stringify r))
-                 (tool-text-result (str "Joined voice " ch " in guild " (aget r "guildId")) (js->clj r :keywordize-keys true)))))))
+    (let [r (await (.joinVoice m ch))]
+      (js/console.log "[voice:tool] joined voice, result:" (js/JSON.stringify r))
+      (tool-text-result (str "Joined voice " ch " in guild " (aget r "guildId")) (js->clj r :keywordize-keys true)))))
 
 (def voice-join-tool (partial create-tool-obj "discord.voice.join" "Join Voice"
                               "Join a Discord voice channel."
@@ -118,7 +117,7 @@
   [:map
    [:guild_id {:description "Guild ID with an active voice connection."} :string]])
 
-(defn voice-leave-execute [_runtime _config _tool-call-id params a b c]
+(defn ^:async voice-leave-execute [_runtime _config _tool-call-id params a b c]
   (let [on-update (or (when (fn? a) a) (when (fn? b) b) (when (fn? c) c))
         m (gw)
         g (or (aget params "guild_id") (aget params "guildId") "")]
@@ -130,8 +129,8 @@
       (when-let [sf (aget m "__voiceListener")] (try (sf) (catch js/Error _)))
       (aset m "__voiceListener" nil)
       (aset m "__voiceSessionContext" nil))
-    (-> (.leaveVoice m g)
-        (.then (fn [r] (tool-text-result (str "Left voice in guild " g) (js->clj r :keywordize-keys true)))))))
+    (let [r (await (.leaveVoice m g))]
+      (tool-text-result (str "Left voice in guild " g) (js->clj r :keywordize-keys true)))))
 
 (def voice-leave-tool (partial create-tool-obj "discord.voice.leave" "Leave Voice"
                                "Leave a Discord voice channel."
@@ -148,7 +147,7 @@
    [:voice_id {:optional true :description "Voxx/Kokoro voice ID. Default: af_jessica."} :string]
    [:model_id {:optional true :description "Voxx model ID. Default: kokoro."} :string]])
 
-(defn voice-say-execute [_runtime config _tool-call-id params a b c]
+(defn ^:async voice-say-execute [_runtime config _tool-call-id params a b c]
   (let [on-update (or (when (fn? a) a) (when (fn? b) b) (when (fn? c) c))
         m (gw)
         g (or (aget params "guild_id") (aget params "guildId") "")
@@ -164,11 +163,10 @@
     (when-not listening?
       (throw (js/Error. "Voice listener is not running. Use discord.voice.connect (preferred) before discord.voice.say.")))
     (maybe-tool-update! on-update (str "TTS: \"" (.slice text 0 40) "\"…"))
-    (-> (fetch-tts! config text vi mi)
-        (.then (fn [buf] (.playAudio m g buf)))
-        (.then (fn [_]
-                 (tool-text-result (str "Playing in guild " g ": \"" (.slice text 0 60) "\"")
-                                   {:guildId g :text text :played true :listening true}))))))
+    (let [buf (await (fetch-tts! config text vi mi))]
+      (await (.playAudio m g buf))
+      (tool-text-result (str "Playing in guild " g ": \"" (.slice text 0 60) "\"")
+                        {:guildId g :text text :played true :listening true}))))
 
 (def voice-say-tool (partial create-tool-obj "discord.voice.say" "Voice Say"
                              "Synthesize speech and play in a voice channel."
@@ -254,7 +252,7 @@
             (str "conversation_id required (auto-detect failed; no active agent turn context). "
                  "If calling manually, provide session_id and conversation_id explicitly.")))))
 
-(defn- flush-voice-buffer!
+(defn- ^:async flush-voice-buffer!
   "Send accumulated transcription text for a user as a single steer."
   [config sid cid uid]
   (let [m (gw)
@@ -266,9 +264,10 @@
           (let [merged (str/trim (str/join " " (js/Array.from texts)))]
             (js/console.log "[voice:tool] >>> FLUSHING buffer for" uid "concatenated:" (if (str/blank? merged) "[EMPTY]" merged))
             (when-not (str/blank? merged)
-              (-> (deliver-voice-text! config sid cid merged)
-                  (.catch (fn [e]
-                            (js/console.error "[voice:tool] voice delivery FAILED for" uid ":" (.-message e))))))))
+              (try
+                (await (deliver-voice-text! config sid cid merged))
+                (catch :default e
+                  (js/console.error "[voice:tool] voice delivery FAILED for" uid ":" (.-message e)))))))
         ;; Clear the buffer
         (aset user-buf "texts" #js [])
         (aset user-buf "timer" nil)))))
@@ -284,7 +283,7 @@
   (doseq [window (reverse windows)]
     (.unshift queue window)))
 
-(defn- trigger-agent-voice-event! [config loop-state windows]
+(defn- ^:async trigger-agent-voice-event! [config loop-state windows]
   (let [guild-id (aget loop-state "guildId")
         channel-id (aget loop-state "channelId")
         event-id (str "discord-voice-audio-" guild-id "-" (.now js/Date))
@@ -298,11 +297,10 @@
                         :content "Raw Discord voice audio window(s) are attached. Do not require ASR; perceive the audio directly if the model supports it."
                         :summary (str "Discord voice audio event with " (count windows) " window(s).")
                         :content_parts windows}}]
-    (-> (knoxx-client/dispatch-event! (knoxx-control-client config) body)
-        (.then (fn [_]
-                 {:event_id event-id :windows (count windows)})))))
+    (await (knoxx-client/dispatch-event! (knoxx-control-client config) body))
+    {:event_id event-id :windows (count windows)}))
 
-(defn- run-agent-event-loop-step! [config loop-state]
+(defn- ^:async run-agent-event-loop-step! [config loop-state]
   (let [queue (or (aget loop-state "audioWindows") #js [])]
     (if (or (aget loop-state "running") (zero? (.-length queue)))
       (js/Promise.resolve nil)
@@ -310,29 +308,31 @@
             n (min (.-length queue) max-windows)
             windows (vec (array-seq (.splice queue 0 n)))]
         (aset loop-state "running" true)
-        (-> (trigger-agent-voice-event! config loop-state windows)
-            (.catch (fn [err]
-                      ;; This is the trigger condition: only fire when the agent's own
-                      ;; session is idle. If direct/start says it is not idle, preserve
-                      ;; the audio windows and let the next cadence retry. Other errors
-                      ;; are real failures and should not create an infinite retry loop.
-                      (let [message (str (.-message err))
-                            busy? (or (str/includes? message "agent_already_processing")
-                                      (str/includes? message "already processing"))]
-                        (when busy?
-                          (requeue-front! queue windows))
-                        (js/console.log "[voice:agent-event] trigger not accepted:" message))))
-            (.finally (fn []
-                        (aset loop-state "running" false))))))))
+        (try
+          (await (trigger-agent-voice-event! config loop-state windows))
+          (catch :default err
+            ;; This is the trigger condition: only fire when the agent's own
+            ;; session is idle. If direct/start says it is not idle, preserve
+            ;; the audio windows and let the next cadence retry. Other errors
+            ;; are real failures and should not create an infinite retry loop.
+            (let [message (str (.-message err))
+                  busy? (or (str/includes? message "agent_already_processing")
+                            (str/includes? message "already processing"))]
+              (when busy?
+                (requeue-front! queue windows))
+              (js/console.log "[voice:agent-event] trigger not accepted:" message)))
+          (finally
+            (aset loop-state "running" false)))))))
 
 (defn- schedule-agent-event-loop! [config m loop-state]
   (when-not (aget loop-state "stopped")
     (aset loop-state "timer"
           (js/setTimeout
-           (fn []
-             (-> (run-agent-event-loop-step! config loop-state)
-                 (.finally (fn []
-                             (schedule-agent-event-loop! config m loop-state)))))
+           (^:async fn []
+             (try
+               (await (run-agent-event-loop-step! config loop-state))
+               (finally
+                 (schedule-agent-event-loop! config m loop-state))))
            (aget loop-state "tickMs")))))
 
 (defn- stop-agent-event-loop! [m]
@@ -345,7 +345,7 @@
     (aset m "__voiceAgentEventLoop" nil)
     (aset m "__voiceListener" nil)))
 
-(defn- start-agent-event-voice-listener!
+(defn- ^:async start-agent-event-voice-listener!
   [config m g ch sid cid auto? params on-update]
   (let [tick-ms (max 250 (param-int params "tick_ms" "tickMs" 1000))
         max-windows (max 1 (or (param-int params "max_windows_per_event" "maxWindowsPerEvent" nil)
@@ -354,73 +354,71 @@
     (stop-agent-event-loop! m)
     (maybe-tool-update! on-update (str "Listening in guild " g " as agent-event voice trigger…"))
     (js/console.log "[voice:tool] discord.voice.listen agent-event guild:" g "session:" sid "conv:" cid "auto-detect?" auto?)
-    (-> (.startVoiceListener
-         m g
-         (fn [uid]
-           (js/console.log "[voice:agent-event] speaker start:" uid))
-         (fn [uid buf]
-           (js/console.log "[voice:agent-event] audio window:" uid "bytes:" (.-length buf))
-           (when-let [loop-state (aget m "__voiceAgentEventLoop")]
-             (.push (aget loop-state "audioWindows") (audio-window-content-part uid buf)))))
-        (.then (fn [stop]
-                 (let [loop-state #js {:guildId g
-                                        :channelId ch
-                                        :sessionId sid
-                                        :conversationId cid
-                                        :modelId model-id
-                                        :tickMs tick-ms
-                                        :maxWindowsPerTurn max-windows
-                                        :audioWindows #js []
-                                        :running false
-                                        :stopped false
-                                        :listenerStop stop}]
-                   (aset m "__voiceAgentEventLoop" loop-state)
-                   (aset m "__voiceListener" stop)
-                   (schedule-agent-event-loop! config m loop-state)
-                   (tool-text-result (str "Listening in guild " g " as agent-event trigger for session " sid)
-                                     {:guildId g :listening true :mode "agent_event"
-                                      :sessionId sid :conversationId cid :tickMs tick-ms})))))))
+    (let [stop (await (.startVoiceListener
+                       m g
+                       (fn [uid]
+                         (js/console.log "[voice:agent-event] speaker start:" uid))
+                       (fn [uid buf]
+                         (js/console.log "[voice:agent-event] audio window:" uid "bytes:" (.-length buf))
+                         (when-let [loop-state (aget m "__voiceAgentEventLoop")]
+                           (.push (aget loop-state "audioWindows") (audio-window-content-part uid buf))))))
+          loop-state #js {:guildId g
+                          :channelId ch
+                          :sessionId sid
+                          :conversationId cid
+                          :modelId model-id
+                          :tickMs tick-ms
+                          :maxWindowsPerTurn max-windows
+                          :audioWindows #js []
+                          :running false
+                          :stopped false
+                          :listenerStop stop}]
+      (aset m "__voiceAgentEventLoop" loop-state)
+      (aset m "__voiceListener" stop)
+      (schedule-agent-event-loop! config m loop-state)
+      (tool-text-result (str "Listening in guild " g " as agent-event trigger for session " sid)
+                        {:guildId g :listening true :mode "agent_event"
+                         :sessionId sid :conversationId cid :tickMs tick-ms}))))
 
-(defn- start-asr-steer-voice-listener!
+(defn- ^:async start-asr-steer-voice-listener!
   [config m g sid auto? steer-debounce-ms on-update]
   (stop-agent-event-loop! m)
   (maybe-tool-update! on-update (str "Listening in guild " g "…"))
   (js/console.log "[voice:tool] discord.voice.listen guild:" g "session:" sid "auto-detect?" auto?)
-  (-> (.startVoiceListener
-       m g
-       (fn [uid]
-         (js/console.log "[voice:tool] >>> on-start callback fired for user:" uid)
-         (let [buf-obj (when m (aget m "__voiceTranscriptionBuffer"))
-               user-buf (when buf-obj (aget buf-obj uid))]
-           (when user-buf
-             (when-let [t (aget user-buf "timer")]
-               (js/clearTimeout t)
-               (aset user-buf "timer" nil)))))
-       (fn [uid buf]
-         (js/console.log "[voice:tool] >>> on-audio callback fired for user:" uid "buffer length:" (.-length buf) "bytes")
-         (-> (transcribe! config buf)
-             (.then (fn [t]
-                      (js/console.log "[voice:tool] transcription result for" uid ":" (if (str/blank? t) "[EMPTY]" t))
-                      (when-not (str/blank? t)
-                        (let [buf-obj (when m (aget m "__voiceTranscriptionBuffer"))
-                              _ (when (and m (not buf-obj))
-                                  (aset m "__voiceTranscriptionBuffer" #js {}))
-                              buf-obj (or buf-obj (aget m "__voiceTranscriptionBuffer"))
-                              user-buf (or (aget buf-obj uid) #js {:texts #js [] :timer nil})]
-                          (.push (aget user-buf "texts") t)
-                          (aset buf-obj uid user-buf)
-                          (when-let [old-timer (aget user-buf "timer")]
-                            (js/clearTimeout old-timer))
-                          (let [new-timer (js/setTimeout
-                                           #(flush-voice-buffer! config sid (aget (aget m "__voiceSessionContext") "conversationId") uid)
-                                           steer-debounce-ms)]
-                            (aset user-buf "timer" new-timer))))))
-             (.catch (fn [e]
-                       (js/console.error "[voice:tool] transcription/steering pipeline FAILED for" uid ":" (.-message e)))))))
-      (.then (fn [stop]
-               (aset m "__voiceListener" stop)
-               (tool-text-result (str "Listening in guild " g ". Transcriptions → session " sid)
-                                 {:guildId g :listening true :mode "asr_steer"})))))
+  (let [stop (await (.startVoiceListener
+                     m g
+                     (fn [uid]
+                       (js/console.log "[voice:tool] >>> on-start callback fired for user:" uid)
+                       (let [buf-obj (when m (aget m "__voiceTranscriptionBuffer"))
+                             user-buf (when buf-obj (aget buf-obj uid))]
+                         (when user-buf
+                           (when-let [t (aget user-buf "timer")]
+                             (js/clearTimeout t)
+                             (aset user-buf "timer" nil)))))
+                     (^:async fn [uid buf]
+                       (js/console.log "[voice:tool] >>> on-audio callback fired for user:" uid "buffer length:" (.-length buf) "bytes")
+                       (try
+                         (let [t (await (transcribe! config buf))]
+                           (js/console.log "[voice:tool] transcription result for" uid ":" (if (str/blank? t) "[EMPTY]" t))
+                           (when-not (str/blank? t)
+                             (let [buf-obj (when m (aget m "__voiceTranscriptionBuffer"))
+                                   _ (when (and m (not buf-obj))
+                                       (aset m "__voiceTranscriptionBuffer" #js {}))
+                                   buf-obj (or buf-obj (aget m "__voiceTranscriptionBuffer"))
+                                   user-buf (or (aget buf-obj uid) #js {:texts #js [] :timer nil})]
+                               (.push (aget user-buf "texts") t)
+                               (aset buf-obj uid user-buf)
+                               (when-let [old-timer (aget user-buf "timer")]
+                                 (js/clearTimeout old-timer))
+                               (let [new-timer (js/setTimeout
+                                                #(flush-voice-buffer! config sid (aget (aget m "__voiceSessionContext") "conversationId") uid)
+                                                steer-debounce-ms)]
+                                 (aset user-buf "timer" new-timer)))))
+                         (catch :default e
+                           (js/console.error "[voice:tool] transcription/steering pipeline FAILED for" uid ":" (.-message e)))))))]
+    (aset m "__voiceListener" stop)
+    (tool-text-result (str "Listening in guild " g ". Transcriptions → session " sid)
+                      {:guildId g :listening true :mode "asr_steer"})))
 
 (defn voice-listen-execute
   [_runtime config _tool-call-id params a b c]
@@ -437,7 +435,7 @@
       (aset m "__voiceTranscriptionBuffer" #js {}))
     (start-asr-steer-voice-listener! config m g sid auto? steer-debounce-ms on-update)))
 
-(defn voice-connect-execute
+(defn ^:async voice-connect-execute
   [runtime config _tool-call-id params a b c]
   (let [on-update (or (when (fn? a) a) (when (fn? b) b) (when (fn? c) c))
         m (gw)
@@ -451,18 +449,16 @@
     (when m
       (aset m "__voiceSessionContext" #js {:sessionId sid :conversationId cid}))
     (maybe-tool-update! on-update (str "Connecting voice + listener for channel " ch "…"))
-    (-> (.joinVoice m ch)
-        (.then (fn [r]
-                 (let [guild-id (or (aget r "guildId") "")]
-                   (when (str/blank? guild-id)
-                     (throw (js/Error. "joinVoice did not return guildId")))
-                   (js/console.log "[voice:tool] discord.voice.connect joined" ch "guild" guild-id "auto-detect?" auto?)
-                   (voice-listen-execute runtime config _tool-call-id (clj->js {:guild_id guild-id
-                                                                              :session_id sid
-                                                                              :conversation_id cid}) a b c))))
-        (.then (fn [_]
-                 (tool-text-result (str "Connected to voice " ch " and listening")
-                                   {:channelId ch :listening true :sessionId sid :conversationId cid}))))))
+    (let [r (await (.joinVoice m ch))
+          guild-id (or (aget r "guildId") "")]
+      (when (str/blank? guild-id)
+        (throw (js/Error. "joinVoice did not return guildId")))
+      (js/console.log "[voice:tool] discord.voice.connect joined" ch "guild" guild-id "auto-detect?" auto?)
+      (await (voice-listen-execute runtime config _tool-call-id (clj->js {:guild_id guild-id
+                                                                          :session_id sid
+                                                                          :conversation_id cid}) a b c))
+      (tool-text-result (str "Connected to voice " ch " and listening")
+                        {:channelId ch :listening true :sessionId sid :conversationId cid}))))
 
 (def voice-connect-tool
   (partial create-tool-obj
@@ -508,7 +504,7 @@
     (when (str/blank? g) (throw (js/Error. "guild_id required")))
     (start-agent-event-voice-listener! config m g ch sid cid auto? params on-update)))
 
-(defn voice-agent-event-connect-execute
+(defn ^:async voice-agent-event-connect-execute
   [runtime config _tool-call-id params a b c]
   (let [on-update (or (when (fn? a) a) (when (fn? b) b) (when (fn? c) c))
         m (gw)
@@ -516,19 +512,18 @@
     (when-not m (throw (js/Error. "Gateway not started")))
     (when (str/blank? ch) (throw (js/Error. "channel_id required")))
     (maybe-tool-update! on-update (str "Connecting voice event source for channel " ch "…"))
-    (-> (.joinVoice m ch)
-        (.then (fn [r]
-                 (let [guild-id (or (aget r "guildId") "")]
-                   (when (str/blank? guild-id)
-                     (throw (js/Error. "joinVoice did not return guildId")))
-                   (voice-agent-event-listen-execute runtime config _tool-call-id
-                                                     (clj->js {:guild_id guild-id
-                                                               :channel_id ch
-                                                               :tick_ms (or (aget params "tick_ms")
-                                                                            (aget params "tickMs"))
-                                                               :max_windows_per_event (or (aget params "max_windows_per_event")
-                                                                                          (aget params "maxWindowsPerEvent"))})
-                                                     a b c)))))))
+    (let [r (await (.joinVoice m ch))
+          guild-id (or (aget r "guildId") "")]
+      (when (str/blank? guild-id)
+        (throw (js/Error. "joinVoice did not return guildId")))
+      (await (voice-agent-event-listen-execute runtime config _tool-call-id
+                                               (clj->js {:guild_id guild-id
+                                                         :channel_id ch
+                                                         :tick_ms (or (aget params "tick_ms")
+                                                                      (aget params "tickMs"))
+                                                         :max_windows_per_event (or (aget params "max_windows_per_event")
+                                                                                    (aget params "maxWindowsPerEvent"))})
+                                               a b c)))))
 
 (def voice-agent-event-connect-tool
   (partial create-tool-obj
@@ -578,7 +573,7 @@
    [:guild_id {:description "Guild ID with an active voice connection."} :string]
    [:channel_id {:description "Voice channel ID to list members of."} :string]])
 
-(defn voice-list-members-execute [_runtime _config _tool-call-id params a b c]
+(defn ^:async voice-list-members-execute [_runtime _config _tool-call-id params a b c]
   (let [on-update (or (when (fn? a) a) (when (fn? b) b) (when (fn? c) c))
         m (gw)
         g (or (aget params "guild_id") (aget params "guildId") "")
@@ -587,13 +582,12 @@
     (when (str/blank? g) (throw (js/Error. "guild_id required")))
     (when (str/blank? ch) (throw (js/Error. "channel_id required")))
     (maybe-tool-update! on-update (str "Listing voice members in " ch "…"))
-    (-> (.listVoiceMembers m g ch)
-        (.then (fn [members]
-                 (let [ms (js->clj members :keywordize-keys true)
-                       lines (map (fn [m] (str (if (:isBot m) "[bot] " "") (:displayName m) " (" (:userId m) ")")) ms)]
-                   (tool-text-result
-                    (str "Voice members in " ch ":\n" (str/join "\n" lines))
-                    {:channelId ch :members ms :count (count ms)})))))))
+    (let [members (await (.listVoiceMembers m g ch))
+          ms (js->clj members :keywordize-keys true)
+          lines (map (fn [m] (str (if (:isBot m) "[bot] " "") (:displayName m) " (" (:userId m) ")")) ms)]
+      (tool-text-result
+       (str "Voice members in " ch ":\n" (str/join "\n" lines))
+       {:channelId ch :members ms :count (count ms)}))))
 
 (def voice-list-members-tool (partial create-tool-obj "discord.voice.list_members" "List Voice Members"
                                       "List members currently in a voice channel."

--- a/backend/src/cljs/knoxx/backend/domain/media.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/media.cljs
@@ -24,12 +24,11 @@
   [value]
   (some-> (str value) (str/includes? "cdn.discordapp.com/attachments")))
 
-(defn- discord-bot-token!
+(defn- ^:async discord-bot-token!
   "Get Discord bot token from the current actor credential."
   [runtime]
-  (-> (actor-credentials/get-credential! runtime "discord_bot")
-      (.then (fn [credential]
-               (actor-credentials/secret-value credential :botToken :bot-token :token)))))
+  (let [credential (await (actor-credentials/get-credential! runtime "discord_bot"))]
+    (actor-credentials/secret-value credential :botToken :bot-token :token)))
 
 ;; -------------------------------------------------------------------------
 ;; Path / FS shims
@@ -263,19 +262,18 @@
   [buffer mime-type]
   (str "data:" (sanitize-mime-type mime-type "application/octet-stream") ";base64," (.toString buffer "base64")))
 
-(defn temp-media-dir!
+(defn ^:async temp-media-dir!
   [_runtime name]
   (let [dir (.join path (os-tmpdir os) "knoxx-media" name)]
-    (-> (fs-mkdir! fs dir #js {:recursive true})
-        (.then (fn [] dir)))))
+    (await (fs-mkdir! fs dir #js {:recursive true}))
+    dir))
 
-(defn temp-file-path!
+(defn ^:async temp-file-path!
   [runtime name ext]
-  (-> (temp-media-dir! runtime name)
-      (.then (fn [dir]
-               (.join path
-                      dir
-                      (str (.randomUUID crypto) (or ext "")))))))
+  (let [dir (await (temp-media-dir! runtime name))]
+    (.join path
+           dir
+           (str (.randomUUID crypto) (or ext "")))))
 
 (defn infer-upload-filename
   [url idx]
@@ -283,7 +281,7 @@
         candidate (some-> pathname (str/split #"/") last str/trim not-empty)]
     (or candidate (str "attachment-" idx ".bin"))))
 
-(defn load-media-source!
+(defn ^:async load-media-source!
   [runtime config raw-source max-bytes]
   (let [source (or (normalize-tool-path-arg raw-source) raw-source "")]
     (cond
@@ -298,61 +296,54 @@
       (source-http-url? source)
       (let [token-promise (if (source-discord-cdn-url? source)
                             (discord-bot-token! runtime)
-                            (js/Promise.resolve nil))]
-        (-> token-promise
-            (.then (fn [token]
-                     (remote-client/fetch-bytes!
-                      (remote-client/client)
-                      source
-                      (cond-> {:max-bytes max-bytes
-                               :label "Source media"
-                               :fallback-mime-type (workspace-media-mime-type source)
-                               :filename (infer-upload-filename source 0)}
-                        token (assoc :authorization (str "Bot " token))))))))
+                            (js/Promise.resolve nil))
+            token (await token-promise)]
+        (remote-client/fetch-bytes!
+         (remote-client/client)
+         source
+         (cond-> {:max-bytes max-bytes
+                  :label "Source media"
+                  :fallback-mime-type (workspace-media-mime-type source)
+                  :filename (infer-upload-filename source 0)}
+           token (assoc :authorization (str "Bot " token)))))
 
       :else
       (let [{:keys [absolute relative]} (resolve-workspace-media-path runtime config source)
             mime-type (sanitize-mime-type (workspace-media-mime-type relative)
-                                          (workspace-media-mime-type absolute))]
-        (-> (fs-stat! fs absolute)
-            (.then (fn [stat]
-                     (when-not (.isFile stat)
-                       (throw (js/Error. (str relative " is not a file"))))
-                     (ensure-source-size! (.-size stat) max-bytes relative)
-                     (fs-read-file! fs absolute)))
-            (.then (fn [buffer]
-                     {:absolute-path absolute
-                      :relative relative
-                      :buffer buffer
-                      :mime-type mime-type
-                      :filename (path-basename path absolute)
-                      :size (.-length buffer)
-                      :source-kind "workspace"})))))))
+                                          (workspace-media-mime-type absolute))
+            stat (await (fs-stat! fs absolute))
+            _ (when-not (.isFile stat)
+                (throw (js/Error. (str relative " is not a file"))))
+            _ (ensure-source-size! (.-size stat) max-bytes relative)
+            buffer (await (fs-read-file! fs absolute))]
+        {:absolute-path absolute
+         :relative relative
+         :buffer buffer
+         :mime-type mime-type
+         :filename (path-basename path absolute)
+         :size (.-length buffer)
+         :source-kind "workspace"}))))
 
-(defn materialize-media-source!
+(defn ^:async materialize-media-source!
   [runtime config raw-source max-bytes]
-  (-> (load-media-source! runtime config raw-source max-bytes)
-      (.then (fn [source]
-               (if (:absolute-path source)
-                 source
-                 (-> (temp-file-path! runtime "inputs" (mime-type->extension (:mime-type source)))
-                     (.then (fn [absolute-path]
-                              (-> (fs-write-file! fs absolute-path (:buffer source))
-                                  (.then (fn []
-                                           (assoc source :absolute-path absolute-path))))))))))))
+  (let [source (await (load-media-source! runtime config raw-source max-bytes))]
+    (if (:absolute-path source)
+      source
+      (let [absolute-path (await (temp-file-path! runtime "inputs" (mime-type->extension (:mime-type source))))]
+        (await (fs-write-file! fs absolute-path (:buffer source)))
+        (assoc source :absolute-path absolute-path)))))
 
-(defn media-source->content-part!
+(defn ^:async media-source->content-part!
   [runtime config raw-source max-bytes]
-  (-> (load-media-source! runtime config raw-source max-bytes)
-      (.then (fn [source]
-               (let [mime-type (sanitize-mime-type (:mime-type source) "application/octet-stream")
-                     part-type (workspace-media-type mime-type)]
-                 {:source source
-                  :part {:type part-type
-                         :data (buffer->data-url (:buffer source) mime-type)
-                         :mimeType mime-type
-                         :filename (:filename source)
-                         :size (:size source)}})))))
+  (let [source (await (load-media-source! runtime config raw-source max-bytes))
+        mime-type (sanitize-mime-type (:mime-type source) "application/octet-stream")
+        part-type (workspace-media-type mime-type)]
+    {:source source
+     :part {:type part-type
+            :data (buffer->data-url (:buffer source) mime-type)
+            :mimeType mime-type
+            :filename (:filename source)
+            :size (:size source)}}))
 
 ;; -------------------------------------------------------------------------
 ;; Audio visualization
@@ -363,43 +354,36 @@
   (let [n (if (number? value) value fallback)]
     (-> n (max min-value) (min max-value))))
 
-(defn audio-visualization-result!
+(defn ^:async audio-visualization-result!
   [runtime config raw-source {:keys [kind width height title]}]
   (let [label (case kind
                 :waveform "waveform"
                 "spectrogram")
         out-width (clamp-dimension width (if (= kind :waveform) 1200 1024) 256 4096)
-        out-height (clamp-dimension height (if (= kind :waveform) 320 640) 128 2048)]
-    (-> (materialize-media-source! runtime config raw-source audio-render-max-bytes)
-        (.then
-         (fn [source]
-           (let [base-name (or title
-                               (some-> (:filename source) (str/replace #"\.[^.]+$" ""))
-                               "audio")]
-             (-> (temp-file-path! runtime "renders" ".png")
-                 (.then
-                  (fn [output-path]
-                    (let [filter-expr (if (= kind :waveform)
-                                        (str "showwavespic=s=" out-width "x" out-height ":colors=0x7dd3fc")
-                                        (str "showspectrumpic=s=" out-width "x" out-height ":legend=disabled"))
-                          args (clj->js ["-y"
-                                         "-i" (:absolute-path source)
-                                         "-lavfi" filter-expr
-                                         "-frames:v" "1"
-                                         output-path])]
-                      (-> (exec-file-async "ffmpeg" args #js {:timeout 120000 :maxBuffer 1048576})
-                          (.then (fn [_]
-                                   (fs-read-file! fs output-path)))
-                          (.then
-                           (fn [buffer]
-                             (let [filename (str base-name "-" label ".png")
-                                   part {:type "image"
-                                         :data (buffer->data-url buffer "image/png")
-                                         :mimeType "image/png"
-                                         :filename filename
-                                         :size (.-length buffer)}]
-                               (tool-text-result
-                                (str "Rendered " label " for " (or (:filename source) (:relative source) raw-source) ".")
-                                {:source raw-source
-                                 :kind label
-                                 :content_parts [part]})))))))))))))))
+        out-height (clamp-dimension height (if (= kind :waveform) 320 640) 128 2048)
+        source (await (materialize-media-source! runtime config raw-source audio-render-max-bytes))
+        base-name (or title
+                      (some-> (:filename source) (str/replace #"\.[^.]+$" ""))
+                      "audio")
+        output-path (await (temp-file-path! runtime "renders" ".png"))
+        filter-expr (if (= kind :waveform)
+                      (str "showwavespic=s=" out-width "x" out-height ":colors=0x7dd3fc")
+                      (str "showspectrumpic=s=" out-width "x" out-height ":legend=disabled"))
+        args (clj->js ["-y"
+                       "-i" (:absolute-path source)
+                       "-lavfi" filter-expr
+                       "-frames:v" "1"
+                       output-path])
+        _ (await (exec-file-async "ffmpeg" args #js {:timeout 120000 :maxBuffer 1048576}))
+        buffer (await (fs-read-file! fs output-path))
+        filename (str base-name "-" label ".png")
+        part {:type "image"
+              :data (buffer->data-url buffer "image/png")
+              :mimeType "image/png"
+              :filename filename
+              :size (.-length buffer)}]
+    (tool-text-result
+     (str "Rendered " label " for " (or (:filename source) (:relative source) raw-source) ".")
+     {:source raw-source
+      :kind label
+      :content_parts [part]})))

--- a/backend/src/cljs/knoxx/backend/domain/media/blaze.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/media/blaze.cljs
@@ -470,7 +470,7 @@
   [err]
   (str (or (.-message err) err)))
 
-(defn- attempt-generation!
+(defn- ^:async attempt-generation!
   [config params modality prompt models attempts log-context]
   (if-let [model (first models)]
     (let [body (build-body params modality model prompt)
@@ -479,23 +479,23 @@
                                  :model model)]
       (log-info! "attempt-start" (assoc attempt-context
                                         :remaining_models (count models)))
-      (-> (generate-payload! config body modality attempt-context)
-          (.then (fn [payload]
-                   (log-info! "attempt-ok" (assoc attempt-context
-                                                  :payload (summarize-payload payload)))
-                   {:payload payload
-                    :model model
-                    :attempts (conj attempts {:model model :status "ok"})}))
-          (.catch (fn [err]
-                    (let [msg (error-message err)
-                          next-attempts (conj attempts {:model model
-                                                        :status "failed"
-                                                        :error msg})]
-                      (log-warn! "attempt-failed" (assoc attempt-context
-                                                         :error msg
-                                                         :attempts next-attempts))
-                      (attempt-generation! config params modality prompt (rest models)
-                                           next-attempts log-context))))))
+      (try
+        (let [payload (await (generate-payload! config body modality attempt-context))]
+          (log-info! "attempt-ok" (assoc attempt-context
+                                         :payload (summarize-payload payload)))
+          {:payload payload
+           :model model
+           :attempts (conj attempts {:model model :status "ok"})})
+        (catch :default err
+          (let [msg (error-message err)
+                next-attempts (conj attempts {:model model
+                                              :status "failed"
+                                              :error msg})]
+            (log-warn! "attempt-failed" (assoc attempt-context
+                                               :error msg
+                                               :attempts next-attempts))
+            (attempt-generation! config params modality prompt (rest models)
+                                 next-attempts log-context)))))
     (do
       (log-error! "all-attempts-failed" (assoc log-context :attempts attempts))
       (js/Promise.reject

--- a/backend/src/cljs/knoxx/backend/domain/media/multimodal.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/media/multimodal.cljs
@@ -10,27 +10,26 @@
    [:source {:description "Workspace path, URL, or data URL for the media to load."} :string]
    [:title {:optional true :description "Optional human-readable title for the media."} :string]])
 
-(defn upload-execute [runtime config _tool-call-id params a b c]
+(defn ^:async upload-execute [runtime config _tool-call-id params a b c]
   (let [on-update (or (when (fn? a) a) (when (fn? b) b) (when (fn? c) c))
         source (or (aget params "source") "")
         title (normalize-tool-path-arg (aget params "title"))]
     (maybe-tool-update! on-update "Loading multimodal media…")
-    (-> (media-source->content-part! runtime config source multimodal-upload-max-bytes)
-        (.then (fn [{asset :source part :part}]
-                 (let [part* (cond-> part
-                               title (assoc :filename title))
-                       label (case (:type part*)
-                               "image" "image"
-                               "audio" "audio"
-                               "video" "video"
-                               "document")]
-                   (tool-text-result
-                    (str "Loaded " label " " (or title (:filename part*) (:filename asset) source) " for multimodal model context.")
-                    {:source source
-                     :source_kind (:source-kind asset)
-                     :mimeType (:mimeType part*)
-                     :filename (:filename part*)
-                     :content_parts [part*]})))))))
+    (let [{asset :source part :part} (await (media-source->content-part! runtime config source multimodal-upload-max-bytes))
+          part* (cond-> part
+                  title (assoc :filename title))
+          label (case (:type part*)
+                  "image" "image"
+                  "audio" "audio"
+                  "video" "video"
+                  "document")]
+      (tool-text-result
+       (str "Loaded " label " " (or title (:filename part*) (:filename asset) source) " for multimodal model context.")
+       {:source source
+        :source_kind (:source-kind asset)
+        :mimeType (:mimeType part*)
+        :filename (:filename part*)
+        :content_parts [part*]}))))
 
 (def upload-tool
   (partial create-tool-obj

--- a/backend/src/cljs/knoxx/backend/domain/media/workspace.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/media/workspace.cljs
@@ -11,7 +11,7 @@
    [:path {:description "Workspace-relative path to the image, audio file, video, or document to attach."} :string]
    [:title {:optional true :description "Optional human-readable label for the attachment."} :string]])
 
-(defn attach-execute [runtime config _tool-call-id params a b c]
+(defn ^:async attach-execute [runtime config _tool-call-id params a b c]
   (let [on-update (or (when (fn? a) a) (when (fn? b) b) (when (fn? c) c))
         raw-path (or (aget params "path") "")
         title (media/normalize-tool-path-arg (aget params "title"))
@@ -21,32 +21,30 @@
     (when-not mime-type
       (throw (js/Error. (str "Unsupported workspace media type for " relative ". Supported formats: images, audio, video, pdf, txt, md, csv, json."))))
     (maybe-tool-update! on-update (str "Attaching workspace file " relative "…"))
-    (-> (media/fs-stat! fs absolute)
-        (.then (fn [stat]
-                 (when-not (.isFile stat)
-                   (throw (js/Error. (str relative " is not a file"))))
-                 (when (> (.-size stat) media/workspace-media-max-bytes)
-                   (throw (js/Error. (str "File exceeds " media/workspace-media-max-bytes " bytes. Choose a smaller file or summarize it instead."))))
-                 (media/fs-read-file! fs absolute)))
-        (.then (fn [buffer]
-                 (let [size (.-length buffer)
-                       data-url (str "data:" mime-type ";base64," (.toString buffer "base64"))
-                       part {:type (media/workspace-media-type mime-type)
-                             :data data-url
-                             :mimeType mime-type
-                             :filename (or title filename)
-                             :size size}
-                       label (case (:type part)
-                               "image" "image"
-                               "audio" "audio file"
-                               "video" "video"
-                               "document" "document"
-                               "file")]
-                   #js {:content #js [#js {:type "text"
-                                           :text (str "Attached workspace " label " " relative " for the final reply.")}]
-                        :details #js {:path relative
-                                      :title (or title filename)
-                                      :content_parts (clj->js [part])}}))))))
+    (let [stat (await (media/fs-stat! fs absolute))
+          _ (when-not (.isFile stat)
+              (throw (js/Error. (str relative " is not a file"))))
+          _ (when (> (.-size stat) media/workspace-media-max-bytes)
+              (throw (js/Error. (str "File exceeds " media/workspace-media-max-bytes " bytes. Choose a smaller file or summarize it instead."))))
+          buffer (await (media/fs-read-file! fs absolute))
+          size (.-length buffer)
+          data-url (str "data:" mime-type ";base64," (.toString buffer "base64"))
+          part {:type (media/workspace-media-type mime-type)
+                :data data-url
+                :mimeType mime-type
+                :filename (or title filename)
+                :size size}
+          label (case (:type part)
+                  "image" "image"
+                  "audio" "audio file"
+                  "video" "video"
+                  "document" "document"
+                  "file")]
+      #js {:content #js [#js {:type "text"
+                              :text (str "Attached workspace " label " " relative " for the final reply.")}]
+           :details #js {:path relative
+                         :title (or title filename)
+                         :content_parts (clj->js [part])}})))
 
 (def attach-tool
   (partial create-tool-obj

--- a/backend/src/cljs/knoxx/backend/domain/voice/tools.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/voice/tools.cljs
@@ -281,7 +281,7 @@
    [:ustx_path {:description "Path to the .ustx file to render."} :string]
    [:output_path {:optional true :description "Output .wav path. Defaults to same dir as .ustx."} :string]])
 
-(defn voice-openutau-render-execute [runtime config _call-id params a b c]
+(defn ^:async voice-openutau-render-execute [runtime config _call-id params a b c]
   (let [on-update (or (when (fn? a) a) (when (fn? b) b) (when (fn? c) c))
         ustx-path (normalize-tool-path-arg (aget params "ustx_path"))
         output-path (or (when-let [p (aget params "output_path")]
@@ -290,14 +290,14 @@
         {:keys [absolute]} (media/resolve-workspace-media-path runtime config output-path)]
     (when-not ustx-path (throw (js/Error. "ustx_path is required")))
     (maybe-tool-update! on-update (str "Rendering " ustx-path " to WAV..."))
-    (-> (openutau/render-ustx-to-wav ustx-path absolute)
-        (.then (fn [result]
-                 (tool-text-result
-                  (str "Rendered OpenUTAU project to " output-path)
-                  {:wav_path output-path
-                   :stdout (:stdout result)})))
-        (.catch (fn [err]
-                  (throw (js/Error. (str "Render failed: " (.-message err)))))))))
+    (try
+      (let [result (await (openutau/render-ustx-to-wav ustx-path absolute))]
+        (tool-text-result
+         (str "Rendered OpenUTAU project to " output-path)
+         {:wav_path output-path
+          :stdout (:stdout result)}))
+      (catch :default err
+        (throw (js/Error. (str "Render failed: " (.-message err))))))))
 
 (def voice-openutau-render-tool
   (partial create-tool-obj

--- a/backend/src/cljs/knoxx/backend/domain/voice/turn_control.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/voice/turn_control.cljs
@@ -54,7 +54,7 @@
           (assoc entry :conversation_id conversation-id))
         @active-turns*))
 
-(defn abort-active-turn!
+(defn ^:async abort-active-turn!
   "Abort the currently registered turn for conversation-id.
 
    Returns a Promise resolving to {:ok boolean, ...}."
@@ -69,15 +69,15 @@
       (js/Promise.resolve {:ok false :error "no_abort_handler"})
 
       :else
-      (-> (abort! (or reason "aborted"))
-          (.then (fn [_]
-                   {:ok true
-                    :conversation_id (str conversation-id)
-                    :run_id (:run_id entry)
-                    :session_id (:session_id entry)}))
-          (.catch (fn [err]
-                    {:ok false
-                     :conversation_id (str conversation-id)
-                     :run_id (:run_id entry)
-                     :session_id (:session_id entry)
-                     :error (str err)}))))))
+      (try
+        (await (abort! (or reason "aborted")))
+        {:ok true
+         :conversation_id (str conversation-id)
+         :run_id (:run_id entry)
+         :session_id (:session_id entry)}
+        (catch :default err
+          {:ok false
+           :conversation_id (str conversation-id)
+           :run_id (:run_id entry)
+           :session_id (:session_id entry)
+           :error (str err)})))))

--- a/backend/src/cljs/knoxx/backend/infra/document_state.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/document_state.cljs
@@ -162,24 +162,22 @@
         prefix (if (str/blank? base) "db" base)]
     (str prefix "-" (.slice (.randomUUID crypto) 0 8))))
 
-(defn list-files-recursive!
+(defn- ^:async list-files-recursive!
   [runtime dir-path]
-  (let [read-promise (.readdir fs dir-path #js {:withFileTypes true})]
-    (-> read-promise
-        (.then (fn [entries]
-                 (.then (js/Promise.all
+  (try
+    (let [entries (await (.readdir fs dir-path #js {:withFileTypes true}))
+          nested (await (js/Promise.all
                          (clj->js
                           (for [entry (js-array-seq entries)]
                             (let [full-path (.join path dir-path (.-name entry))]
                               (if (.isDirectory entry)
                                 (list-files-recursive! runtime full-path)
-                                (js/Promise.resolve #js [full-path]))))))
-                        (fn [nested]
-                          (into [] (mapcat js-array-seq) (js-array-seq nested))))))
-        (.catch (fn [err]
-                  (if (= (aget err "code") "ENOENT")
-                    (js/Promise.resolve [])
-                    (js/Promise.reject err)))))))
+                                (js/Promise.resolve #js [full-path])))))))]
+      (into [] (mapcat js-array-seq) (js-array-seq nested)))
+    (catch :default err
+      (if (= (aget err "code") "ENOENT")
+        []
+        (throw err)))))
 
 (defn file-chunk-count
   [text]
@@ -189,34 +187,31 @@
   [runtime config db-id rel-path]
   (get-in (ensure-database-state! runtime config) [:records db-id :indexed rel-path]))
 
-(defn document-entry!
+(defn- ^:async document-entry!
   [runtime config profile db-id abs-path]
-  (let [docs-path (:docsPath profile)]
-    (-> (.stat fs abs-path)
-        (.then (fn [stats]
-                 (let [rel-path (normalize-relative-path (.relative path docs-path abs-path))
-                       meta (indexed-meta runtime config db-id rel-path)]
-                   {:name (.basename path abs-path)
-                    :relativePath rel-path
-                    :size (or (aget stats "size") 0)
-                    :indexed (boolean meta)
-                    :chunkCount (or (:chunkCount meta) 0)
-                    :indexedAt (:indexedAt meta)}))))))
+  (let [docs-path (:docsPath profile)
+        stats (await (.stat fs abs-path))
+        rel-path (normalize-relative-path (.relative path docs-path abs-path))
+        meta (indexed-meta runtime config db-id rel-path)]
+    {:name (.basename path abs-path)
+     :relativePath rel-path
+     :size (or (aget stats "size") 0)
+     :indexed (boolean meta)
+     :chunkCount (or (:chunkCount meta) 0)
+     :indexedAt (:indexedAt meta)}))
 
-(defn list-documents!
+(defn ^:async list-documents!
   ([runtime config request] (list-documents! runtime config request nil))
   ([runtime config request auth-context]
    (let [profile (active-database-profile runtime config request auth-context)
          db-id (:id profile)]
-     (-> (ensure-dir! runtime (:docsPath profile))
-         (.then (fn [] (list-files-recursive! runtime (:docsPath profile))))
-         (.then (fn [paths]
-                  (-> (js/Promise.all
-                       (clj->js (map #(document-entry! runtime config profile db-id %) paths)))
-                      (.then (fn [items]
-                               {:documents (->> (js-array-seq items)
-                                                (sort-by :relativePath)
-                                                vec)})))))))))
+     (await (ensure-dir! runtime (:docsPath profile)))
+     (let [paths (await (list-files-recursive! runtime (:docsPath profile)))
+           items (await (js/Promise.all
+                         (clj->js (map #(document-entry! runtime config profile db-id %) paths))))]
+       {:documents (->> (js-array-seq items)
+                        (sort-by :relativePath)
+                        vec)}))))
 
 (defn active-record
   ([runtime config request] (active-record runtime config request nil))
@@ -309,11 +304,12 @@
   (.all js/Promise
         (clj->js
          (map (fn [{:keys [abs rel]}]
-                (-> (.readFile fs abs "utf8")
-                    (.then (fn [content]
-                             {:rel rel :content content :error false}))
-                    (.catch (fn [err]
-                              {:rel rel :content nil :error true :detail (str err)}))))
+                ((^:async fn []
+                  (try
+                    (let [content (await (.readFile fs abs "utf8"))]
+                      {:rel rel :content content :error false})
+                    (catch :default err
+                      {:rel rel :content nil :error true :detail (str err)})))))
               queue))))
 
 (defn- openplanner-documents
@@ -381,40 +377,37 @@
      :failedCount failed-count
      :openplanner true}))
 
-(defn- index-document-queue!
+(defn- ^:async index-document-queue!
   [config profile db-id project queue started-at mode]
-  (-> (read-ingestion-queue! queue)
-      (.then (fn [read-results]
-               (let [items (vec (js-array-seq read-results))
-                     read-failed (vec (filter :error items))
-                     valid-items (vec (remove :error items))]
-                 (-> (op-memory/batch-upsert-openplanner-documents!
-                      config
-                      (openplanner-documents db-id project profile valid-items)
-                      {:concurrency 3
-                       :project project
-                       :visibility "internal"
-                       :extra {:database-id db-id
-                               :org-id (:orgId profile)}})
-                     (.then (fn [index-result]
-                              (finish-document-ingestion! db-id queue started-at mode read-failed valid-items index-result)))))))))
+  (let [read-results (await (read-ingestion-queue! queue))
+        items (vec (js-array-seq read-results))
+        read-failed (vec (filter :error items))
+        valid-items (vec (remove :error items))
+        index-result (await (op-memory/batch-upsert-openplanner-documents!
+                             config
+                             (openplanner-documents db-id project profile valid-items)
+                             {:concurrency 3
+                              :project project
+                              :visibility "internal"
+                              :extra {:database-id db-id
+                                      :org-id (:orgId profile)}}))]
+    (finish-document-ingestion! db-id queue started-at mode read-failed valid-items index-result)))
 
-(defn start-document-ingestion!
+(defn ^:async start-document-ingestion!
   "Ingest documents into OpenPlanner for embedding and vector storage.
    Replaces previous metadata-only tracking with OpenPlanner /v1/documents indexing."
   [runtime config profile {:keys [full selected-files]}]
   (let [db-id (:id profile)
         docs-path (:docsPath profile)
-        project (or (:project-name config) "workspace")]
-    (-> (list-files-recursive! runtime docs-path)
-        (.then (fn [all-abs]
-                 (let [queue (ingestion-queue docs-path full selected-files all-abs)
-                       started-at (time/now-iso)
-                       mode (if full "full" "selected")]
-                   (mark-ingestion-started! db-id queue started-at mode full)
-                   (if (zero? (count queue))
-                     (complete-empty-ingestion! db-id started-at mode)
-                     (index-document-queue! config profile db-id project queue started-at mode))))))))
+        project (or (:project-name config) "workspace")
+        all-abs (await (list-files-recursive! runtime docs-path))
+        queue (ingestion-queue docs-path full selected-files all-abs)
+        started-at (time/now-iso)
+        mode (if full "full" "selected")]
+    (mark-ingestion-started! db-id queue started-at mode full)
+    (if (zero? (count queue))
+      (complete-empty-ingestion! db-id started-at mode)
+      (index-document-queue! config profile db-id project queue started-at mode))))
 
 
 (defn text-like-path?
@@ -431,25 +424,25 @@
                     ".css" ".scss" ".less" ".graphql" ".gql" ".proto" ".tf" ".hcl"}
                   (.slice lower idx)))))
 
-(defn- read-workspace-file!
+(defn- ^:async read-workspace-file!
   "Read a single workspace file and return a result map."
   [workspace-root rel-path]
   (let [abs-path (.resolve path workspace-root rel-path)]
-    (-> (.stat fs abs-path)
-        (.then (fn [stat]
-                 (if (and (.isFile stat) (text-like-path? abs-path))
-                   (-> (.readFile fs abs-path "utf8")
-                       (.then (fn [content]
-                                {:rel rel-path :abs abs-path :content content
-                                 :size (or (.-size stat) 0) :error false}))
-                       (.catch (fn [err]
-                                 {:rel rel-path :abs abs-path :content nil
-                                  :size 0 :error true :detail (str err)})))
-                   {:rel rel-path :abs abs-path :content nil
-                    :size (or (.-size stat) 0) :error true :detail "binary or unsupported file type"})))
-        (.catch (fn [err]
-                  {:rel rel-path :abs abs-path :content nil
-                   :size 0 :error true :detail (str err)})))))
+    (try
+      (let [stat (await (.stat fs abs-path))]
+        (if (and (.isFile stat) (text-like-path? abs-path))
+          (try
+            (let [content (await (.readFile fs abs-path "utf8"))]
+              {:rel rel-path :abs abs-path :content content
+               :size (or (.-size stat) 0) :error false})
+            (catch :default err
+              {:rel rel-path :abs abs-path :content nil
+               :size 0 :error true :detail (str err)}))
+          {:rel rel-path :abs abs-path :content nil
+           :size (or (.-size stat) 0) :error true :detail "binary or unsupported file type"}))
+      (catch :default err
+        {:rel rel-path :abs abs-path :content nil
+         :size 0 :error true :detail (str err)}))))
 
 (defn- classify-document-kind
   "Classify a file extension into a document kind."
@@ -488,29 +481,26 @@
                   (map (fn [f] (str (:rel-path f) " (index error)")) (when (pos? failed-index-count) [])))
    :source source})
 
-(defn priority-ingest-workspace-files!
+(defn ^:async priority-ingest-workspace-files!
   "Immediately ingest specific workspace files into OpenPlanner, bypassing queues.
    Takes workspace-relative paths, reads them from disk, and sends to /v1/documents.
   Returns {:ok true, :indexed N, :failed M, :files [...]} summary."
   [_runtime config {:keys [paths project source]}]
   (let [workspace-root (:workspace-root config)
         project (or project (:project-name config) "workspace")
-        source (or source "knoxx-priority-ingest")]
-    (-> (js/Promise.all
-         (clj->js
-          (map (fn [rel-path] (read-workspace-file! workspace-root rel-path))
-               paths)))
-        (.then (fn [read-results]
-                 (let [items (vec (js-array-seq read-results))
-                       valid (vec (remove :error items))
-                       failed-reads (vec (filter :error items))
-                       docs (build-priority-documents valid project source)]
-                   (if (seq docs)
-                     (-> (op-memory/batch-upsert-openplanner-documents!
-                          config docs {:concurrency 5 :project project :visibility "internal" :extra {:source source}})
-                         (.then (fn [index-result]
-                                  (priority-ingest-summary (count (:indexed index-result)) failed-reads (:failed-count index-result 0) (count paths) (map :rel (:indexed index-result)) source))))
-                     (js/Promise.resolve
-                      (priority-ingest-summary 0 failed-reads 0 (count paths) [] source)))))))))
+        source (or source "knoxx-priority-ingest")
+        read-results (await (js/Promise.all
+                             (clj->js
+                              (map (fn [rel-path] (read-workspace-file! workspace-root rel-path))
+                                   paths))))
+        items (vec (js-array-seq read-results))
+        valid (vec (remove :error items))
+        failed-reads (vec (filter :error items))
+        docs (build-priority-documents valid project source)]
+    (if (seq docs)
+      (let [index-result (await (op-memory/batch-upsert-openplanner-documents!
+                                config docs {:concurrency 5 :project project :visibility "internal" :extra {:source source}}))]
+        (priority-ingest-summary (count (:indexed index-result)) failed-reads (:failed-count index-result 0) (count paths) (map :rel (:indexed index-result)) source))
+      (priority-ingest-summary 0 failed-reads 0 (count paths) [] source))))
 
 ;; Route registration

--- a/backend/src/cljs/knoxx/backend/infra/eta_mu_session_ingester.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/eta_mu_session_ingester.cljs
@@ -39,60 +39,59 @@
   []
   (.mkdir fs INGEST-STATE-DIR #js {:recursive true}))
 
-(defn- load-ingest-state
+(defn- ^:async load-ingest-state
   []
-  (-> (.readFile fs INGEST-STATE-FILE "utf-8")
-      (.then (fn [raw] (js/JSON.parse raw)))
-      (.catch (fn [_] #js {:sessions (js/Object.create nil)}))))
+  (try
+    (let [raw (await (.readFile fs INGEST-STATE-FILE "utf-8"))]
+      (js/JSON.parse raw))
+    (catch :default _ #js {:sessions (js/Object.create nil)})))
 
-(defn- save-ingest-state
+(defn- ^:async save-ingest-state
   [state]
-  (-> (ensure-state-dir)
-      (.then (fn [_] (.writeFile fs INGEST-STATE-FILE (js/JSON.stringify state nil 2) "utf-8")))))
+  (await (ensure-state-dir))
+  (.writeFile fs INGEST-STATE-FILE (js/JSON.stringify state nil 2) "utf-8"))
 
 
-(defn- discover-session-files
+(defn- ^:async discover-session-files
   [since-ts]
   (let [since-ts (or since-ts 0)]
-    (-> (.readdir fs ETA-MU-SESSIONS-ROOT)
-        (.then
-         (fn [dirs]
-           (js/Promise.all
-            (map
-             (fn [dir]
-               (let [dir-path (.join path ETA-MU-SESSIONS-ROOT dir)]
-                 (-> (.readdir fs dir-path)
-                     (.then
-                      (fn [entries]
-                        (js/Promise.all
-                         (map
-                          (fn [entry]
-                            (when (.endsWith entry ".jsonl")
-                              (let [file-path (.join path dir-path entry)]
-                                (-> (.stat fs file-path)
-                                    (.then
-                                     (fn [s]
-                                       (when (> (obj-get s "mtimeMs") since-ts)
-                                         (let [match (.match entry #"^[\dT:-]+_(.+)\.jsonl$")
-                                               session-id (if match
-                                                            (aget match 1)
-                                                            (.replace entry #"\.jsonl$" ""))]
-                                           #js {:dir dir
-                                                :path file-path
-                                                :sessionId session-id
-                                                :mtime (obj-get s "mtimeMs")
-                                                :size (obj-get s "size")}))))
-                                    (.catch (fn [_] nil))))))
-                          entries))))
-                     (.catch (fn [_] #js [])))))
-             dirs))))
-        (.then
-         (fn [dir-results]
-           (let [flat (->> (js/Array.from dir-results)
-                           (reduce (fn [acc r] (if (array? r) (into acc (js/Array.from r)) (conj acc r))) [])
-                           (filterv some?))]
-             (.sort flat (fn [a b] (- (obj-get a "mtime") (obj-get b "mtime")))))))
-        (.catch (fn [_] #js [])))))
+    (try
+      (let [dirs (await (.readdir fs ETA-MU-SESSIONS-ROOT))
+            dir-results
+            (await
+             (js/Promise.all
+              (map
+               (^:async fn [dir]
+                (let [dir-path (.join path ETA-MU-SESSIONS-ROOT dir)]
+                  (try
+                    (let [entries (await (.readdir fs dir-path))]
+                      (await
+                       (js/Promise.all
+                        (map
+                         (^:async fn [entry]
+                          (when (.endsWith entry ".jsonl")
+                            (let [file-path (.join path dir-path entry)]
+                              (try
+                                (let [s (await (.stat fs file-path))]
+                                  (when (> (obj-get s "mtimeMs") since-ts)
+                                    (let [match (.match entry #"^[\dT:-]+_(.+)\.jsonl$")
+                                          session-id (if match
+                                                       (aget match 1)
+                                                       (.replace entry #"\.jsonl$" ""))]
+                                      #js {:dir dir
+                                           :path file-path
+                                           :sessionId session-id
+                                           :mtime (obj-get s "mtimeMs")
+                                           :size (obj-get s "size")})))
+                                (catch :default _ nil)))))
+                         entries))))
+                    (catch :default _ #js []))))
+               dirs)))
+            flat (->> (js/Array.from dir-results)
+                      (reduce (fn [acc r] (if (array? r) (into acc (js/Array.from r)) (conj acc r))) [])
+                      (filterv some?))]
+        (.sort flat (fn [a b] (- (obj-get a "mtime") (obj-get b "mtime")))))
+      (catch :default _ #js []))))
 
 
 (defn- truncate-text
@@ -316,96 +315,91 @@
       :else #js [])))
 
 
-(defn- parse-session-file
+(defn- ^:async parse-session-file
   [file-path]
-  (-> (.readFile fs file-path "utf-8")
-      (.then
-       (fn [raw]
-         (let [lines (.split raw "\n")
-               events #js []
-               session-meta #js {:sessionId "unknown" :cwd "/unknown"}]
-           (doseq [line (js/Array.from lines)]
-             (let [trimmed (.trim line)]
-               (when (not (str/blank? trimmed))
-                 (try
-                   (let [parsed (js/JSON.parse trimmed)]
-                     (when (= (.-type parsed) "session")
-                       (aset session-meta "sessionId" (or (.-id parsed) "unknown"))
-                       (aset session-meta "cwd" (or (.-cwd parsed) "/unknown")))
-                     (.push events parsed))
-                   (catch :default _ nil)))))
-           #js {:events events :sessionMeta session-meta})))))
+  (let [raw (await (.readFile fs file-path "utf-8"))
+        lines (.split raw "\n")
+        events #js []
+        session-meta #js {:sessionId "unknown" :cwd "/unknown"}]
+    (doseq [line (js/Array.from lines)]
+      (let [trimmed (.trim line)]
+        (when (not (str/blank? trimmed))
+          (try
+            (let [parsed (js/JSON.parse trimmed)]
+              (when (= (.-type parsed) "session")
+                (aset session-meta "sessionId" (or (.-id parsed) "unknown"))
+                (aset session-meta "cwd" (or (.-cwd parsed) "/unknown")))
+              (.push events parsed))
+            (catch :default _ nil)))))
+    #js {:events events :sessionMeta session-meta}))
 
 
-(defn- ingest-session-file
+(defn- ^:async ingest-session-file
   [file-path _session-file-meta client]
-  (-> (parse-session-file file-path)
-      (.then
-       (fn [{:keys [events session-meta]}]
-         ;; Map all eta-mu events to OpenPlanner events
-         (let [all-op-events (reduce
-                              (fn [acc eta-mu-event]
-                                (into (js/Array.from acc)
-                                      (js/Array.from (map-eta-mu-event-to-events eta-mu-event session-meta))))
-                              #js []
-                              (js/Array.from events))]
-           (if (= (.-length all-op-events) 0)
-             #js {:sessionId (.-sessionId session-meta) :eventsIngested 0 :batches 0}
-             ;; Batch and send
-             (let [promises #js []
-                   events-ingested (atom 0)
-                   batches (atom 0)]
-               (loop [i 0]
-                 (when (< i (.-length all-op-events))
-                   (let [batch (.slice all-op-events i (+ i MAX-EVENTS-PER-BATCH))]
-                     (.push promises
-                            (-> (openplanner-client/events! client batch)
-                                (.then (fn [_]
-                                         (swap! events-ingested + (.-length batch))
-                                         (swap! batches inc)))
-                                (.catch (fn [err]
-                                          (.error js/console
-                                                  (str "[eta-mu-ingester] Batch failed for "
-                                                       (.-sessionId session-meta) ":")
-                                                  (.-message err)))))))
-                   (recur (+ i MAX-EVENTS-PER-BATCH))))
-               (-> (js/Promise.all promises)
-                   (.then (fn [_]
-                            #js {:sessionId (.-sessionId session-meta)
-                                 :eventsIngested @events-ingested
-                                 :batches @batches}))))))))))
+  (let [{:keys [events session-meta]} (await (parse-session-file file-path))
+        ;; Map all eta-mu events to OpenPlanner events
+        all-op-events (reduce
+                       (fn [acc eta-mu-event]
+                         (into (js/Array.from acc)
+                               (js/Array.from (map-eta-mu-event-to-events eta-mu-event session-meta))))
+                       #js []
+                       (js/Array.from events))]
+    (if (= (.-length all-op-events) 0)
+      #js {:sessionId (.-sessionId session-meta) :eventsIngested 0 :batches 0}
+      ;; Batch and send
+      (let [promises #js []
+            events-ingested (atom 0)
+            batches (atom 0)]
+        (loop [i 0]
+          (when (< i (.-length all-op-events))
+            (let [batch (.slice all-op-events i (+ i MAX-EVENTS-PER-BATCH))]
+              (.push promises
+                     ((^:async fn []
+                       (try
+                         (await (openplanner-client/events! client batch))
+                         (swap! events-ingested + (.-length batch))
+                         (swap! batches inc)
+                         (catch :default err
+                           (.error js/console
+                                   (str "[eta-mu-ingester] Batch failed for "
+                                        (.-sessionId session-meta) ":")
+                                   (.-message err))))))))
+            (recur (+ i MAX-EVENTS-PER-BATCH))))
+        (await (js/Promise.all promises))
+        #js {:sessionId (.-sessionId session-meta)
+             :eventsIngested @events-ingested
+             :batches @batches}))))
 
 
-(defn- aggregate-ingest-results
+(defn- ^:async aggregate-ingest-results
   "Aggregate ingest results into a summary JS object."
   [results-atom files to-ingest state]
-  (-> (save-ingest-state state)
-      (.then (fn [_]
-               (let [results @results-atom
-                     total-events (reduce (fn [sum ^js r] (+ sum (or (.-eventsIngested r) 0))) 0 (js/Array.from results))
-                     errors (reduce (fn [cnt ^js r] (if (.-error r) (inc cnt) cnt)) 0 (js/Array.from results))]
-                 #js {:ok true
-                      :scanned (.-length files)
-                      :newSessions (.-length to-ingest)
-                      :ingested (- (.-length to-ingest) errors)
-                      :totalEvents total-events
-                      :errors errors
-                      :details results})))))
+  (await (save-ingest-state state))
+  (let [results @results-atom
+        total-events (reduce (fn [sum ^js r] (+ sum (or (.-eventsIngested r) 0))) 0 (js/Array.from results))
+        errors (reduce (fn [cnt ^js r] (if (.-error r) (inc cnt) cnt)) 0 (js/Array.from results))]
+    #js {:ok true
+         :scanned (.-length files)
+         :newSessions (.-length to-ingest)
+         :ingested (- (.-length to-ingest) errors)
+         :totalEvents total-events
+         :errors errors
+         :details results}))
 
-(defn- ingest-single-session!
+(defn- ^:async ingest-single-session!
   "Ingest a single session file and update state."
   [file state results-atom client]
-  (-> (ingest-session-file (.-path file) file client)
-      (.then (fn [^js result]
-               (aset (.-sessions state) (.-sessionId file)
-                     #js {:mtime (.-mtime file) :eventCount (.-eventsIngested result)
-                          :ingestedAt (.toISOString (js/Date.)) :dir (.-dir file) :size (.-size file)})
-               (.push @results-atom result)))
-      (.catch (fn [err]
-                (.error js/console (str "[eta-mu-ingester] Failed: " (.-sessionId file) ":") (.-message err))
-                (.push @results-atom #js {:sessionId (.-sessionId file) :error (.-message err) :eventsIngested 0 :batches 0})))))
+  (try
+    (let [^js result (await (ingest-session-file (.-path file) file client))]
+      (aset (.-sessions state) (.-sessionId file)
+            #js {:mtime (.-mtime file) :eventCount (.-eventsIngested result)
+                 :ingestedAt (.toISOString (js/Date.)) :dir (.-dir file) :size (.-size file)})
+      (.push @results-atom result))
+    (catch :default err
+      (.error js/console (str "[eta-mu-ingester] Failed: " (.-sessionId file) ":") (.-message err))
+      (.push @results-atom #js {:sessionId (.-sessionId file) :error (.-message err) :eventsIngested 0 :batches 0}))))
 
-(defn run-eta-mu-session-ingest
+(defn ^:async run-eta-mu-session-ingest
   [{:keys [openplanner-client config force limit session-dirs]
     :or {force false limit 50}}]
   (let [client (or openplanner-client
@@ -413,56 +407,45 @@
     (when-not client
       (throw (js/Error. "OpenPlanner client or config is required")))
     (let [limit (or limit 50)]
-    (-> (if force
-          (js/Promise.resolve #js {:sessions (js/Object.create nil)})
-          (load-ingest-state))
-        (.then
-         (fn [state]
-           (let [^js state state]
-           (-> (discover-session-files 0)
-               (.then
-                (fn [all-files]
-                  (let [files (if session-dirs
-                                (.filter all-files
-                                         (fn [^js f]
-                                           (some (fn [d] (.includes (.-dir f) d)) session-dirs)))
-                                all-files)
-                        new-files (if force
-                                    files
-                                    (.filter files
-                                             (fn [^js f]
-                                               (let [^js existing (aget (.-sessions state) (.-sessionId f))]
-                                                 (or (not existing)
-                                                     (< (or (.-mtime existing) 0) (.-mtime f)))))))
-                        to-ingest (.slice new-files 0 limit)]
-                    (if (= (.-length to-ingest) 0)
-                      #js {:ok true
-                           :scanned (.-length files)
-                           :newSessions 0
-                           :ingested 0
-                           :totalEvents 0
-                           :skipped (- (.-length files) (.-length to-ingest))}
-                      (let [results-atom (atom #js [])]
-                        (-> (reduce
-                             (fn [promise-chain ^js file]
-                               (-> promise-chain
-                                   (.then (fn [_] (ingest-single-session! file state results-atom client)))))                    (js/Promise.resolve nil)
-                             (js/Array.from to-ingest))
-                            (.then (fn [_] (aggregate-ingest-results results-atom files to-ingest state)))))))))))))
-
-        (.catch
-         (fn [err]
-           #js {:ok false :error (.-message err)}))))))
+      (try
+        (let [^js state (await (if force
+                                 (js/Promise.resolve #js {:sessions (js/Object.create nil)})
+                                 (load-ingest-state)))
+              all-files (await (discover-session-files 0))
+              files (if session-dirs
+                      (.filter all-files
+                               (fn [^js f]
+                                 (some (fn [d] (.includes (.-dir f) d)) session-dirs)))
+                      all-files)
+              new-files (if force
+                          files
+                          (.filter files
+                                   (fn [^js f]
+                                     (let [^js existing (aget (.-sessions state) (.-sessionId f))]
+                                       (or (not existing)
+                                           (< (or (.-mtime existing) 0) (.-mtime f)))))))
+              to-ingest (.slice new-files 0 limit)]
+          (if (= (.-length to-ingest) 0)
+            #js {:ok true
+                 :scanned (.-length files)
+                 :newSessions 0
+                 :ingested 0
+                 :totalEvents 0
+                 :skipped (- (.-length files) (.-length to-ingest))}
+            (let [results-atom (atom #js [])]
+              (doseq [^js file (js/Array.from to-ingest)]
+                (await (ingest-single-session! file state results-atom client)))
+              (await (aggregate-ingest-results results-atom files to-ingest state)))))
+        (catch :default err
+          #js {:ok false :error (.-message err)})))))
 
 
 
-(defn get-eta-mu-ingest-status
+(defn ^:async get-eta-mu-ingest-status
   []
-  (-> (promise/all-vec [(load-ingest-state) (discover-session-files 0)])
-      (.then
-       (fn [[state all-files]]
-         (let [^js state state
-               ingested-ids (js/Set. (js/Object.keys (.-sessions state)))
+  (let [[state all-files] (await (promise/all-vec [(load-ingest-state) (discover-session-files 0)]))]
+    (let [^js state state
+          ingested-ids (js/Set. (js/Object.keys (.-sessions state)))
                pending (.filter all-files
                                 (fn [^js f] (not (.has ingested-ids (.-sessionId f)))))
                stale (.filter all-files
@@ -495,61 +478,56 @@
                 :staleSessions (.-length stale)
                 :totalIngestedEvents total-ingested
                 :lastIngestedAt last-ingested
-                :recentIngested (clj->js recent)})))))
+                :recentIngested (clj->js recent)})))
 
 
-(defn list-eta-mu-sessions
+(defn ^:async list-eta-mu-sessions
   [{:keys [limit offset workspace]
     :or {limit 50 offset 0}}]
-  (-> (discover-session-files 0)
-      (.then
-       (fn [all-files]
-         (let [filtered (if workspace
-                          (.filter all-files (fn [^js f] (.includes (.-dir f) workspace)))
-                          all-files)
-               sorted (.sort filtered (fn [^js a ^js b] (- (.-mtime b) (.-mtime a))))
-               total (.-length sorted)
-               page (.slice sorted offset (+ offset limit))]
-           (-> (js/Promise.all
-                (map
-                 (fn [^js f]
-                   (-> (.readFile fs (.-path f) "utf-8")
-                       (.then
-                        (fn [raw]
-                          (let [lines (.split raw "\n")
-                                first-line (some (fn [l] (when (not (str/blank? (.trim l))) l)) (js/Array.from lines))]
-                            (if (not first-line)
-                              #js {:sessionId (.-sessionId f) :workspace (.-dir f)
-                                   :lastModified (.toISOString (js/Date. (.-mtime f)))
-                                   :fileSize (.-size f) :dir (.-dir f)}
-                              (try
-                                (let [header (js/JSON.parse (.trim first-line))
-                                      msg-count (or (.length (.match raw (js/RegExp. "\"type\":\"message\"" "g"))) 0)
-                                      tool-count (or (.length (.match raw (js/RegExp. "\"type\":\"toolCall\"" "g"))) 0)]
-                                  #js {:sessionId (or (.-id header) (.-sessionId f))
-                                       :workspace (or (.-cwd header) (.-dir f))
-                                       :startTime (.-timestamp header)
-                                       :lastModified (.toISOString (js/Date. (.-mtime f)))
-                                       :messageCount msg-count
-                                       :toolCallCount tool-count
-                                       :fileSize (.-size f)
-                                       :dir (.-dir f)})
-                                (catch :default _
-                                  #js {:sessionId (.-sessionId f) :workspace (.-dir f)
-                                       :lastModified (.toISOString (js/Date. (.-mtime f)))
-                                       :fileSize (.-size f) :dir (.-dir f)}))))))
-                       (.catch
-                        (fn [_]
-                          #js {:sessionId (.-sessionId f) :workspace (.-dir f)
-                               :lastModified (.toISOString (js/Date. (.-mtime f)))
-                               :fileSize (.-size f) :dir (.-dir f)}))))
-                 (js/Array.from page)))
-               (.then
-                (fn [sessions]
-                  (let [valid (.filter sessions some?)]
-                    #js {:ok true
-                         :sessions valid
-                         :total total
-                         :offset offset
-                         :limit limit
-                         :has_more (< (+ offset (.-length valid)) total)})))))))))
+  (let [all-files (await (discover-session-files 0))
+        filtered (if workspace
+                   (.filter all-files (fn [^js f] (.includes (.-dir f) workspace)))
+                   all-files)
+        sorted (.sort filtered (fn [^js a ^js b] (- (.-mtime b) (.-mtime a))))
+        total (.-length sorted)
+        page (.slice sorted offset (+ offset limit))
+        sessions (await
+                  (js/Promise.all
+                   (map
+                    (^:async fn [^js f]
+                     (try
+                       (let [raw (await (.readFile fs (.-path f) "utf-8"))
+                             lines (.split raw "\n")
+                             first-line (some (fn [l] (when (not (str/blank? (.trim l))) l)) (js/Array.from lines))]
+                         (if (not first-line)
+                           #js {:sessionId (.-sessionId f) :workspace (.-dir f)
+                                :lastModified (.toISOString (js/Date. (.-mtime f)))
+                                :fileSize (.-size f) :dir (.-dir f)}
+                           (try
+                             (let [header (js/JSON.parse (.trim first-line))
+                                   msg-count (or (.length (.match raw (js/RegExp. "\"type\":\"message\"" "g"))) 0)
+                                   tool-count (or (.length (.match raw (js/RegExp. "\"type\":\"toolCall\"" "g"))) 0)]
+                               #js {:sessionId (or (.-id header) (.-sessionId f))
+                                    :workspace (or (.-cwd header) (.-dir f))
+                                    :startTime (.-timestamp header)
+                                    :lastModified (.toISOString (js/Date. (.-mtime f)))
+                                    :messageCount msg-count
+                                    :toolCallCount tool-count
+                                    :fileSize (.-size f)
+                                    :dir (.-dir f)})
+                             (catch :default _
+                               #js {:sessionId (.-sessionId f) :workspace (.-dir f)
+                                    :lastModified (.toISOString (js/Date. (.-mtime f)))
+                                    :fileSize (.-size f) :dir (.-dir f)}))))
+                       (catch :default _
+                         #js {:sessionId (.-sessionId f) :workspace (.-dir f)
+                              :lastModified (.toISOString (js/Date. (.-mtime f)))
+                              :fileSize (.-size f) :dir (.-dir f)})))
+                    (js/Array.from page))))
+        valid (.filter sessions some?)]
+    #js {:ok true
+         :sessions valid
+         :total total
+         :offset offset
+         :limit limit
+         :has_more (< (+ offset (.-length valid)) total)}))


### PR DESCRIPTION
## Backend lint async/await — ingesters, discord, voice, media (chunk 3)

Part of **`knoxx-backend-lint-async-workflows-src`** (P1). **Stacked on #38** so the diff is only this chunk's conversions.

Converts raw `.then`/`.catch` Promise chains to `^:async` + bare `await` across the two heaviest files plus the discord/voice/media domains (12 files, ~107 warnings cleared):

- **heaviest**: `infra/eta_mu_session_ingester` (28 sites), `infra/document_state` (18)
- **discord**: `domain/discord/source`, `discord_io`, `discord_reaction_labels`
- **voice**: `domain/discord/voice_tools`, `domain/voice/tools`, `domain/voice/turn_control`
- **media**: `domain/media`, `media/workspace`, `media/blaze`, `media/multimodal`

### Notes
- Parallel fan-outs keep `js/Promise.all`; the mapped fns become `^:async` and the enclosing fn `await`s the all-vec.
- Sequential ingest ordering preserved (a reduce-over-promises became `doseq` + `await`).
- `promesa` (`p/let` etc.) chains left untouched — they are not raw interop chains.

### Verification
- `pnpm -C backend lint` → **errors 0, warnings 368** (down from 475)
- `pnpm -C backend typecheck` → 0 warnings
- `pnpm -C backend test` → **578 tests / 1702 assertions / 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
