### PR TITLE
fix(mcp): wrap nested tool-parameter objects as zod schemas

### DIFF
--- a/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
@@ -17,7 +17,7 @@
             ["zod" :refer [z]])
   (:require-macros [knoxx.backend.macros :refer [defroute]]))
 
-(declare typebox->zod-shape reply-header!)
+(declare typebox->zod-shape reply-header! http-error)
 
 (defonce ^:private mcp-sessions* (atom {}))
 
@@ -118,13 +118,21 @@
 
 (defn- protected-resource-metadata
   "RFC 9728 metadata for the MCP resource. One document, served at every
-   well-known location a client may look in."
+   well-known location a client may look in.
+
+   Checked against law.mcp-oauth/ProtectedResourceMetadata before it leaves: the
+   payload is derived from the public base URL, and a client handed a blank
+   resource or an empty server list has nowhere to go and no way to say so."
   [base]
-  (let [issuer (-> (.toString (js/URL. (.toString base))) (.replace (js/RegExp. "/$") ""))]
-    {:resource                 (.toString (js/URL. "/mcp" base))
-     :authorization_servers    [issuer]
-     :scopes_supported         ["mcp:tools"]
-     :bearer_methods_supported ["header"]}))
+  (let [issuer  (-> (.toString (js/URL. (.toString base))) (.replace (js/RegExp. "/$") ""))
+        payload {:resource                 (.toString (js/URL. "/mcp" base))
+                 :authorization_servers    [issuer]
+                 :scopes_supported         ["mcp:tools"]
+                 :bearer_methods_supported ["header"]}]
+    (when-not (law/valid-protected-resource-metadata? payload)
+      (throw (http-error 500 "metadata_unavailable"
+                         "protected resource metadata failed its contract")))
+    payload))
 
 (defn- www-authenticate-challenge [base]
   (str "Bearer realm=\"mcp\", resource_metadata=\""

--- a/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
@@ -116,6 +116,16 @@
 (defn- protected-resource-metadata-url [base]
   (.toString (js/URL. "/.well-known/oauth-protected-resource" base)))
 
+(defn- protected-resource-metadata
+  "RFC 9728 metadata for the MCP resource. One document, served at every
+   well-known location a client may look in."
+  [base]
+  (let [issuer (-> (.toString (js/URL. (.toString base))) (.replace (js/RegExp. "/$") ""))]
+    {:resource                 (.toString (js/URL. "/mcp" base))
+     :authorization_servers    [issuer]
+     :scopes_supported         ["mcp:tools"]
+     :bearer_methods_supported ["header"]}))
+
 (defn- www-authenticate-challenge [base]
   (str "Bearer realm=\"mcp\", resource_metadata=\""
        (protected-resource-metadata-url base) "\""))
@@ -409,7 +419,9 @@
   (let [description (some-> (aget schema-json "description") str str/trim not-empty)]
     (if description (.describe schema-node description) schema-node)))
 
-(defn- typebox->zod-node [^js z ^js schema-json]
+(defn typebox->zod-node
+  "Convert one TypeBox schema node to a zod schema. Pure."
+  [^js z ^js schema-json]
   (let [schema-type (aget schema-json "type")
         node (case schema-type
                "string"  (.string z)
@@ -417,14 +429,24 @@
                "integer" (-> (.number z) (.int))
                "boolean" (.boolean z)
                "array"   (.array z (or (typebox->zod-node z (aget schema-json "items")) (.any z)))
-               "object"  (or (typebox->zod-shape z schema-json) (.object z (js-obj)))
+               ;; A nested object must become a zod schema, not the bare field
+               ;; shape typebox->zod-shape builds. Returning the shape gave the
+               ;; parent a plain JS object with no zod methods, so marking the
+               ;; field optional threw "fschema.optional is not a function" and
+               ;; the whole tool registration failed — every MCP POST that
+               ;; registers tools answered 400.
+               "object"  (.object z (or (typebox->zod-shape z schema-json) (js-obj)))
                (.any z))]
     (-> node
         (apply-zod-description schema-json)
         ((fn [n] (if-let [min (aget schema-json "minimum")] (.min n min) n)))
         ((fn [n] (if-let [max (aget schema-json "maximum")] (.max n max) n))))))
 
-(defn- typebox->zod-shape [^js z ^js schema-json]
+(defn typebox->zod-shape
+  "Convert a TypeBox object schema to a zod *field shape* — the map of field
+   name to zod schema that registerTool wants. Not itself a zod schema; a
+   nested object goes through typebox->zod-node, which wraps it. Pure."
+  [^js z ^js schema-json]
   (let [properties   (or (aget schema-json "properties") (js/Object.))
         required-set (into #{} (map str) (array-seq (or (aget schema-json "required") (js/Array.))))
         entries      (.entries js/Object properties)]
@@ -461,12 +483,19 @@
                  :token_endpoint_auth_methods_supported ["none"]})))
 
 (defroute mcp-protected-resource-metadata! [base] "GET" "/.well-known/oauth-protected-resource" []
-  (let [issuer (-> (.toString (js/URL. (.toString base))) (.replace (js/RegExp. "/$") ""))]
-    (json-send! reply 200
-                {:resource                (.toString (js/URL. "/mcp" base))
-                 :authorization_servers   [issuer]
-                 :scopes_supported        ["mcp:tools"]
-                 :bearer_methods_supported ["header"]})))
+  (json-send! reply 200 (protected-resource-metadata base)))
+
+;; RFC 9728 locates a resource's metadata by inserting the resource path into
+;; the well-known URI, so the document for https://host/mcp lives at
+;; /.well-known/oauth-protected-resource/mcp — not only at the root. ChatGPT
+;; probes the path-inserted form first and got 404 for both it and the
+;; /mcp/.well-known variant some clients try (run of 2026-08-04 19:01). Serve
+;; the same document at all three rather than relying on a client falling back.
+(defroute mcp-protected-resource-metadata-for-mcp! [base] "GET" "/.well-known/oauth-protected-resource/mcp" []
+  (json-send! reply 200 (protected-resource-metadata base)))
+
+(defroute mcp-protected-resource-metadata-suffixed! [base] "GET" "/mcp/.well-known/oauth-protected-resource" []
+  (json-send! reply 200 (protected-resource-metadata base)))
 
 ;; preHandler-mode routes
 
@@ -705,6 +734,23 @@
               (.end raw-res (js/JSON.stringify (clj->js {:error "mcp_post_failed"
                                                           :detail (or (.-message err) (str err))}))))))))))
 
