### PR TITLE
fix(mcp): read the expiry key the writers actually write

### DIFF
--- a/backend/src/cljs/knoxx/backend/extern/mongo.cljs
+++ b/backend/src/cljs/knoxx/backend/extern/mongo.cljs
@@ -12,6 +12,21 @@
   (await (.insertOne collection-handle (clj->js doc)))
   doc)
 
+(defn instant-ms
+  "Decode a stored BSON instant to epoch milliseconds, or nil if unreadable.
+
+   Mongo hands a date back as a native js/Date, and inspecting that anywhere
+   but here would put the driver's shape in an ordinary namespace. A number is
+   passed through and an ISO string is parsed so hand-written and migrated
+   documents still read; anything else — including a date that parses to NaN —
+   is nil, leaving the caller to decide what an unreadable instant means."
+  [value]
+  (cond
+    (number? value)           value
+    (instance? js/Date value) (let [ms (.getTime value)] (when-not (js/isNaN ms) ms))
+    (string? value)           (let [ms (.parse js/Date value)] (when-not (js/isNaN ms) ms))
+    :else                     nil))
+
 (defn ^:async delete-one!
   "Delete at most one document matching a CLJS field-equality query.
 

--- a/backend/src/cljs/knoxx/backend/extern/mongo.cljs
+++ b/backend/src/cljs/knoxx/backend/extern/mongo.cljs
@@ -4,7 +4,8 @@
    Knoxx does not ship a MongoDB driver; callers inject a native collection
    handle (any object exposing insertOne/find with a toArray cursor). All raw
    interop with that handle is born and dies here — store records upstream
-   speak CLJS maps only.")
+   speak CLJS maps only."
+  (:require [knoxx.backend.law.mongo :as law-mongo]))
 
 (defn ^:async insert-one!
   "Insert one CLJS document into a native collection handle. Returns the doc."
@@ -12,21 +13,14 @@
   (await (.insertOne collection-handle (clj->js doc)))
   doc)
 
-;; ECMAScript's maximum time value: ±100,000,000 days from the epoch. A number
-;; outside this cannot be an instant, and js/Date rejects it too.
-(def ^:private max-time-value 8.64e15)
+(defn- decoded-instant
+  "A time value only when it satisfies law.mongo/EpochMillis.
 
-(defn- finite-instant
-  "A time value only when it is a real, representable instant.
-
-   Infinity is the dangerous one: it is a number, it compares greater than
-   every clock reading, and unguarded it would leave a credential live for
-   good. NaN and out-of-range values are rejected for the same reason —
-   nothing that cannot name a moment may be treated as one."
+   The admissible shape is named by the contract rather than re-derived here,
+   so this boundary and every caller that consumes the decoded value cannot
+   drift apart on what counts as an instant."
   [ms]
-  (when (and (js/Number.isFinite ms)
-             (<= (- max-time-value) ms max-time-value))
-    ms))
+  (when (law-mongo/valid-epoch-ms? ms) ms))
 
 (defn instant-ms
   "Decode a stored BSON instant to epoch milliseconds, or nil if unreadable.
@@ -36,15 +30,15 @@
    accepted and an ISO string is parsed so hand-written and migrated documents
    still read.
 
-   Every path goes through finite-instant, so anything that cannot name a real
-   moment — an invalid Date, an unparseable string, Infinity, NaN, a value past
-   the representable range — decodes to nil, and the caller decides what an
-   unreadable instant means."
+   Every path is checked against law.mongo/EpochMillis, so anything that cannot
+   name a real moment — an invalid Date, an unparseable string, Infinity, NaN,
+   a value past the representable range — decodes to nil, and the caller
+   decides what an unreadable instant means."
   [value]
   (cond
-    (number? value)           (finite-instant value)
-    (instance? js/Date value) (finite-instant (.getTime value))
-    (string? value)           (finite-instant (.parse js/Date value))
+    (number? value)           (decoded-instant value)
+    (instance? js/Date value) (decoded-instant (.getTime value))
+    (string? value)           (decoded-instant (.parse js/Date value))
     :else                     nil))
 
 (defn ^:async delete-one!

--- a/backend/src/cljs/knoxx/backend/extern/mongo.cljs
+++ b/backend/src/cljs/knoxx/backend/extern/mongo.cljs
@@ -12,19 +12,39 @@
   (await (.insertOne collection-handle (clj->js doc)))
   doc)
 
+;; ECMAScript's maximum time value: ±100,000,000 days from the epoch. A number
+;; outside this cannot be an instant, and js/Date rejects it too.
+(def ^:private max-time-value 8.64e15)
+
+(defn- finite-instant
+  "A time value only when it is a real, representable instant.
+
+   Infinity is the dangerous one: it is a number, it compares greater than
+   every clock reading, and unguarded it would leave a credential live for
+   good. NaN and out-of-range values are rejected for the same reason —
+   nothing that cannot name a moment may be treated as one."
+  [ms]
+  (when (and (js/Number.isFinite ms)
+             (<= (- max-time-value) ms max-time-value))
+    ms))
+
 (defn instant-ms
   "Decode a stored BSON instant to epoch milliseconds, or nil if unreadable.
 
    Mongo hands a date back as a native js/Date, and inspecting that anywhere
    but here would put the driver's shape in an ordinary namespace. A number is
-   passed through and an ISO string is parsed so hand-written and migrated
-   documents still read; anything else — including a date that parses to NaN —
-   is nil, leaving the caller to decide what an unreadable instant means."
+   accepted and an ISO string is parsed so hand-written and migrated documents
+   still read.
+
+   Every path goes through finite-instant, so anything that cannot name a real
+   moment — an invalid Date, an unparseable string, Infinity, NaN, a value past
+   the representable range — decodes to nil, and the caller decides what an
+   unreadable instant means."
   [value]
   (cond
-    (number? value)           value
-    (instance? js/Date value) (let [ms (.getTime value)] (when-not (js/isNaN ms) ms))
-    (string? value)           (let [ms (.parse js/Date value)] (when-not (js/isNaN ms) ms))
+    (number? value)           (finite-instant value)
+    (instance? js/Date value) (finite-instant (.getTime value))
+    (string? value)           (finite-instant (.parse js/Date value))
     :else                     nil))
 
 (defn ^:async delete-one!

--- a/backend/src/cljs/knoxx/backend/extern/mongo.cljs
+++ b/backend/src/cljs/knoxx/backend/extern/mongo.cljs
@@ -41,6 +41,24 @@
     (string? value)           (decoded-instant (.parse js/Date value))
     :else                     nil))
 
+(defn ^:async find-one-and-delete!
+  "Atomically remove one document matching a CLJS field-equality query and
+   return it as CLJS data, or nil when nothing matched.
+
+   The atomicity is the point: exactly one concurrent caller can receive the
+   document, so a caller can use this to make a single-use credential single
+   use. A read followed by a separate delete cannot promise that.
+
+   Driver v6 returns the document itself; earlier versions wrapped it as
+   {value: doc}. Both are unwrapped here so the caller never has to know."
+  [collection-handle query]
+  (let [result (await (.findOneAndDelete collection-handle (clj->js query)))]
+    (when result
+      (let [doc (if (and (object? result) (.hasOwnProperty result "value"))
+                  (aget result "value")
+                  result)]
+        (when doc (js->clj doc :keywordize-keys true))))))
+
 (defn ^:async delete-one!
   "Delete at most one document matching a CLJS field-equality query.
 

--- a/backend/src/cljs/knoxx/backend/extern/mongo.cljs
+++ b/backend/src/cljs/knoxx/backend/extern/mongo.cljs
@@ -22,6 +22,16 @@
   [ms]
   (when (law-mongo/valid-epoch-ms? ms) ms))
 
