### PR TITLE
fix(mcp): return the client registration, not its storage envelope

### DIFF
--- a/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
@@ -149,9 +149,18 @@
         (aset raw "rawHeaders" (clj->js (conj filtered "accept" accept-value)))))
     req))
 
+;; Fastify's default error handler reads `statusCode` off the thrown object and
+;; falls back to 500 when it is absent. A bare ex-info keeps its status in
+;; ex-data, which Fastify cannot see, so every client error these routes raise
+;; was reported as 500 Internal Server Error with the real message attached —
+;; a rejected redirect_uri, an unregistered client and a bad PKCE verifier all
+;; looked like the server had fallen over. Stamp the status where Fastify looks.
 (defn- http-error
-  ([status error detail]      (ex-info detail {:status status :error error :detail detail}))
-  ([status error detail data] (ex-info detail (merge {:status status :error error :detail detail} data))))
+  ([status error detail]      (http-error status error detail nil))
+  ([status error detail data]
+   (let [e (ex-info detail (merge {:status status :error error :detail detail} data))]
+     (aset e "statusCode" status)
+     e)))
 
 (defn- validation-detail [schema value]
   (some-> (m/explain schema value) me/humanize pr-str))

--- a/backend/src/cljs/knoxx/backend/infra/stores/mongo_mcp_oauth.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/stores/mongo_mcp_oauth.cljs
@@ -35,28 +35,39 @@
 ;; ─── Clients ────────────────────────────────────────────────────────────────
 
 (defn ^:async get-client!
-  "Read registered OAuth client by client_id."
+  "Read a registered OAuth client by client_id.
+
+   Returns the client record itself, not the storage envelope. set-client!
+   nests the registration under :client_data alongside bookkeeping fields, and
+   callers want the registration — every caller reads redirect_uris off the top
+   level of what this returns. Handing back the envelope made those lookups
+   undefined, so every registered client's redirect_uri was rejected and no MCP
+   OAuth flow could be completed.
+
+   Records written before the envelope existed are stored flat; fall back to
+   the whole document for those."
   ([client-id] (get-client! (mongo-client/get-db) client-id))
   ([db client-id]
    (when (and db client-id)
      (let [c (clients-coll db)
            result (await (.findOne c #js {"client_id" (str client-id)}))]
        (when result
-         (js/JSON.stringify (clj->js (keywordize result))))))))
+         (let [doc    (keywordize result)
+               record (or (:client_data doc) doc)]
+           (js/JSON.stringify (clj->js record))))))))
 
 (defn ^:async set-client!
-  "Store registered OAuth client."
+  "Store a registered OAuth client.
+
+   The registration is nested under :client_data, beside this store's own
+   bookkeeping. get-client! unwraps it again; keep the two in step. Clients
+   carry no TTL, unlike codes and tokens."
   ([client-id client-json] (set-client! (mongo-client/get-db) client-id client-json))
   ([db client-id client-json]
    (when (and db client-id)
      (let [c (clients-coll db)
            now (js/Date.)
-           parsed (js/JSON.parse client-json)
-           doc {:client_id (str client-id)
-                :client_data parsed
-                :created_at now
-                :system_instance_id (system-instance/current-id)
-                :expiresAt nil}] ;; No TTL for clients
+           parsed (js/JSON.parse client-json)]
        (await (.updateOne
                c
                #js {"client_id" (str client-id)}

--- a/backend/test/cljs/knoxx/backend/mcp_http_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_http_test.cljs
@@ -227,6 +227,27 @@
       (is (= [test-base] (js->clj (aget payload "authorization_servers"))))
       (is (= ["header"] (js->clj (aget payload "bearer_methods_supported")))))))
 
+(deftest ^:async client-errors-carry-their-http-status
+  (testing "a rejected registration surfaces as 400, not 500"
+    ;; Fastify's default error handler reads statusCode off the thrown object
+    ;; and falls back to 500. A bare ex-info keeps its status in ex-data, where
+    ;; Fastify cannot see it, so every client error in these routes was
+    ;; reported as 500 Internal Server Error with the real message attached —
+    ;; which is how a rejected redirect_uri came to look like a server crash.
+    (let [app (recording-app)]
+      (with-public-base-url test-base
+        (fn [] (mcp/register-mcp-http-routes! app nil {:knoxx-base-url test-base})))
+      (let [route (registered-route app "POST" "/api/mcp/oauth/register")]
+        (is (some? route) "the registration route is registered")
+        (let [outcome (try
+                        (await ((aget route "handler") #js {:body #js {}} (fake-reply)))
+                        :resolved
+                        (catch :default e e))]
+          (is (not= :resolved outcome) "a body with no redirect_uris must be rejected")
+          (when (not= :resolved outcome)
+            (is (= 400 (aget outcome "statusCode"))
+                "the status Fastify actually reads must be the intended one")))))))
+
 (deftest mcp-discovery-tests-leave-the-environment-alone
   (testing "the pinned KNOXX_PUBLIC_BASE_URL does not leak into later tests"
     (let [had?     (.hasOwnProperty js/process.env "KNOXX_PUBLIC_BASE_URL")

--- a/backend/test/cljs/knoxx/backend/mcp_oauth_store_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_oauth_store_test.cljs
@@ -1,0 +1,81 @@
+(ns knoxx.backend.mcp-oauth-store-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [knoxx.backend.infra.stores.mongo-mcp-oauth :as store]))
+
+;; ─────────────────────────────────────────────────────────
+;; set-client! / get-client! round trip
+;;
+;; set-client! nests the registration under :client_data beside its own
+;; bookkeeping fields. get-client! used to hand the whole envelope back, while
+;; every caller reads redirect_uris off the top level of what it returns — so
+;; the lookup was undefined, the allow-list was empty, and every registered
+;; client's redirect_uri was rejected:
+;;
+;;   500 {"message":"redirect_uri not allowed for registered client"}
+;;
+;; No MCP OAuth flow could be completed by any client. Nothing caught it
+;; because the two halves were only ever exercised against a live Mongo, and
+;; the browser-auth guard 302s an unauthenticated caller away before the
+;; authorize handler ever reads the client. These tests pin the two halves
+;; together with a double, so the write shape and the read shape cannot drift.
+;; ─────────────────────────────────────────────────────────
+
+(defn- fake-db
+  "Minimal Mongo double: one in-memory clients collection keyed by client_id.
+   Models the $set / $setOnInsert split so an existing document keeps its
+   original bookkeeping fields, exactly as the real upsert does."
+  []
+  (let [docs (atom {})
+        coll #js {:updateOne
+                  (fn [query update-doc _opts]
+                    (let [id      (aget query "client_id")
+                          set-doc (js->clj (aget update-doc "$set") :keywordize-keys true)
+                          on-ins  (js->clj (aget update-doc "$setOnInsert") :keywordize-keys true)]
+                      (swap! docs
+                             (fn [m]
+                               (let [base (or (get m id) (merge {:client_id id} on-ins))]
+                                 (assoc m id (merge base set-doc)))))
+                      (js/Promise.resolve #js {})))
+                  :findOne
+                  (fn [query]
+                    (js/Promise.resolve
+                     (some-> (get @docs (aget query "client_id")) clj->js)))}
+        db   #js {:collection (fn [_name] coll)}]
+    (aset db "docs" docs)
+    db))
+
+(def ^:private registration
+  {:client_id                  "8db87cc0-ec93-4ab1-949b-181bca83b61f"
+   :client_name                "ChatGPT"
+   :redirect_uris              ["https://chatgpt.com/connector/oauth/uglCS2GPPUb0"]
+   :token_endpoint_auth_method "none"
+   :grant_types                ["authorization_code"]
+   :response_types             ["code"]})
+
+(deftest ^:async registered-client-round-trips-as-the-registration
+  (testing "get-client! returns the client record, not the storage envelope"
+    (let [db (fake-db)
+          id (:client_id registration)]
+      (await (store/set-client! db id (js/JSON.stringify (clj->js registration))))
+      (let [client (js/JSON.parse (await (store/get-client! db id)))]
+        (is (= id (aget client "client_id")))
+        (is (= (:redirect_uris registration) (js->clj (aget client "redirect_uris")))
+            "redirect_uris must be readable at the top level — this is what the allow-list checks")
+        (is (= "ChatGPT" (aget client "client_name")))
+        (is (nil? (aget client "client_data"))
+            "the storage envelope must not leak through to callers")))))
+
+(deftest ^:async legacy-flat-client-record-still-reads
+  (testing "a document written before the envelope existed is returned as-is"
+    (let [db (fake-db)
+          id "legacy-client"]
+      ;; Written flat, with no :client_data wrapper.
+      (swap! (aget db "docs") assoc id
+             {:client_id id :redirect_uris ["https://legacy.example/cb"]})
+      (let [client (js/JSON.parse (await (store/get-client! db id)))]
+        (is (= ["https://legacy.example/cb"] (js->clj (aget client "redirect_uris"))))))))
+
+(deftest ^:async unknown-client-reads-as-nothing
+  (testing "an unregistered client_id yields nil rather than an empty record"
+    (let [db (fake-db)]
+      (is (nil? (await (store/get-client! db "never-registered")))))))


### PR DESCRIPTION
## What is broken

Every registered OAuth client's `redirect_uri` is rejected, so **no MCP client
can complete the flow** — reported from a real ChatGPT connector attempt:

```
500 {"statusCode":500,"error":"Internal Server Error",
     "message":"redirect_uri not allowed for registered client"}
```

## Why

`set-client!` nests the registration under `:client_data` beside its own
bookkeeping, but `get-client!` serialised the **whole document**. Every caller
reads `redirect_uris` off the top level of what it returns:

```clojure
(defn- redirect-uri-allowed? [client redirect-uri]
  (if-not client true
    (boolean (.includes (js/Array.from (or (aget client "redirect_uris") (js/Array.))) redirect-uri))))
```

So the lookup was `undefined`, the allow-list fell back to `[]`, and the check
could only ever fail. Confirmed against the production record:

```
client_id:                8db87cc0-ec93-4ab1-949b-181bca83b61f
top-level redirect_uris:  undefined          ← what the check reads
client_data.redirect_uris: ["https://chatgpt.com/connector/oauth/uglCS2GPPUb0"]
                                             ← exactly the requested redirect_uri
```

`get-client!` now unwraps `:client_data`, falling back to the whole document for
records written before the envelope existed.

## The 500

Fastify's default error handler reads `statusCode` off the thrown object and
falls back to 500. A bare `ex-info` keeps its status in ex-data, where Fastify
cannot see it — so a rejected `redirect_uri`, an unregistered client and a bad
PKCE verifier were **all** reported as `500 Internal Server Error` with the real
message attached. That is why this read as a server fault instead of the `400`
it was. `http-error` now stamps `statusCode` where Fastify looks.

The dead `doc` binding in `set-client!` goes too — it described a document shape
that is not what `updateOne` writes, which is precisely the misreading behind
the bug.

## Why nothing caught it

The two halves of the store were only ever exercised together against a live
Mongo, and the browser-auth guard `302`s an unauthenticated caller to login
*before* the authorize handler reads the client — so probing the flow without
logging in never reaches this code. That is exactly how it survived the
verification on #212.

The new `mcp_oauth_store_test.cljs` pins the write shape and the read shape
together with a Mongo double. Reverting either fix fails the suite:

```
FAIL in (registered-client-round-trips-as-the-registration)
  expected: (= (:redirect_uris registration) (js->clj (aget client "redirect_uris")))
    actual: (not (= ["https://chatgpt.com/connector/oauth/uglCS2GPPUb0"] nil))

FAIL in (client-errors-carry-their-http-status)
  expected: (= 400 (aget outcome "statusCode"))
    actual: (not (= 400 nil))
```

690 tests / 2008 assertions, 0 failures. `clj-kondo` clean on all four files.

## Follow-up, not in scope

These endpoints return Fastify's `{statusCode, error, message}` rather than RFC
6749's `{error, error_description}`. Worth aligning separately; this PR only
corrects the status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)