+(def ^:private route-registrars
+  "Every MCP route, in registration order. Kept as data so adding one is a line
+   rather than an edit to the registration function."
+  [mcp-discovery-metadata!
+   mcp-protected-resource-metadata!
+   mcp-protected-resource-metadata-for-mcp!
+   mcp-protected-resource-metadata-suffixed!
+   mcp-register-client!
+   mcp-authorize-client!
+   mcp-authorize-confirm!
+   mcp-exchange-token!
+   mcp-list-user-tokens!
+   mcp-revoke-user-token!
+   mcp-handle-post!
+   mcp-handle-session!
+   mcp-handle-delete-session!])
+
 (defn register-mcp-http-routes!
   [app runtime config]
   (let [base         (public-base-url config)
@@ -724,14 +770,5 @@
               :z                             z
               :code-ttl  code-ttl
               :token-ttl token-ttl}]
-    (mcp-discovery-metadata!          app runtime config deps)
-    (mcp-protected-resource-metadata! app runtime config deps)
-    (mcp-register-client!             app runtime config deps)
-    (mcp-authorize-client!            app runtime config deps)
-    (mcp-authorize-confirm!           app runtime config deps)
-    (mcp-exchange-token!              app runtime config deps)
-    (mcp-list-user-tokens!            app runtime config deps)
-    (mcp-revoke-user-token!           app runtime config deps)
-    (mcp-handle-post!                 app runtime config deps)
-    (mcp-handle-session!              app runtime config deps)
-    (mcp-handle-delete-session!       app runtime config deps)))
+    (doseq [register! route-registrars]
+      (register! app runtime config deps))))