+(defn- assert-query!
+  "Refuse a query that does not satisfy law.mongo/FieldEqualityQuery.
+
+   Shared by both delete paths: an empty query matches every document, so on
+   either of them it is the difference between removing one record and
+   removing the collection."
+  [query]
+  (when-not (law-mongo/valid-query? query)
+    (throw (ex-info "refusing an unsafe field-equality query" {:query query}))))
+
 (defn instant-ms
   "Decode a stored BSON instant to epoch milliseconds, or nil if unreadable.
 
@@ -50,14 +60,27 @@
    use. A read followed by a separate delete cannot promise that.
 
    Driver v6 returns the document itself; earlier versions wrapped it as
-   {value: doc}. Both are unwrapped here so the caller never has to know."
+   {value: doc}. Both are unwrapped here so the caller never has to know.
+
+   The query is checked against law.mongo/FieldEqualityQuery before it is
+   issued and the decoded document against DecodedDocument before it is
+   returned. The input check matters most on this operation: an empty query
+   matches every document, which on a delete would take the whole collection
+   rather than the one code being claimed. The output check keeps an
+   unexpected driver shape from reaching a caller that has already destroyed
+   the record it is about to misread."
   [collection-handle query]
-  (let [result (await (.findOneAndDelete collection-handle (clj->js query)))]
-    (when result
-      (let [doc (if (and (object? result) (.hasOwnProperty result "value"))
-                  (aget result "value")
-                  result)]
-        (when doc (js->clj doc :keywordize-keys true))))))
+  (assert-query! query)
+  (let [result (await (.findOneAndDelete collection-handle (clj->js query)))
+        raw    (when result
+                 (if (and (object? result) (.hasOwnProperty result "value"))
+                   (aget result "value")
+                   result))
+        doc    (when raw (js->clj raw :keywordize-keys true))]
+    (when-not (law-mongo/valid-document? doc)
+      (throw (ex-info "mongo findOneAndDelete returned an undecodable document"
+                      {:decoded doc})))
+    doc))
 
 (defn ^:async delete-one!
   "Delete at most one document matching a CLJS field-equality query.
@@ -73,6 +96,7 @@
    all, and callers validating a required count would accept the fabrication
    and carry on — the boundary must fail closed, not invent an answer."
   [collection-handle query]
+  (assert-query! query)
   (let [result (await (.deleteOne collection-handle (clj->js query)))
         count  (aget result "deletedCount")]
     {:deleted-count (when (number? count) count)}))

--- a/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
@@ -540,6 +540,23 @@
             (when state (.set (.-searchParams redir) "state" state))
             (.redirect reply (.toString redir) 302)))))))
 
+(defn- ensure-code-bindings!
+  "Reject an exchange whose client, redirect or PKCE verifier does not match the
+   code it presents.
+
+   Checked against a non-destructive read so a rejected request never spends the
+   code: anyone who merely observed the code on the front channel could
+   otherwise destroy it with any wrong verifier, and it would buy nothing, since
+   a verifier carries far too much entropy to guess."
+  [crypto record client-id redirect-uri code-verifier]
+  (when (or (not= (:clientId record) client-id)
+            (not= (:redirectUri record) redirect-uri))
+    (throw (http-error 400 "invalid_grant" "Client/redirect mismatch")))
+  (let [expected (str (or (:codeChallenge record) ""))
+        actual   (pkce-challenge crypto code-verifier)]
+    (when (or (str/blank? expected) (not= expected actual))
+      (throw (http-error 400 "invalid_grant" "PKCE verification failed")))))
+
 (defn- ^:async persist-access-token!
   "Mint and store an access token from a claimed code record (a CLJS map)."
   [crypto token-ttl client-id record]
@@ -566,25 +583,19 @@
       (throw (http-error 400 "invalid_request" "Missing required token exchange parameters")))
     (let [client (await (get-registered-client client-id))]
       (ensure-redirect-uri-allowed! client redirect-uri "invalid_grant")
-      ;; Claimed, not read: an authorization code is single use, and the delete
-      ;; has to happen in the same operation as the read. Reading first and
-      ;; deleting after issuing left a window in which two concurrent exchanges
-      ;; both saw a live code and both minted a token from it.
-      ;;
-      ;; The claim precedes every check below, so a code that fails PKCE or the
-      ;; client match is spent rather than left for another attempt. That is the
-      ;; intent: it denies an attacker repeated guesses at the verifier.
-      (let [record (await (mongo-mcp/consume-code! code))]
-        (when-not record (throw (http-error 400 "invalid_grant" "Unknown or expired code")))
-        (let [expected (str (or (:codeChallenge record) ""))
-              actual   (pkce-challenge crypto code-verifier)]
-          (when (or (not= (:clientId record) client-id)
-                    (not= (:redirectUri record) redirect-uri))
-            (throw (http-error 400 "invalid_grant" "Client/redirect mismatch")))
-          (when (or (str/blank? expected) (not= expected actual))
-            (throw (http-error 400 "invalid_grant" "PKCE verification failed")))
-          (let [token-response (await (persist-access-token! crypto token-ttl client-id record))]
-            (json-send! reply 200 token-response)))))))
+      ;; Validate against a peek, then claim. Single use is enforced by the
+      ;; claim rather than the read: two concurrent exchanges can both pass the
+      ;; bindings, but find-one-and-delete picks one winner and the loser is
+      ;; told the code is spent. The token is minted from the claimed record,
+      ;; not the peeked one, so its contents cannot have changed in between.
+      (let [peeked (await (mongo-mcp/peek-code! code))]
+        (when-not peeked (throw (http-error 400 "invalid_grant" "Unknown or expired code")))
+        (ensure-code-bindings! crypto peeked client-id redirect-uri code-verifier)
+        (let [record (await (mongo-mcp/consume-code! code))]
+          (when-not record
+            (throw (http-error 400 "invalid_grant" "Authorization code already used")))
+          (json-send! reply 200
+                      (await (persist-access-token! crypto token-ttl client-id record))))))))
 
 (defroute mcp-list-user-tokens! [browser-auth-guard] "GET" "/api/mcp/tokens" [browser-auth-guard]
   (let [auth-context  (aget request "authContext")

--- a/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
@@ -540,18 +540,22 @@
             (when state (.set (.-searchParams redir) "state" state))
             (.redirect reply (.toString redir) 302)))))))
 
