### PR TITLE
fix(backend): import mongodb and node builtins as ESM, drop js/require

### DIFF
--- a/backend/src/cljs/knoxx/backend/domain/openutau/tools.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/openutau/tools.cljs
@@ -1,5 +1,7 @@
 (ns knoxx.backend.domain.openutau.tools
   (:require [clojure.string :as str]
+            ["node:child_process" :refer [execFile]]
+            ["node:util" :refer [promisify]]
             [knoxx.backend.domain.openutau.openutau :as openutau]))
 
 (def default-render-script-path "render-ustx.sh")
@@ -32,9 +34,7 @@
   "Render a .ustx file to .wav using the headless OpenUTAU pipeline.
    Returns a promise that resolves to {:wav_path string} or rejects with error."
   [ustx-path output-wav-path]
-  (let [child-process (js/require "node:child_process")
-        util (js/require "node:util")
-        exec-file (.promisify util (.-execFile child-process))
+  (let [exec-file (promisify execFile)
         script (render-script-path)
         result (await (exec-file script #js [ustx-path output-wav-path]
                                  #js {:timeout 600000 :maxBuffer 4194304}))

--- a/backend/src/cljs/knoxx/backend/infra/mongo_client.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/mongo_client.cljs
@@ -1,7 +1,7 @@
 (ns knoxx.backend.infra.mongo-client
   "MongoDB client for Knoxx session/run persistence.
    Replaces Redis as the primary state store."
-  )
+  (:require ["mongodb" :refer [MongoClient]]))
 
 (defonce mongo-client* (atom nil))
 (defonce mongo-db* (atom nil))
@@ -25,8 +25,7 @@
   "Connect to MongoDB and cache client + db. Returns the Db instance."
   []
   (try
-    (let [MongoClient (.-MongoClient (js/require "mongodb"))
-          url (mongo-url)
+    (let [url (mongo-url)
           client (MongoClient. url #js {:serverSelectionTimeoutMS 5000})
           _ (await (.connect client))
           db (.db client (mongo-db-name))]


### PR DESCRIPTION
`js/require` is raw interop shadow-cljs never rewrites; in the ESM (`:none`, `type: module`) server bundle there is no CJS `require`, so the mongo client died with `require is not defined`, `create-policy-db` returned nil, and the backend silently ran with RBAC disabled — every `/api` route answered 200 unauthenticated. The DigitalOcean production health gate caught this as `knoxx: unauthenticated /api/config returned 200, expected 401/403`.

`mongodb` was already a declared dependency; import `MongoClient` directly so shadow emits a real ESM import (matches the cephalon-cljs precedent). Same treatment for `node:child_process`/`node:util` in openutau tools — identical latent bug.

Verified: `shadow-cljs compile server` clean (0 warnings); the emitted module loads under node and references `MongoClient` via a real import.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal module loading for audio rendering and database connectivity.
  * Preserved existing rendering, connection, caching, error handling, and shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->