--- a/backend/src/cljs/knoxx/backend/law/mcp_oauth.cljs
+++ b/backend/src/cljs/knoxx/backend/law/mcp_oauth.cljs
@@ -52,6 +52,24 @@
          (not (str/blank? actual))
          (= expected actual))))
 
+(def ProtectedResourceMetadata
+  "RFC 9728 protected resource metadata, as served to an unauthenticated client.
+
+   Every field is required and non-blank because a client cannot recover from a
+   partial answer: this document is how it learns which authorization server to
+   use, and a blank resource or an empty server list sends it nowhere. The
+   payload is derived from the public base URL, so validating it here catches a
+   misconfigured base before a client is handed an unusable document."
+  [:map
+   [:resource                 NonBlankString]
+   [:authorization_servers    [:and [:vector NonBlankString] [:fn {:error/message "must name a server"} seq]]]
+   [:scopes_supported         [:vector NonBlankString]]
+   [:bearer_methods_supported [:and [:vector NonBlankString] [:fn {:error/message "must name a method"} seq]]]])
+
+(defn valid-protected-resource-metadata?
+  [metadata]
+  (m/validate ProtectedResourceMetadata metadata))
+
 (def RevocationRequest
   "Identity required to revoke an access token.
 

--- a/backend/test/cljs/knoxx/backend/mcp_http_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_http_test.cljs
@@ -277,6 +277,21 @@
               (is (str/includes? html "acme")
                   "the org slug is read the same way"))))))))
 
