### PR TITLE
fix(mcp): actually select the SDK's stateless transport mode

### DIFF
--- a/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
@@ -142,6 +142,19 @@
   (-> (reply-header! reply "WWW-Authenticate" (www-authenticate-challenge base))
       (.code 401) (.send "Unauthorized")))
 
+(defn stateless-transport-options
+  "Options that actually select the MCP SDK's stateless mode.
+
+   The key must be ABSENT, not undefined. (clj->js {:sessionIdGenerator
+   js/undefined}) emits {sessionIdGenerator: null}, and the SDK selects
+   stateless only on === undefined — so null selected *stateful* mode, where
+   everything after initialize is rejected with
+   \"Bad Request: Server not initialized\". A client saw that as connected but
+   advertising no tools. Verified against SDK 1.18, 1.24, 1.29 and 1.30: all
+   four read null as stateful, so this is ours, not a protocol change."
+  []
+  #js {})
+
 (defn- transport-handle-request!
   ([^js t req reply]      (.handleRequest t req reply))
   ([^js t req reply body] (.handleRequest t req reply body)))
@@ -716,7 +729,7 @@
                                    into-array)
                     server    (new McpServer (clj->js {:name "knoxx" :version "0.1.0"}))
                     transport (new StreamableHTTPServerTransport
-                                   (clj->js {:sessionIdGenerator js/undefined}))]
+                                   (stateless-transport-options))]
                 (doseq [tool (array-seq effective)]
                   (let [n (some-> (aget tool "name") str str/trim not-empty)
                         s (or (when z (typebox->zod-shape z (or (aget tool "parameters") (js/Object.)))) (js-obj))]

--- a/backend/test/cljs/knoxx/backend/mcp_schema_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_schema_test.cljs
@@ -61,3 +61,29 @@
     (is (false? (aget (.safeParse (mcp/typebox->zod-node z #js {:type "integer"}) 3.5) "success")))
     (is (true? (aget (.safeParse (mcp/typebox->zod-node z #js {:type "array" :items #js {:type "string"}})
                                  #js ["a"]) "success")))))
+
+;; ── stateless transport options ──────────────────────────
+;;
+;; The SDK selects stateless mode only when sessionIdGenerator is === undefined.
+;; (clj->js {:sessionIdGenerator js/undefined}) emits null, which selects
+;; STATEFUL mode — and with no session storage, everything after initialize is
+;; rejected with "Bad Request: Server not initialized". That is what a client
+;; saw as "connected, but advertises no tools". Verified against SDK 1.18, 1.24,
+;; 1.29 and 1.30: all four treat null as stateful, so this is ours to get right.
+
+(deftest stateless-options-omit-the-session-generator
+  (testing "the key is absent, not null"
+    (let [opts (mcp/stateless-transport-options)]
+      (is (false? (.hasOwnProperty opts "sessionIdGenerator"))
+          "present-but-null is what selected stateful mode")
+      (is (undefined? (aget opts "sessionIdGenerator")))
+      (is (not (nil? opts)) "still an options object")))
+
+  (testing "clj->js cannot express this, which is why it is built with #js"
+    ;; Documents the trap rather than trusting a comment: the obvious spelling
+    ;; produces exactly the value that broke it.
+    (let [via-clj->js (clj->js {:sessionIdGenerator js/undefined})]
+      (is (true? (.hasOwnProperty via-clj->js "sessionIdGenerator"))
+          "clj->js keeps the key")
+      (is (nil? (aget via-clj->js "sessionIdGenerator"))
+          "and its value is null — the SDK reads that as stateful"))))


### PR DESCRIPTION
## Symptom

A connector authorizes, reports itself connected, and advertises **no tools**.
Every request after `initialize` is rejected:

```json
{"jsonrpc":"2.0","error":{"code":-32000,"message":"Bad Request: Server not initialized"},"id":null}
```

Observed in production for both ChatGPT and Perplexity.

## Cause

```clojure
(clj->js {:sessionIdGenerator js/undefined})   ; => {sessionIdGenerator: null}
```

CLJS treats `js/undefined` as `nil`, and `clj->js` maps `nil` to `null`. The SDK
selects stateless mode only on `=== undefined`, so `null` selected **stateful**
mode. Each request builds a fresh `McpServer`, so `initialize` succeeds on a
throwaway instance and the `tools/list` that follows hits a server that has
never been initialized.

Reproduced directly against the SDK with the code held constant:

| options | result |
|---|---|
| `sessionIdGenerator: undefined` | `200` |
| `sessionIdGenerator: null` | `400 Bad Request: Server not initialized` |
| key absent | `200` |

`#js {}` omits the key, which is the only spelling that works.

## This is a regression, not a protocol change

The route was **originally stateful** — `sessionIdGenerator` returned a UUID and
sessions were kept in `mcp-sessions*`:

```clojure
sessionIdGenerator (fn [] (.randomUUID crypto))   ; 2026-04-21
```

The later conversion to stateless never took effect, while the session storage it
relied on was removed. That is why `mcp-sessions*` is still **read** by the `GET`
and `DELETE` handlers and **written by nothing** — `git log -S'swap! mcp-sessions*'`
returns no commits.

I checked whether an SDK upgrade was responsible: **1.18, 1.24, 1.29 and 1.30 all
read `null` as stateful**, so no. Worth noting separately that
`backend/Dockerfile` installs with `--no-frozen-lockfile` against `^1.29.0`, so
production currently runs **1.30.0** while the lockfile pins **1.29.0** — not the
cause here, but it means production can drift from what we test. Flagged below.

## Why it stayed hidden

`get-token!` returned `nil` unconditionally until the `:expiresAt` fix (#215), so
no authenticated request ever reached this code. Fixing the token path is what
made this reachable.

## Tests

Asserts the key is absent, and separately that the `clj->js` spelling produces
the `null` that broke it — documenting the trap rather than trusting a comment.

725 tests / 2149 assertions, 0 failures, 0 warnings. `clj-kondo` clean; the
module stays under the 800-line error ceiling (795).

## Follow-ups worth their own issues

- **Unpinned SDK in a `--no-frozen-lockfile` build.** Production resolves a
  different SDK than the lockfile. Pin it, or build with `--frozen-lockfile`.
- **`mcp-sessions*` is vestigial.** `GET /mcp` (resumable SSE) and `DELETE /mcp`
  read a map nothing populates, so they cannot work. Either implement stateful
  sessions or remove the routes; leaving them is a trap for the next reader.
- `infra.routes.mcp` is 795 lines against an 800-line lint error ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP request handling by ensuring stateless transport mode is selected reliably.
  * Prevented requests from accidentally being treated as stateful when no session is intended.

* **Tests**
  * Added coverage verifying stateless transport configuration and session handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->