-(defn- ^:async persist-access-token! [crypto token-ttl client-id record]
-  (let [access-token (.randomUUID crypto)
-        token-value  {:accessToken access-token :clientId client-id
-                      :membershipId (aget record "membershipId")
-                      :userEmail    (aget record "userEmail")
-                      :orgSlug      (aget record "orgSlug")
-                      :tools        (aget record "tools")
-                      :createdAt    (.toISOString (js/Date.))
-                      :expiresAt    (.toISOString (js/Date. (+ (.now js/Date) (* token-ttl 1000))))}]
-    (await (mongo-mcp/set-token! access-token (js/JSON.stringify (clj->js token-value)) token-ttl (aget record "membershipId")))
+(defn- ^:async persist-access-token!
+  "Mint and store an access token from a claimed code record (a CLJS map)."
+  [crypto token-ttl client-id record]
+  (let [access-token  (.randomUUID crypto)
+        membership-id (:membershipId record)
+        tools         (vec (:tools record))
+        token-value   {:accessToken access-token :clientId client-id
+                       :membershipId membership-id
+                       :userEmail    (:userEmail record)
+                       :orgSlug      (:orgSlug record)
+                       :tools        tools
+                       :createdAt    (.toISOString (js/Date.))
+                       :expiresAt    (.toISOString (js/Date. (+ (.now js/Date) (* token-ttl 1000))))}]
+    (await (mongo-mcp/set-token! access-token (js/JSON.stringify (clj->js token-value)) token-ttl membership-id))
     {:access_token access-token :token_type "Bearer"
-     :scope        (->> (array-seq (or (aget record "tools") (js/Array.))) (str/join " "))
+     :scope        (str/join " " tools)
      :expires_in   token-ttl}))
 
 (defroute mcp-exchange-token! [crypto token-ttl] "POST" "/api/mcp/oauth/token" []
@@ -570,13 +574,12 @@
       ;; The claim precedes every check below, so a code that fails PKCE or the
       ;; client match is spent rather than left for another attempt. That is the
       ;; intent: it denies an attacker repeated guesses at the verifier.
-      (let [raw (await (mongo-mcp/consume-code! code))]
-        (when-not raw (throw (http-error 400 "invalid_grant" "Unknown or expired code")))
-        (let [record   (js/JSON.parse raw)
-              expected (str (or (aget record "codeChallenge") ""))
+      (let [record (await (mongo-mcp/consume-code! code))]
+        (when-not record (throw (http-error 400 "invalid_grant" "Unknown or expired code")))
+        (let [expected (str (or (:codeChallenge record) ""))
               actual   (pkce-challenge crypto code-verifier)]
-          (when (or (not= (aget record "clientId") client-id)
-                    (not= (aget record "redirectUri") redirect-uri))
+          (when (or (not= (:clientId record) client-id)
+                    (not= (:redirectUri record) redirect-uri))
             (throw (http-error 400 "invalid_grant" "Client/redirect mismatch")))
           (when (or (str/blank? expected) (not= expected actual))
             (throw (http-error 400 "invalid_grant" "PKCE verification failed")))

--- a/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
@@ -562,7 +562,15 @@
       (throw (http-error 400 "invalid_request" "Missing required token exchange parameters")))
     (let [client (await (get-registered-client client-id))]
       (ensure-redirect-uri-allowed! client redirect-uri "invalid_grant")
-      (let [raw (await (mongo-mcp/get-code! code))]
+      ;; Claimed, not read: an authorization code is single use, and the delete
+      ;; has to happen in the same operation as the read. Reading first and
+      ;; deleting after issuing left a window in which two concurrent exchanges
+      ;; both saw a live code and both minted a token from it.
+      ;;
+      ;; The claim precedes every check below, so a code that fails PKCE or the
+      ;; client match is spent rather than left for another attempt. That is the
+      ;; intent: it denies an attacker repeated guesses at the verifier.
+      (let [raw (await (mongo-mcp/consume-code! code))]
         (when-not raw (throw (http-error 400 "invalid_grant" "Unknown or expired code")))
         (let [record   (js/JSON.parse raw)
               expected (str (or (aget record "codeChallenge") ""))
@@ -572,7 +580,6 @@
             (throw (http-error 400 "invalid_grant" "Client/redirect mismatch")))
           (when (or (str/blank? expected) (not= expected actual))
             (throw (http-error 400 "invalid_grant" "PKCE verification failed")))
-          (await (mongo-mcp/delete-code! code))
           (let [token-response (await (persist-access-token! crypto token-ttl client-id record))]
             (json-send! reply 200 token-response)))))))
 

--- a/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
@@ -9,6 +9,7 @@
             [knoxx.backend.infra.db.policy :as db-policy]
             [knoxx.backend.domain.mcp.mcp-expose :as mcp-expose]
             [knoxx.backend.infra.stores.mongo-mcp-oauth :as mongo-mcp]
+            [knoxx.backend.law.mcp-oauth :as law]
             [knoxx.backend.runtime.state :as runtime-state]
             ["@modelcontextprotocol/sdk/server/mcp.js" :refer [McpServer]]
             ["@modelcontextprotocol/sdk/server/streamableHttp.js" :refer [StreamableHTTPServerTransport]]
@@ -549,13 +550,13 @@
    otherwise destroy it with any wrong verifier, and it would buy nothing, since
    a verifier carries far too much entropy to guess."
   [crypto record client-id redirect-uri code-verifier]
-  (when (or (not= (:clientId record) client-id)
-            (not= (:redirectUri record) redirect-uri))
+  ;; Parsing and the challenge computation stay here — the crypto is effectful.
+  ;; Whether the result admits the exchange is law's decision, so both rules
+  ;; live in one pure place that every future caller shares.
+  (when-not (law/code-bound-to? record client-id redirect-uri)
     (throw (http-error 400 "invalid_grant" "Client/redirect mismatch")))
-  (let [expected (str (or (:codeChallenge record) ""))
-        actual   (pkce-challenge crypto code-verifier)]
-    (when (or (str/blank? expected) (not= expected actual))
-      (throw (http-error 400 "invalid_grant" "PKCE verification failed")))))
+  (when-not (law/pkce-verified? record (pkce-challenge crypto code-verifier))
+    (throw (http-error 400 "invalid_grant" "PKCE verification failed"))))
 
 (defn- ^:async persist-access-token!
   "Mint and store an access token from a claimed code record (a CLJS map)."

--- a/backend/src/cljs/knoxx/backend/infra/stores/mongo_mcp_oauth.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/stores/mongo_mcp_oauth.cljs
@@ -34,6 +34,34 @@
 (defn- keywordize [doc]
   (when doc (js->clj doc :keywordize-keys true)))
 
+(defn- expiry-ms
+  "Milliseconds since epoch for a stored document's expiry, or nil if unreadable.
+
+   The writers store :expiresAt as a BSON date, which the driver hands back as a
+   js/Date; a number or an ISO string are accepted too so a hand-written or
+   migrated document still reads. Anything else yields nil."
+  [doc]
+  (let [v (:expiresAt doc)]
+    (cond
+      (number? v)             v
+      (instance? js/Date v)   (.getTime v)
+      (string? v)             (let [t (.parse js/Date v)] (when-not (js/isNaN t) t))
+      :else                   nil)))
+
+(defn- live?
+  "True when a document has a readable expiry that is still in the future.
+
+   Reads :expiresAt — the key the writers actually use. The readers previously
+   asked for :expires-at, which no document has ever carried, so the default of
+   0 made every code and every token read as already expired: the token
+   exchange answered 'Unknown or expired code' for codes it had just minted,
+   and no access token could ever be presented successfully. An unreadable or
+   missing expiry counts as expired, so this fails closed."
+  [doc]
+  (if-let [ms (expiry-ms doc)]
+    (> ms (.now js/Date))
+    false))
+
 ;; ─── Clients ────────────────────────────────────────────────────────────────
 
 (defn ^:async get-client!
@@ -90,7 +118,7 @@
            result (await (.findOne c #js {"code" (str code)}))]
        (when result
          (let [doc (keywordize result)]
-           (when (> (:expires-at doc 0) (.now js/Date))
+           (when (live? doc)
              (js/JSON.stringify (clj->js (:code_data doc))))))))))
 
 (defn ^:async set-code!
@@ -136,7 +164,7 @@
            result (await (.findOne c #js {"access_token" (str access-token)}))]
        (when result
          (let [doc (keywordize result)]
-           (when (> (:expires-at doc 0) (.now js/Date))
+           (when (live? doc)
              (js/JSON.stringify (clj->js (:token_data doc))))))))))
 
 (defn ^:async set-token!
@@ -214,5 +242,5 @@
            results (await (.toArray cursor))]
        (vec (for [doc results
                   :let [d (keywordize doc)]
-                  :when (> (:expires-at d 0) (.now js/Date))]
+                  :when (live? d)]
               (js/JSON.stringify (clj->js (:token_data d)))))))))

--- a/backend/src/cljs/knoxx/backend/infra/stores/mongo_mcp_oauth.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/stores/mongo_mcp_oauth.cljs
@@ -34,20 +34,6 @@
 (defn- keywordize [doc]
   (when doc (js->clj doc :keywordize-keys true)))
 
-(defn- expiry-ms
-  "Milliseconds since epoch for a stored document's expiry, or nil if unreadable.
-
-   The writers store :expiresAt as a BSON date, which the driver hands back as a
-   js/Date; a number or an ISO string are accepted too so a hand-written or
-   migrated document still reads. Anything else yields nil."
-  [doc]
-  (let [v (:expiresAt doc)]
-    (cond
-      (number? v)             v
-      (instance? js/Date v)   (.getTime v)
-      (string? v)             (let [t (.parse js/Date v)] (when-not (js/isNaN t) t))
-      :else                   nil)))
-
 (defn- live?
   "True when a document has a readable expiry that is still in the future.
 
@@ -55,10 +41,13 @@
    asked for :expires-at, which no document has ever carried, so the default of
    0 made every code and every token read as already expired: the token
    exchange answered 'Unknown or expired code' for codes it had just minted,
-   and no access token could ever be presented successfully. An unreadable or
-   missing expiry counts as expired, so this fails closed."
+   and no access token could ever be presented successfully.
+
+   Decoding the stored instant belongs to extern.mongo, which owns the driver's
+   shape; this only decides what the decoded value means. An unreadable or
+   missing expiry counts as expired, so the check fails closed."
   [doc]
-  (if-let [ms (expiry-ms doc)]
+  (if-let [ms (extern-mongo/instant-ms (:expiresAt doc))]
     (> ms (.now js/Date))
     false))
 

--- a/backend/src/cljs/knoxx/backend/infra/stores/mongo_mcp_oauth.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/stores/mongo_mcp_oauth.cljs
@@ -43,18 +43,13 @@
    exchange answered 'Unknown or expired code' for codes it had just minted,
    and no access token could ever be presented successfully.
 
-   Decoding the stored instant belongs to extern.mongo, which owns the driver's
-   shape; this only decides what the decoded value means. An unreadable or
-   missing expiry counts as expired, so the check fails closed."
+   Each layer does its own part: extern.mongo decodes the driver's instant,
+   law.mcp-oauth decides what a decoded instant means, and this reads the
+   clock. An unreadable or missing expiry is not live, so the check fails
+   closed."
   [doc]
-  ;; instant-ms yields a finite number or nil, but that guarantee does not
-  ;; cross the namespace boundary for the compiler's inference, so both sides
-  ;; of the comparison are hinted rather than left to warn.
-  (if-let [ms (extern-mongo/instant-ms (:expiresAt doc))]
-    (let [^number expiry ms
-          ^number now    (.now js/Date)]
-      (> expiry now))
-    false))
+  (law/credential-live? (extern-mongo/instant-ms (:expiresAt doc))
+                        (.now js/Date)))
 
 ;; ─── Clients ────────────────────────────────────────────────────────────────
 

--- a/backend/src/cljs/knoxx/backend/infra/stores/mongo_mcp_oauth.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/stores/mongo_mcp_oauth.cljs
@@ -98,22 +98,6 @@
 
 ;; ─── Codes ──────────────────────────────────────────────────────────────────
 
-(defn ^:async get-code!
-  "Read an OAuth auth code without consuming it.
-
-   Does not make the code single use. A token exchange wants consume-code!;
-   reading here and deleting afterwards lets two concurrent exchanges both pass
-   the read before either deletes, and both then mint a token from one code."
-  ([code] (get-code! (mongo-client/get-db) code))
-  ([db code]
-   (when (and db code)
-     (let [c (codes-coll db)
-           result (await (.findOne c #js {"code" (str code)}))]
-       (when result
-         (let [doc (keywordize result)]
-           (when (live? doc)
-             (js/JSON.stringify (clj->js (:code_data doc))))))))))
-
 (defn ^:async consume-code!
   "Atomically claim an OAuth auth code, returning its data exactly once.
 
@@ -132,7 +116,7 @@
      (let [doc (await (extern-mongo/find-one-and-delete!
                        (codes-coll db) {:code (str code)}))]
        (when (and doc (live? doc))
-         (js/JSON.stringify (clj->js (:code_data doc))))))))
+         (:code_data doc))))))
 
 (defn ^:async set-code!
   "Store OAuth auth code with TTL."

--- a/backend/src/cljs/knoxx/backend/infra/stores/mongo_mcp_oauth.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/stores/mongo_mcp_oauth.cljs
@@ -104,7 +104,11 @@
 ;; ─── Codes ──────────────────────────────────────────────────────────────────
 
 (defn ^:async get-code!
-  "Read OAuth auth code."
+  "Read an OAuth auth code without consuming it.
+
+   Does not make the code single use. A token exchange wants consume-code!;
+   reading here and deleting afterwards lets two concurrent exchanges both pass
+   the read before either deletes, and both then mint a token from one code."
   ([code] (get-code! (mongo-client/get-db) code))
   ([db code]
    (when (and db code)
@@ -114,6 +118,26 @@
          (let [doc (keywordize result)]
            (when (live? doc)
              (js/JSON.stringify (clj->js (:code_data doc))))))))))