+(deftest resource-metadata-is-served-at-every-well-known-location
+  (testing "RFC 9728 inserts the resource path, and some clients try a suffix"
+    ;; ChatGPT probes /.well-known/oauth-protected-resource/mcp first and got
+    ;; 404 for it and for the /mcp/.well-known variant, relying on a fallback
+    ;; to the root document. Serve all three.
+    (doseq [url ["/.well-known/oauth-protected-resource"
+                 "/.well-known/oauth-protected-resource/mcp"
+                 "/mcp/.well-known/oauth-protected-resource"]]
+      (let [{:keys [status payload]} (serve "GET" url)]
+        (is (= 200 status) (str url " must answer 200"))
+        (is (= (str test-base "/mcp") (aget payload "resource"))
+            (str url " must name the same resource"))
+        (is (= [test-base] (js->clj (aget payload "authorization_servers")))
+            (str url " must name the same authorization server"))))))
+
 (deftest ^:async token-routes-read-membership-from-a-cljs-auth-context
   (testing "GET /api/mcp/tokens resolves the membership instead of throwing or 400ing"
     ;; These two routes carried the same (aget ctx "membership" "id") expression

--- a/backend/test/cljs/knoxx/backend/mcp_oauth_store_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_oauth_store_test.cljs
@@ -467,3 +467,22 @@
     (let [handle #js {:deleteOne (fn [_] (js/Promise.resolve #js {:deletedCount 0}))}]
       (is (= {:deleted-count 0} (await (extern-mongo/delete-one! handle {:x "y"})))
           "'nothing matched' must stay distinguishable from 'no count reported'"))))
+
+(deftest protected-resource-metadata-contract-requires-a-usable-document
+  (testing "a client cannot recover from a partial answer, so every field is required"
+    (is (law/valid-protected-resource-metadata?
+         {:resource "https://k/mcp" :authorization_servers ["https://k"]
+          :scopes_supported ["mcp:tools"] :bearer_methods_supported ["header"]}))
+    (is (not (law/valid-protected-resource-metadata?
+              {:resource "" :authorization_servers ["https://k"]
+               :scopes_supported [] :bearer_methods_supported ["header"]}))
+        "a blank resource names nothing")
+    (is (not (law/valid-protected-resource-metadata?
+              {:resource "https://k/mcp" :authorization_servers []
+               :scopes_supported [] :bearer_methods_supported ["header"]}))
+        "an empty server list sends the client nowhere")
+    (is (not (law/valid-protected-resource-metadata?
+              {:resource "https://k/mcp" :authorization_servers ["https://k"]
+               :scopes_supported [] :bearer_methods_supported []}))
+        "no bearer method leaves the client unable to present a token")
+    (is (not (law/valid-protected-resource-metadata? {})))))

--- a/backend/test/cljs/knoxx/backend/mcp_schema_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_schema_test.cljs
@@ -35,7 +35,9 @@
           (is (true? (aget (.safeParse field #js {:inner "x"}) "success"))
               "it accepts a matching object")
           (is (false? (aget (.safeParse field #js {:inner 1}) "success"))
-              "and still enforces the nested field's type"))))))
+              "and still enforces the nested field's type")
+          (is (false? (aget (.safeParse field #js {}) "success"))
+              "and the nested :required list still applies inside it"))))))
 
 (deftest optionality-follows-the-required-list
   (testing "a required field is not optional and an unlisted one is"

--- a/backend/test/cljs/knoxx/backend/mcp_schema_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_schema_test.cljs
@@ -1,0 +1,61 @@
+(ns knoxx.backend.mcp-schema-test
+  "TypeBox -> zod conversion for MCP tool parameters.
+
+   A nested object property used to be handed to the parent as the bare field
+   shape rather than a zod schema, so marking it optional threw
+
+     TypeError: fschema.optional is not a function
+
+   inside registerTool. That failed the whole registration, and every MCP POST
+   that registers tools answered 400 — which is what a ChatGPT connector does
+   immediately after obtaining a token (Mcp-Method: server/discover,
+   2026-08-04 19:01). Exercised against real zod, not a double, because the
+   defect was that the value lacked zod's own methods."
+  (:require [cljs.test :refer [deftest is testing]]
+            [knoxx.backend.infra.routes.mcp :as mcp]
+            ["zod" :refer [z]]))
+
+(def ^:private nested-schema
+  #js {:type "object"
+       :properties #js {:name  #js {:type "string"}
+                        :outer #js {:type "object"
+                                    :properties #js {:inner #js {:type "string"}}
+                                    :required #js ["inner"]}}
+       :required #js ["name"]})
+
+(deftest a-nested-object-property-becomes-a-zod-schema
+  (testing "converting a schema with a nested object does not throw"
+    (let [shape (mcp/typebox->zod-shape z nested-schema)]
+      (is (some? shape))
+      (is (some? (aget shape "outer")) "the nested field is present")
+      (testing "and the nested field is a usable zod schema, not a bare shape"
+        (let [field (aget shape "outer")]
+          (is (fn? (aget field "safeParse"))
+              "a bare field shape has no safeParse — that was the defect")
+          (is (true? (aget (.safeParse field #js {:inner "x"}) "success"))
+              "it accepts a matching object")
+          (is (false? (aget (.safeParse field #js {:inner 1}) "success"))
+              "and still enforces the nested field's type"))))))
+
+(deftest optionality-follows-the-required-list
+  (testing "a required field is not optional and an unlisted one is"
+    (let [shape (mcp/typebox->zod-shape z nested-schema)]
+      (is (true? (aget (.safeParse (aget shape "name") "hello") "success")))
+      (is (false? (aget (.safeParse (aget shape "name") js/undefined) "success"))
+          "name is in :required, so undefined must be rejected")
+      (is (true? (aget (.safeParse (aget shape "outer") js/undefined) "success"))
+          "outer is not required, so it is optional"))))
+
+(deftest an-empty-object-still-converts
+  (testing "an object schema with no properties yields a zod object"
+    (let [node (mcp/typebox->zod-node z #js {:type "object" :properties #js {}})]
+      (is (fn? (aget node "safeParse")))
+      (is (true? (aget (.safeParse node #js {}) "success"))))))
+
+(deftest scalar-and-array-nodes-convert
+  (testing "the other branches still behave"
+    (is (true? (aget (.safeParse (mcp/typebox->zod-node z #js {:type "string"}) "s") "success")))
+    (is (true? (aget (.safeParse (mcp/typebox->zod-node z #js {:type "integer"}) 3) "success")))
+    (is (false? (aget (.safeParse (mcp/typebox->zod-node z #js {:type "integer"}) 3.5) "success")))
+    (is (true? (aget (.safeParse (mcp/typebox->zod-node z #js {:type "array" :items #js {:type "string"}})
+                                 #js ["a"]) "success")))))


### PR DESCRIPTION
## The OAuth flow now works

Worth recording, since #215 was the last blocker there. From the ingress log of
the connector attempt at 2026-08-04 19:01:

```
POST /api/mcp/oauth/token   200   ← token exchange succeeded
POST /mcp  (Bearer)         200 text/event-stream   ← authenticated call verified
POST /mcp  (Bearer)         200 text/event-stream
```

A token was issued **and verified** — the first time either has happened in
production.

## What still fails

ChatGPT's first real MCP call is `Mcp-Method: server/discover`, and it answers
`400`:

```
[knoxx-mcp] post failed TypeError: fschema.optional is not a function
```

`typebox->zod-shape` builds the *field shape* `registerTool` wants — a map of
field name to zod schema. It is **not** itself a zod schema. But the `"object"`
branch of `typebox->zod-node` returned that shape directly:

```clojure
"object"  (or (typebox->zod-shape z schema-json) (.object z (js-obj)))
```

So a nested object property reached its parent as a plain JS object with none of
zod's methods, and `(.optional fschema)` threw. **One** tool with a nested object
parameter fails the whole registration, so every MCP POST that registers tools
answers 400. Knoxx exposes ~60 tools.

Wrapping it in `z.object` fixes the branch.

Both converters become public so the conversion is testable directly — against
**real zod**, not a double. The defect was precisely that the value lacked zod's
methods, so a double asserting on shape would have missed it.

## Resource metadata 404s

The same log shows ChatGPT probing two locations and getting 404 for both:

```
GET /.well-known/oauth-protected-resource/mcp   404
GET /mcp/.well-known/oauth-protected-resource   404
```

RFC 9728 locates a resource's metadata by **inserting the resource path** into
the well-known URI, so the path-inserted form is the correct one for
`https://host/mcp`; the root document we served was only ever a fallback the
client happened to try. All three now serve one extracted payload, and the
registration list moves to data so adding a route no longer grows the
registration function.

## Verification

Reverting the zod fix reproduces the production error in two tests:

```
ERROR in (a-nested-object-property-becomes-a-zod-schema)
  actual: #object[TypeError TypeError: fschema.optional is not a function]
ERROR in (optionality-follows-the-required-list)
  actual: #object[TypeError TypeError: fschema.optional is not a function]
```

723 tests / 2138 assertions, 0 failures, 0 warnings. `clj-kondo` clean.

## Not addressed here

Two further things visible in that log, left out deliberately:

- `POST /mcp` with `Content-Type: application/octet-stream` and an empty body
  answers `415`. That looks like a client probe rather than a real call; worth
  confirming against a working server before changing content-type handling.
- 31 × `502` in the backend window, not on the MCP path. Separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added standardized OAuth protected-resource metadata endpoints.
  - Exposed consistent MCP resource and authorization-server information across the supported well-known URLs.

- **Bug Fixes**
  - Improved conversion of nested object definitions for more accurate validation.
  - Preserved correct handling of required and optional fields, empty objects, scalar values, and arrays.

- **Tests**
  - Added coverage confirming metadata endpoints and nested schema validation behave as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->