+
+(defn ^:async consume-code!
+  "Atomically claim an OAuth auth code, returning its data exactly once.
+
+   An authorization code is single use: RFC 6749 requires that presenting one
+   twice does not yield two credentials. The delete and the read are one
+   operation so that exactly one of any number of concurrent exchanges can
+   claim it — a read followed by a separate delete leaves a window in which
+   both callers see a live code and both mint a token.
+
+   The claim happens before the code's own validity is judged, so a code that
+   turns out to be expired is still consumed. That is deliberate: an expired
+   code is spent either way, and leaving it readable would invite retries."
+  ([code] (consume-code! (mongo-client/get-db) code))
+  ([db code]
+   (when (and db code)
+     (let [doc (await (extern-mongo/find-one-and-delete!
+                       (codes-coll db) {:code (str code)}))]
+       (when (and doc (live? doc))
+         (js/JSON.stringify (clj->js (:code_data doc))))))))
 
 (defn ^:async set-code!
   "Store OAuth auth code with TTL."

--- a/backend/src/cljs/knoxx/backend/infra/stores/mongo_mcp_oauth.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/stores/mongo_mcp_oauth.cljs
@@ -98,6 +98,24 @@
 
 ;; ─── Codes ──────────────────────────────────────────────────────────────────
 
+(defn ^:async peek-code!
+  "Read a live OAuth auth code without spending it, as CLJS data or nil.
+
+   Deliberately non-destructive, and paired with consume-code!: an exchange
+   reads the code here to check the client, redirect and PKCE bindings, and
+   only claims it once those hold. Spending it first would let anyone who
+   merely observed the code on the front channel destroy it with a wrong
+   verifier and break the legitimate client's exchange."
+  ([code] (peek-code! (mongo-client/get-db) code))
+  ([db code]
+   (when (and db code)
+     (let [c (codes-coll db)
+           result (await (.findOne c #js {"code" (str code)}))]
+       (when result
+         (let [doc (keywordize result)]
+           (when (live? doc)
+             (:code_data doc))))))))
+
 (defn ^:async consume-code!
   "Atomically claim an OAuth auth code, returning its data exactly once.
 
@@ -107,9 +125,10 @@
    claim it — a read followed by a separate delete leaves a window in which
    both callers see a live code and both mint a token.
 
-   The claim happens before the code's own validity is judged, so a code that
-   turns out to be expired is still consumed. That is deliberate: an expired
-   code is spent either way, and leaving it readable would invite retries."
+   Call this only once an exchange has been found admissible. The claim is what
+   settles a race between two otherwise-valid exchanges; it is not the place to
+   discover that a request was invalid, because a rejected request must not
+   spend the code."
   ([code] (consume-code! (mongo-client/get-db) code))
   ([db code]
    (when (and db code)

--- a/backend/src/cljs/knoxx/backend/infra/stores/mongo_mcp_oauth.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/stores/mongo_mcp_oauth.cljs
@@ -47,8 +47,13 @@
    shape; this only decides what the decoded value means. An unreadable or
    missing expiry counts as expired, so the check fails closed."
   [doc]
+  ;; instant-ms yields a finite number or nil, but that guarantee does not
+  ;; cross the namespace boundary for the compiler's inference, so both sides
+  ;; of the comparison are hinted rather than left to warn.
   (if-let [ms (extern-mongo/instant-ms (:expiresAt doc))]
-    (> ms (.now js/Date))
+    (let [^number expiry ms
+          ^number now    (.now js/Date)]
+      (> expiry now))
     false))
 
 ;; ─── Clients ────────────────────────────────────────────────────────────────

--- a/backend/src/cljs/knoxx/backend/law/mcp_oauth.cljs
+++ b/backend/src/cljs/knoxx/backend/law/mcp_oauth.cljs
@@ -5,7 +5,24 @@
    define them, so the obligations of a boundary can be read without reading
    the code that performs it."
   (:require [clojure.string :as str]
-            [malli.core :as m]))
+            [malli.core :as m]
+            [knoxx.backend.law.mongo :as law-mongo]))
+
+(defn credential-live?
+  "True when a credential with this expiry is still admissible at this instant.
+
+   Pure, and takes the clock reading as an argument: the effectful layer reads
+   the time, this decides what it means. That keeps one rule for every reader —
+   get-code!, consume-code!, get-token! and the token listing all admit exactly
+   the same credentials — and lets the rule be tested without a clock.
+
+   Both arguments must be readable instants. An unreadable expiry is not live:
+   a credential whose expiry cannot be named must not be honoured, so this
+   fails closed rather than treating the unknown as far future."
+  [expiry-ms now-ms]
+  (boolean (and (law-mongo/valid-epoch-ms? expiry-ms)
+                (law-mongo/valid-epoch-ms? now-ms)
+                (> expiry-ms now-ms))))
 
 (def NonBlankString
   [:and string? [:fn {:error/message "must not be blank"} #(not (str/blank? %))]])

--- a/backend/src/cljs/knoxx/backend/law/mcp_oauth.cljs
+++ b/backend/src/cljs/knoxx/backend/law/mcp_oauth.cljs
@@ -27,6 +27,31 @@
 (def NonBlankString
   [:and string? [:fn {:error/message "must not be blank"} #(not (str/blank? %))]])
 
+(defn code-bound-to?
+  "True when a claimed code was issued to this client and redirect URI.
+
+   Pure. An authorization code is bound to the client that requested it and the
+   redirect it was issued for; honouring it for a different pair would let a
+   client redeem someone else's code."
+  [record client-id redirect-uri]
+  (and (some? record)
+       (= (:clientId record) client-id)
+       (= (:redirectUri record) redirect-uri)))
+
+(defn pkce-verified?
+  "True when a computed PKCE challenge matches the one the code carries.
+
+   Pure: the caller computes the challenge from the verifier — that is crypto,
+   and it stays in the effectful layer — while this decides whether the result
+   admits the exchange. A code carrying no challenge is never verified, so a
+   record written without one cannot be redeemed by omitting the verifier."
+  [record computed-challenge]
+  (let [expected (str (or (:codeChallenge record) ""))
+        actual   (str (or computed-challenge ""))]
+    (and (not (str/blank? expected))
+         (not (str/blank? actual))
+         (= expected actual))))
+
 (def RevocationRequest
   "Identity required to revoke an access token.
 

--- a/backend/src/cljs/knoxx/backend/law/mongo.cljs
+++ b/backend/src/cljs/knoxx/backend/law/mongo.cljs
@@ -24,3 +24,28 @@
 (defn valid-epoch-ms?
   [ms]
   (m/validate EpochMillis ms))
+
+(def FieldEqualityQuery
+  "A field-equality query handed to the Mongo adapter.
+
+   Non-empty is the load-bearing part. An empty query matches every document
+   in the collection, so on a delete path it is the difference between
+   removing one authorization code and removing all of them. Values are
+   scalars because this shape is equality matching only — an operator map is
+   a different contract and does not belong on these call sites."
+  [:and
+   [:map-of keyword? [:or string? number? boolean?]]
+   [:fn {:error/message "must name at least one field"} seq]])
+
+(def DecodedDocument
+  "A document decoded out of the driver: CLJS data with keyword keys, or
+   nothing at all when the query matched none."
+  [:maybe [:map-of keyword? any?]])
+
+(defn valid-query?
+  [query]
+  (m/validate FieldEqualityQuery query))
+
+(defn valid-document?
+  [doc]
+  (m/validate DecodedDocument doc))

--- a/backend/src/cljs/knoxx/backend/law/mongo.cljs
+++ b/backend/src/cljs/knoxx/backend/law/mongo.cljs
@@ -1,0 +1,26 @@
+(ns knoxx.backend.law.mongo
+  "Malli contracts for scalars decoded at the Mongo boundary.
+
+   Contract policy only — no I/O. extern.mongo calls these on the way out, so
+   the admissible shape of a decoded value is stated in one place rather than
+   re-derived by each caller that consumes it."
+  (:require [malli.core :as m]))
+
+(def max-time-value
+  "ECMAScript's maximum time value: ±100,000,000 days from the epoch.
+   A number outside this cannot name an instant, and js/Date rejects it too."
+  8.64e15)
+
+(def EpochMillis
+  "A decoded instant, in milliseconds since the epoch.
+
+   The bounds do the work that a bare number? cannot. Infinity is a number and
+   compares greater than every clock reading, so an expiry carrying it would
+   leave a credential live for good; NaN is a number whose comparisons are all
+   false, which fails safe here but only by accident. Both are outside the
+   range and both are rejected by it."
+  [:and number? [:>= (- max-time-value)] [:<= max-time-value]])
+
+(defn valid-epoch-ms?
+  [ms]
+  (m/validate EpochMillis ms))

--- a/backend/test/cljs/knoxx/backend/mcp_oauth_store_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_oauth_store_test.cljs
@@ -239,6 +239,19 @@
       (is (nil? (await (store/get-code! db "code-3")))
           "a missing expiry must not read as a live code"))))
 
+(deftest instant-ms-decodes-what-mongo-actually-returns
+  (testing "the adapter owns the driver's date shape"
+    (let [d (js/Date. 1700000000000)]
+      (is (= 1700000000000 (extern-mongo/instant-ms d)) "a BSON date arrives as js/Date")
+      (is (= 1700000000000 (extern-mongo/instant-ms 1700000000000)) "a number passes through")
+      (is (= 1700000000000 (extern-mongo/instant-ms "2023-11-14T22:13:20.000Z"))
+          "an ISO string still reads, for migrated documents"))
+    (is (nil? (extern-mongo/instant-ms nil)))
+    (is (nil? (extern-mongo/instant-ms "not a date")))
+    (is (nil? (extern-mongo/instant-ms (js/Date. "nonsense")))
+        "an invalid date is unreadable, not epoch zero")
+    (is (nil? (extern-mongo/instant-ms #js {})))))
+
 ;; ── extern.mongo conversion ──────────────────────────────
 ;; AGENTS.md asks for a regression test on the conversion whenever an extern
 ;; adapter grows a new boundary. delete-one! owns decoding the driver's native

--- a/backend/test/cljs/knoxx/backend/mcp_oauth_store_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_oauth_store_test.cljs
@@ -171,6 +171,74 @@
                        (catch :default e e))]
       (is (not= :ok outcome) "an undecodable result must raise, not return false"))))
 
+;; ─────────────────────────────────────────────────────────
+;; Codes and tokens survive their own round trip
+;;
+;; The writers store :expiresAt; the readers asked for :expires-at, a key no
+;; document has ever carried, so the (… 0) default made everything read as
+;; already expired. The token exchange answered "Unknown or expired code" for
+;; a code it had minted seconds earlier, and no access token could ever be
+;; presented successfully — ChatGPT reached the consent page and then failed.
+;; Same shape as the get-client! envelope bug: a writer and a reader that were
+;; only ever exercised together against a live Mongo.
+;; ─────────────────────────────────────────────────────────
+
+(defn- fake-ttl-db
+  "Mongo double for a TTL collection, keyed by the given id field."
+  [id-field]
+  (let [docs (atom {})
+        coll #js {:updateOne
+                  (fn [query update-doc _opts]
+                    (let [id      (aget query id-field)
+                          set-doc (js->clj (aget update-doc "$set") :keywordize-keys true)
+                          on-ins  (js->clj (aget update-doc "$setOnInsert") :keywordize-keys true)]
+                      (swap! docs (fn [m]
+                                    (let [base (or (get m id) (merge {(keyword id-field) id} on-ins))]
+                                      (assoc m id (merge base set-doc)))))
+                      (js/Promise.resolve #js {})))
+                  :findOne
+                  (fn [query]
+                    (js/Promise.resolve
+                     (some-> (get @docs (aget query id-field)) clj->js)))}
+        db   #js {:collection (fn [_name] coll)}]
+    (aset db "docs" docs)
+    db))
+
+(deftest ^:async a-freshly-written-code-reads-back
+  (testing "a code minted seconds ago is not reported as expired"
+    (let [db (fake-ttl-db "code")]
+      (await (store/set-code! db "code-1" (js/JSON.stringify #js {:clientId "c" :tools #js ["t"]}) 300))
+      (let [raw (await (store/get-code! db "code-1"))]
+        (is (some? raw) "the code the exchange just minted must be readable")
+        (is (= "c" (aget (js/JSON.parse raw) "clientId")))))))
+
+(deftest ^:async an-expired-code-does-not-read-back
+  (testing "a code past its TTL is still refused"
+    (let [db (fake-ttl-db "code")]
+      (await (store/set-code! db "code-2" (js/JSON.stringify #js {:clientId "c"}) -1))
+      (is (nil? (await (store/get-code! db "code-2")))))))
+
+(deftest ^:async a-freshly-written-token-reads-back
+  (testing "an access token can actually be presented after it is issued"
+    (let [db (fake-ttl-db "access_token")]
+      (await (store/set-token! db "tok-1" (js/JSON.stringify #js {:membershipId "m" :tools #js ["t"]}) 3600 "m"))
+      (let [raw (await (store/get-token! db "tok-1"))]
+        (is (some? raw) "a live token must verify, or every authenticated /mcp call 401s")
+        (is (= "m" (aget (js/JSON.parse raw) "membershipId")))))))
+
+(deftest ^:async an-expired-token-does-not-read-back
+  (testing "a token past its TTL is refused"
+    (let [db (fake-ttl-db "access_token")]
+      (await (store/set-token! db "tok-2" (js/JSON.stringify #js {:membershipId "m"}) -1 "m"))
+      (is (nil? (await (store/get-token! db "tok-2")))))))
+
+(deftest ^:async an-unreadable-expiry-fails-closed
+  (testing "a document whose expiry cannot be read is treated as expired"
+    (let [db (fake-ttl-db "code")]
+      (swap! (aget db "docs") assoc "code-3" {:code "code-3" :code_data {:clientId "c"}})
+      (is (nil? (await (store/get-code! db "code-3")))
+          "a missing expiry must not read as a live code"))))
+
 ;; ── extern.mongo conversion ──────────────────────────────
 ;; AGENTS.md asks for a regression test on the conversion whenever an extern
 ;; adapter grows a new boundary. delete-one! owns decoding the driver's native

--- a/backend/test/cljs/knoxx/backend/mcp_oauth_store_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_oauth_store_test.cljs
@@ -265,6 +265,78 @@
     (is (= 8.64e15 (extern-mongo/instant-ms 8.64e15))
         "the boundary itself is a representable instant")))
 
+;; ── an authorization code is single use ──────────────────
+;;
+;; Reading a code and deleting it afterwards leaves a window: two exchanges can
+;; both pass the read before either deletes, and both mint a token from one
+;; code. consume-code! claims it in a single operation so exactly one wins.
+;; Raised by Codex on #215.
+
+(defn- claim-one!
+  "Atomically remove and return one document — one winner however calls interleave."
+  [docs id]
+  (let [won (atom nil)]
+    (swap! docs (fn [m]
+                  (when-let [d (get m id)] (reset! won d))
+                  (dissoc m id)))
+    (js/Promise.resolve (some-> @won clj->js))))
+
+(defn- fake-codes-db
+  "Codes collection double.
+
+   findOne and deleteOne are provided alongside findOneAndDelete and are
+   deliberately not atomic together, so swapping the store back to a
+   read-then-delete sequence reproduces the race rather than erroring."
+  [initial]
+  (let [docs  (atom initial)
+        calls (atom 0)
+        coll  #js {:findOneAndDelete (fn [q] (swap! calls inc) (claim-one! docs (aget q "code")))
+                   :findOne          (fn [q] (swap! calls inc)
+                                       (js/Promise.resolve
+                                        (some-> (get @docs (aget q "code")) clj->js)))
+                   :deleteOne        (fn [q] (swap! docs dissoc (aget q "code"))
+                                       (js/Promise.resolve #js {:deletedCount 1}))}
+        db    #js {:collection (fn [_name] coll)}]
+    (doto db (aset "docs" docs) (aset "calls" calls))))
+
+(def ^:private live-code
+  {"code-1" {:code "code-1"
+             :code_data {:clientId "c" :codeChallenge "ch"}
+             :expiresAt (js/Date. (+ (.now js/Date) 300000))}})
+
+(deftest ^:async a-code-can-be-consumed-once
+  (testing "the first claim gets the data"
+    (let [db  (fake-codes-db live-code)
+          raw (await (store/consume-code! db "code-1"))]
+      (is (some? raw))
+      (is (= "c" (aget (js/JSON.parse raw) "clientId"))))))
+
+(deftest ^:async a-consumed-code-cannot-be-claimed-again
+  (testing "a second exchange with the same code gets nothing"
+    (let [db (fake-codes-db live-code)]
+      (is (some? (await (store/consume-code! db "code-1"))))
+      (is (nil? (await (store/consume-code! db "code-1")))
+          "the code is spent — a replay must not mint a second token"))))
+
+(deftest ^:async concurrent-exchanges-yield-exactly-one-token
+  (testing "two exchanges racing on one code produce a single winner"
+    (let [db (fake-codes-db live-code)
+          results (await (js/Promise.all
+                          #js [(store/consume-code! db "code-1")
+                               (store/consume-code! db "code-1")
+                               (store/consume-code! db "code-1")]))
+          winners (filter some? (array-seq results))]
+      (is (= 3 @(aget db "calls")) "all three attempts reached the store")
+      (is (= 1 (count winners)) "exactly one exchange may claim the code"))))
+
+(deftest ^:async an-expired-code-is-still-consumed
+  (testing "an expired code is spent rather than left readable for a retry"
+    (let [db (fake-codes-db {"code-old" {:code "code-old"
+                                         :code_data {:clientId "c"}
+                                         :expiresAt (js/Date. (- (.now js/Date) 1000))}})]
+      (is (nil? (await (store/consume-code! db "code-old"))) "expired yields nothing")
+      (is (empty? @(aget db "docs")) "and the document is gone, not left behind"))))
+
 (deftest the-epoch-millis-contract-states-what-an-instant-is
   (testing "law.mongo/EpochMillis is the named admissible shape"
     (is (law-mongo/valid-epoch-ms? 0))

--- a/backend/test/cljs/knoxx/backend/mcp_oauth_store_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_oauth_store_test.cljs
@@ -337,6 +337,25 @@
       (is (= 3 @(aget db "calls")) "all three attempts reached the store")
       (is (= 1 (count winners)) "exactly one exchange may claim the code"))))
 
+(deftest ^:async peeking-does-not-spend-the-code
+  (testing "a read leaves the code claimable, so a rejected exchange cannot burn it"
+    ;; An attacker who observes the code on the front channel but has no
+    ;; verifier must not be able to destroy it. The exchange checks the
+    ;; bindings against a peek and only claims once they hold.
+    (let [db (fake-codes-db live-code)]
+      (is (some? (await (store/peek-code! db "code-1"))))
+      (is (some? (await (store/peek-code! db "code-1"))) "peeking twice is fine")
+      (is (seq @(aget db "docs")) "the code is still there")
+      (is (some? (await (store/consume-code! db "code-1")))
+          "and the legitimate exchange can still claim it"))))
+
+(deftest ^:async peeking-refuses-an-expired-code
+  (testing "a peek applies the same liveness rule as a claim"
+    (let [db (fake-codes-db {"stale" {:code "stale"
+                                      :code_data {:clientId "c"}
+                                      :expiresAt (js/Date. (- (.now js/Date) 1000))}})]
+      (is (nil? (await (store/peek-code! db "stale")))))))
+
 (deftest ^:async an-expired-code-is-still-consumed
   (testing "an expired code is spent rather than left readable for a retry"
     (let [db (fake-codes-db {"code-old" {:code "code-old"

--- a/backend/test/cljs/knoxx/backend/mcp_oauth_store_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_oauth_store_test.cljs
@@ -2,7 +2,8 @@
   (:require [cljs.test :refer [deftest is testing]]
             [knoxx.backend.extern.mongo :as extern-mongo]
             [knoxx.backend.infra.stores.mongo-mcp-oauth :as store]
-            [knoxx.backend.law.mcp-oauth :as law]))
+            [knoxx.backend.law.mcp-oauth :as law]
+            [knoxx.backend.law.mongo :as law-mongo]))
 
 ;; ─────────────────────────────────────────────────────────
 ;; set-client! / get-client! round trip
@@ -263,6 +264,18 @@
     (is (nil? (extern-mongo/instant-ms (- (- 8.64e15) 1))))
     (is (= 8.64e15 (extern-mongo/instant-ms 8.64e15))
         "the boundary itself is a representable instant")))
+
+(deftest the-epoch-millis-contract-states-what-an-instant-is
+  (testing "law.mongo/EpochMillis is the named admissible shape"
+    (is (law-mongo/valid-epoch-ms? 0))
+    (is (law-mongo/valid-epoch-ms? 1700000000000))
+    (is (law-mongo/valid-epoch-ms? law-mongo/max-time-value) "the boundary is admissible")
+    (is (not (law-mongo/valid-epoch-ms? js/Infinity)))
+    (is (not (law-mongo/valid-epoch-ms? (- js/Infinity))))
+    (is (not (law-mongo/valid-epoch-ms? js/NaN)))
+    (is (not (law-mongo/valid-epoch-ms? (+ law-mongo/max-time-value 1))))
+    (is (not (law-mongo/valid-epoch-ms? "1700000000000")) "a string is not a decoded instant")
+    (is (not (law-mongo/valid-epoch-ms? nil)))))
 
 (deftest ^:async an-infinite-expiry-does-not-keep-a-token-alive
   (testing "a token stamped with Infinity is refused rather than living for good"

--- a/backend/test/cljs/knoxx/backend/mcp_oauth_store_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_oauth_store_test.cljs
@@ -337,6 +337,20 @@
       (is (nil? (await (store/consume-code! db "code-old"))) "expired yields nothing")
       (is (empty? @(aget db "docs")) "and the document is gone, not left behind"))))
 
+(deftest credential-liveness-is-one-pure-rule
+  (testing "an expiry after the given instant is live, before it is not"
+    (is (law/credential-live? 2000 1000))
+    (is (not (law/credential-live? 1000 2000)))
+    (is (not (law/credential-live? 1000 1000)) "expiring exactly now is not live"))
+  (testing "an unreadable instant on either side is not live"
+    ;; Fails closed: a credential whose expiry cannot be named must not be
+    ;; honoured, and Infinity must not outlive every clock reading.
+    (is (not (law/credential-live? nil 1000)))
+    (is (not (law/credential-live? js/Infinity 1000)))
+    (is (not (law/credential-live? js/NaN 1000)))
+    (is (not (law/credential-live? 2000 nil)))
+    (is (not (law/credential-live? 2000 js/NaN)))))
+
 (deftest the-query-contract-refuses-a-collection-wide-delete
   (testing "an empty or non-scalar query is not a field-equality query"
     (is (law-mongo/valid-query? {:code "c"}))

--- a/backend/test/cljs/knoxx/backend/mcp_oauth_store_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_oauth_store_test.cljs
@@ -250,7 +250,26 @@
     (is (nil? (extern-mongo/instant-ms "not a date")))
     (is (nil? (extern-mongo/instant-ms (js/Date. "nonsense")))
         "an invalid date is unreadable, not epoch zero")
-    (is (nil? (extern-mongo/instant-ms #js {})))))
+    (is (nil? (extern-mongo/instant-ms #js {}))))
+
+  (testing "a number that cannot name a moment is not an instant"
+    ;; Infinity is the dangerous one: it is a number and it compares greater
+    ;; than every clock reading, so unguarded it would leave a code or token
+    ;; live for good.
+    (is (nil? (extern-mongo/instant-ms js/Infinity)) "Infinity must not read as live")
+    (is (nil? (extern-mongo/instant-ms (- js/Infinity))))
+    (is (nil? (extern-mongo/instant-ms js/NaN)))
+    (is (nil? (extern-mongo/instant-ms (+ 8.64e15 1))) "past the representable range")
+    (is (nil? (extern-mongo/instant-ms (- (- 8.64e15) 1))))
+    (is (= 8.64e15 (extern-mongo/instant-ms 8.64e15))
+        "the boundary itself is a representable instant")))
+
+(deftest ^:async an-infinite-expiry-does-not-keep-a-token-alive
+  (testing "a token stamped with Infinity is refused rather than living for good"
+    (let [db (fake-ttl-db "access_token")]
+      (swap! (aget db "docs") assoc "tok-inf"
+             {:access_token "tok-inf" :token_data {:membershipId "m"} :expiresAt js/Infinity})
+      (is (nil? (await (store/get-token! db "tok-inf")))))))
 
 ;; ── extern.mongo conversion ──────────────────────────────
 ;; AGENTS.md asks for a regression test on the conversion whenever an extern

--- a/backend/test/cljs/knoxx/backend/mcp_oauth_store_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_oauth_store_test.cljs
@@ -337,6 +337,27 @@
       (is (nil? (await (store/consume-code! db "code-old"))) "expired yields nothing")
       (is (empty? @(aget db "docs")) "and the document is gone, not left behind"))))
 
+(deftest the-query-contract-refuses-a-collection-wide-delete
+  (testing "an empty or non-scalar query is not a field-equality query"
+    (is (law-mongo/valid-query? {:code "c"}))
+    (is (law-mongo/valid-query? {:access_token "t" :membership_id "m"}))
+    (is (not (law-mongo/valid-query? {}))
+        "an empty query matches every document — on a delete that is the collection")
+    (is (not (law-mongo/valid-query? {:code {:$ne nil}}))
+        "an operator map is a different contract")
+    (is (not (law-mongo/valid-query? nil)))))
+
+(deftest ^:async an-empty-query-never-reaches-a-delete
+  (testing "both delete paths refuse before issuing anything"
+    (let [issued? (atom false)
+          handle  #js {:findOneAndDelete (fn [_] (reset! issued? true) (js/Promise.resolve nil))
+                       :deleteOne        (fn [_] (reset! issued? true)
+                                           (js/Promise.resolve #js {:deletedCount 99}))}]
+      (doseq [op [extern-mongo/find-one-and-delete! extern-mongo/delete-one!]]
+        (let [outcome (try (await (op handle {})) :ok (catch :default e e))]
+          (is (not= :ok outcome) "an empty query must raise")))
+      (is (false? @issued?) "and nothing reached the collection"))))
+
 (deftest the-epoch-millis-contract-states-what-an-instant-is
   (testing "law.mongo/EpochMillis is the named admissible shape"
     (is (law-mongo/valid-epoch-ms? 0))

--- a/backend/test/cljs/knoxx/backend/mcp_oauth_store_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_oauth_store_test.cljs
@@ -378,6 +378,25 @@
     (is (not (law/credential-live? 2000 nil)))
     (is (not (law/credential-live? 2000 js/NaN)))))
 
+(def ^:private issued
+  {:clientId "c" :redirectUri "https://app/cb" :codeChallenge "ch"})
+
+(deftest exchange-admission-is-one-pure-rule
+  (testing "a code is bound to the client and redirect it was issued for"
+    (is (law/code-bound-to? issued "c" "https://app/cb"))
+    (is (not (law/code-bound-to? issued "other" "https://app/cb")))
+    (is (not (law/code-bound-to? issued "c" "https://evil/cb")))
+    (is (not (law/code-bound-to? nil "c" "https://app/cb"))))
+  (testing "PKCE admits only a matching computed challenge"
+    (is (law/pkce-verified? issued "ch"))
+    (is (not (law/pkce-verified? issued "wrong")))
+    (is (not (law/pkce-verified? issued nil)))
+    (is (not (law/pkce-verified? issued "")))
+    (is (not (law/pkce-verified? {:clientId "c"} "ch"))
+        "a code carrying no challenge is never verified — omitting the verifier must not admit")
+    (is (not (law/pkce-verified? {:codeChallenge ""} ""))
+        "blank does not match blank")))
+
 (deftest the-query-contract-refuses-a-collection-wide-delete
   (testing "an empty or non-scalar query is not a field-equality query"
     (is (law-mongo/valid-query? {:code "c"}))

--- a/backend/test/cljs/knoxx/backend/mcp_oauth_store_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_oauth_store_test.cljs
@@ -200,7 +200,15 @@
                   :findOne
                   (fn [query]
                     (js/Promise.resolve
-                     (some-> (get @docs (aget query id-field)) clj->js)))}
+                     (some-> (get @docs (aget query id-field)) clj->js)))
+                  :findOneAndDelete
+                  (fn [query]
+                    (let [id  (aget query id-field)
+                          won (atom nil)]
+                      (swap! docs (fn [m]
+                                    (when-let [d (get m id)] (reset! won d))
+                                    (dissoc m id)))
+                      (js/Promise.resolve (some-> @won clj->js))))}
         db   #js {:collection (fn [_name] coll)}]
     (aset db "docs" docs)
     db))
@@ -209,15 +217,15 @@
   (testing "a code minted seconds ago is not reported as expired"
     (let [db (fake-ttl-db "code")]
       (await (store/set-code! db "code-1" (js/JSON.stringify #js {:clientId "c" :tools #js ["t"]}) 300))
-      (let [raw (await (store/get-code! db "code-1"))]
-        (is (some? raw) "the code the exchange just minted must be readable")
-        (is (= "c" (aget (js/JSON.parse raw) "clientId")))))))
+      (let [record (await (store/consume-code! db "code-1"))]
+        (is (some? record) "the code the exchange just minted must be readable")
+        (is (= "c" (:clientId record)) "and arrives as CLJS data, not a JSON string")))))
 
 (deftest ^:async an-expired-code-does-not-read-back
   (testing "a code past its TTL is still refused"
     (let [db (fake-ttl-db "code")]
       (await (store/set-code! db "code-2" (js/JSON.stringify #js {:clientId "c"}) -1))
-      (is (nil? (await (store/get-code! db "code-2")))))))
+      (is (nil? (await (store/consume-code! db "code-2")))))))
 
 (deftest ^:async a-freshly-written-token-reads-back
   (testing "an access token can actually be presented after it is issued"
@@ -237,7 +245,7 @@
   (testing "a document whose expiry cannot be read is treated as expired"
     (let [db (fake-ttl-db "code")]
       (swap! (aget db "docs") assoc "code-3" {:code "code-3" :code_data {:clientId "c"}})
-      (is (nil? (await (store/get-code! db "code-3")))
+      (is (nil? (await (store/consume-code! db "code-3")))
           "a missing expiry must not read as a live code"))))
 
 (deftest instant-ms-decodes-what-mongo-actually-returns
@@ -306,10 +314,10 @@
 
 (deftest ^:async a-code-can-be-consumed-once
   (testing "the first claim gets the data"
-    (let [db  (fake-codes-db live-code)
-          raw (await (store/consume-code! db "code-1"))]
-      (is (some? raw))
-      (is (= "c" (aget (js/JSON.parse raw) "clientId"))))))
+    (let [db     (fake-codes-db live-code)
+          record (await (store/consume-code! db "code-1"))]
+      (is (some? record))
+      (is (= "c" (:clientId record))))))
 
 (deftest ^:async a-consumed-code-cannot-be-claimed-again
   (testing "a second exchange with the same code gets nothing"


### PR DESCRIPTION
## What is broken

ChatGPT now reaches the consent page and approves — then fails. The token
exchange answers `Unknown or expired code` for a code Knoxx minted seconds
earlier:

```
GET  /api/mcp/oauth/authorize/confirm?...   302   (code issued)
POST /api/mcp/oauth/token                   400   "Unknown or expired code"
```

## Why

The writers store `:expiresAt`. The readers asked for `:expires-at` — a key no
document has ever carried — so the `(… 0)` default made the comparison
`(> 0 now)`, false for **every** record.

Confirmed against a live code document in production:

```
keys: _id, code, code_data, created_at, expiresAt, system_instance_id
expiresAt: 2026-08-03T01:38:30.580Z   expires_at: undefined   expires-at: undefined
```

Three readers were affected, all on the critical path:

| reader | effect |
|---|---|
| `get-code!` | every exchange fails as "expired" |
| `get-token!` | no access token can ever be presented — every authenticated `/mcp` call 401s |
| `list-tokens-for-membership!` | always empty |

So even had the exchange succeeded, the token would not have verified on the
next request. Both halves of the remaining flow were dead.

## The change

Reads `:expiresAt` through a shared `live?` helper that accepts the BSON date
the driver returns, plus a number or ISO string for hand-written or migrated
documents, and treats an unreadable expiry as expired so the check fails closed.

`@workspace/mcp-oauth` — the reference that works with ChatGPT — uses `expiresAt`
throughout (`parsed.expiresAt <= now`), confirming the writers here were right
and the readers were wrong.

## Why nothing caught it

Same shape as the `get-client!` envelope bug: a writer and a reader that were
only ever exercised together against a live Mongo, so nothing local could see
them disagree. This is the third instance of that family in this module.

The new tests pin each pair with a double — a freshly written code and token
read back, an expired one does not, and a document with no readable expiry does
not. Restoring the `:expires-at` read fails four assertions:

```
FAIL in (a-freshly-written-code-reads-back)   expected: (some? raw)  actual: (not (some? nil))
FAIL in (a-freshly-written-token-reads-back)  expected: (some? raw)  actual: (not (some? nil))
```

705 tests / 2047 assertions, 0 failures. `clj-kondo` clean.

## What remains unverified

This should carry the flow through code exchange to a live token. The first
authenticated `POST /mcp` with that token is then the last unexercised step —
`get-token!` was dead before this, so no bearer token has ever verified in
production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OAuth authorization codes and access tokens being incorrectly treated as expired after storage.
  * Improved expiry handling for numeric, date, and ISO-formatted timestamps.
  * Records with missing or invalid expiry data are now safely rejected.
  * Authorization codes are now securely consumed only once during token exchange.
  * Added safeguards against invalid database queries and malformed stored data.

* **Tests**
  * Added coverage for token revocation, expiry handling, single-use authorization codes, credential validation, and client registration flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->