### PR TITLE
Ascribe an actor to MCP tool calls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,8 @@
 # Knoxx Agent Style Guide
 
+> **Roadmap:** [`ROADMAP.md`](ROADMAP.md) — this repo's slice. The hub, with the
+> seam, ownership table and sequencing rule, is [eta-mu/ROADMAP.md](https://github.com/open-hax/eta-mu/blob/main/ROADMAP.md).
+
 # Language and Repository Ownership
 - Knoxx backend, domain, persistence, and service features are ClojureScript-first. Do not add or expand TypeScript for Knoxx backend work unless the user explicitly authorizes it.
 - Do not create coordinated implementation changes in OpenPlanner to deliver a Knoxx feature unless the user explicitly requests a cross-repository change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,8 @@
 # CLAUDE.md
 
+> **Roadmap:** [`ROADMAP.md`](ROADMAP.md) — this repo's slice. The hub, with the
+> seam, ownership table and sequencing rule, is [eta-mu/ROADMAP.md](https://github.com/open-hax/eta-mu/blob/main/ROADMAP.md).
+
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 > Also read **AGENTS.md** — it contains mandatory coding style rules, namespace conventions, verification requirements, modern CLJS patterns, and licensing doctrine that apply to all work in this repo.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Knoxx
 
+> **Roadmap:** [`ROADMAP.md`](ROADMAP.md) — this repo's slice. The hub, with the
+> seam, ownership table and sequencing rule, is [eta-mu/ROADMAP.md](https://github.com/open-hax/eta-mu/blob/main/ROADMAP.md).
+
 Knoxx is a local-first knowledge operations and agent workbench. It combines a
 shadow-cljs/Fastify backend, a shadow-cljs + React frontend, a JVM Clojure
 ingestion worker, contract-backed policy/actor/model definitions, and adapters

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,71 @@
+# Roadmap — knoxx's slice
+
+> Hub: **[eta-mu/ROADMAP.md](https://github.com/open-hax/eta-mu/blob/main/ROADMAP.md)** — read that for the seam, the ownership
+> table, and the sequencing rule. This file is only knoxx's slice.
+> Board: `kanban/{epics,tasks}/`. Last surveyed: 2026-08-04.
+
+## What knoxx is, on this roadmap
+
+**A later application composition using stable upstream parts.** It does **not**
+own the upstream seams while they are still moving.
+
+## The rule to not break
+
+> Knoxx is a downstream composition target. It remains deferred until these parts
+> work independently; **code should not be migrated into or out of Knoxx to prove
+> this architecture.**
+> — `muse/docs/design/contract-ownership-and-host-translation.md`
+
+Knoxx cuts over **last** — `eta-mu:knoxx-katamorph-cutover`, iceboxed by design.
+Two extractions out of knoxx have already succeeded (`eta-mu:sol-extraction`,
+`eta-mu:chat-ui-extraction`), so the temptation to do a third is real. Resist it
+until the upstream criteria close.
+
+## What knoxx should do now
+
+Everything achievable **without moving code**: become internally lawful and
+actor-aware, so extraction later is mechanical rather than archaeological.
+
+Epic: **`knoxx-decouple-into-katamorph-contracts`** (misleading name kept for
+card-link stability; scope is compliance, extraction is a listed non-goal).
+
+| Card | Why |
+|---|---|
+| **`knoxx-layer-enforcement-gate`** (P1) | The lever. Nothing else sticks without it. Knoxx has 4 gates and none checks layer dependencies. Ratchet, not cliff. |
+| `knoxx-mcp-actor-ascription` (P1) | Discord/Bluesky over MCP have **no owning actor**, so credentials throw. Fails safe, but those tools are non-functional remotely. |
+| `knoxx-deploy-actor-owning-local-credentials` (P1) | The above is useless in production without an actor that holds credentials. |
+| `knoxx-tool-namespace-boundary-audit` | Name each tool set's boundary before anything moves. |
+| `knoxx-translations-event-sourced` | Translations are a destructive upsert today. |
+| `knoxx-translation-pipeline-validation` | Never validated end to end; on the deploy health gate. |
+| `knoxx-cms-contract-validation` | Contracts never tested; deploy gate **skips** the CMS check every deploy. |
+| `knoxx-voice-tools-remote-transport` | Written for an owned realtime harness; MCP cannot steer. |
+| `knoxx-tool-vocabulary-rename` | "semantic" names a technique, not a subject. Do after the boundaries exist. |
+| `knoxx-mcp-consent-permission-groups` | **Blocked** on `eta-mu:capability-schema-reconciliation` — tool groups *are* capabilities. |
+
+## Knoxx's position in the drift ledger
+
+- **References katamorph nowhere.** No dep in `deps.edn`, `package.json`, or
+  `shadow-cljs.edn`. Consumes `open-hax.contract-runtime` instead.
+- Carries `open-hax.contracts.schema` — *byte-identical lineage; katamorph was
+  extracted from it; never cut over.*
+- **Builds `contract-runtime` from the openplanner copy**, not the standalone
+  repo: `backend/shadow-cljs.edn` source path `../../contract-runtime/src/cljs`,
+  staged in CI from `openplanner/packages/`. Repointing this is a cheap, early
+  win in the openplanner teardown.
+
+## Why compliance has not happened by itself
+
+`AGENTS.md` declares the layer split; the code violates it anyway. Contracts here
+are **optional config**, whereas in muse the build fails without them. Fix is
+enforcement, not documentation — hence the gate card being P1.
+
+The evidence, from getting `/mcp` working: eight defects, **five the same shape** —
+a writer and a reader that only ran together against live infrastructure, so
+their contract drifted unseen. Every one was an undeclared boundary.
+
+## Postgres
+
+Verified clean: **zero** postgres references in `backend/package.json` or
+`backend/src/cljs`. The compose comment claiming pg/redis remain a dependency of
+`knoxx-ingestion` appears stale — no pg dep found there. Deleting that comment
+is a two-minute win.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,6 +3,11 @@
 > Hub: **[eta-mu/ROADMAP.md](https://github.com/open-hax/eta-mu/blob/main/ROADMAP.md)** — read that for the seam, the ownership
 > table, and the sequencing rule. This file is only knoxx's slice.
 > Board: `kanban/{epics,tasks}/`. Last surveyed: 2026-08-04.
+>
+> That link 404s until [eta-mu#167](https://github.com/open-hax/eta-mu/pull/167)
+> merges — the hub is written and on that branch, not yet on `main`. The path is
+> the one it will land at, so it is left as-is rather than pointed at a branch
+> that would rot; delete this note when the PR merges.
 
 ## What knoxx is, on this roadmap
 

--- a/backend/src/cljs/knoxx/backend/domain/actor/acting.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/actor/acting.cljs
@@ -1,5 +1,9 @@
-(ns knoxx.backend.infra.actor.scope
-  "The actor a unit of work is running as, scoped to that work.
+(ns knoxx.backend.domain.actor.acting
+  "The actor a unit of work is currently acting as.
+
+   Distinct from domain.actor.scope, which matches a principal against a
+   contract's declared actors. That answers \"may this actor\"; this answers
+   \"which actor, right now\".
 
    Tool credentials are actor-owned, so something has to say which actor a tool
    call belongs to. The agent runtime answers that with agent-context, but it is
@@ -15,7 +19,14 @@
    The distinction that matters: **being in a scope with no actor is not the
    same as being outside a scope.** A caller that has established there is no
    actor is making a claim, and that claim has to be able to win over a
-   process-global that happens to hold one."
+   process-global that happens to hold one.
+
+   Lives in domain rather than infra because \"which actor is in effect\" is
+   domain vocabulary, and because domain.actor.credentials must be able to read
+   it — a domain namespace requiring infra would be a layering violation. The
+   storage mechanism is externalised to extern.async-local-storage, which is
+   where that interop is born; this namespace exchanges CLJS values only and
+   carries no transport concern."
   (:require [clojure.string :as str]
             [knoxx.backend.extern.async-local-storage :as als]))
 

--- a/backend/src/cljs/knoxx/backend/domain/actor/credentials.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/actor/credentials.cljs
@@ -26,17 +26,20 @@
 (defn current-actor-id
   "The actor whose credentials this call may read, or nil.
 
-   Two sources, and the order matters. An explicit actor scope wins because it
-   is per-unit-of-work and cannot be another request's: agent-context is a
-   process-global atom, so on a concurrent surface a leftover or interleaved
-   value there could otherwise be read as this call's actor. Preferring the
-   scope means the narrower claim always beats the wider one.
+   Two sources, and an actor scope is not merely preferred — inside one it is
+   the only answer, even when it names no actor. agent-context is a
+   process-global atom, so on a concurrent surface it may hold an unrelated
+   agent turn's actor; falling back to it from inside a scope that established
+   there is no actor would let an actor-less call read that turn's credentials.
+   That is the leak the scope exists to prevent, so `or` is the wrong combinator
+   here: absence inside a scope is an answer, not a gap.
 
-   The agent-spawn path sets only agent-context, so it stays as the fallback and
-   keeps working unchanged."
+   Outside any scope nobody has said anything, so the agent-spawn path's
+   agent-context is consulted and keeps working unchanged."
   []
-  (or (actor-scope/current-actor-id)
-      (agent-context-actor-id)))
+  (if (actor-scope/in-scope?)
+    (actor-scope/current-actor-id)
+    (agent-context-actor-id)))
 
 (defn- normalize-credential
   [payload]

--- a/backend/src/cljs/knoxx/backend/domain/actor/credentials.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/actor/credentials.cljs
@@ -5,10 +5,11 @@
    env vars here; missing credentials should be fixed in Admin → Actors."
   (:require [clojure.string :as str]
             [knoxx.backend.domain.agent.agent-context :as agent-context]
+            [knoxx.backend.infra.actor.scope :as actor-scope]
             [knoxx.backend.infra.auth.authz :as authz]
             [knoxx.backend.infra.db.policy :as policy-db]))
 
-(defn current-actor-id
+(defn- agent-context-actor-id
   []
   (let [ctx (or (agent-context/get-context) {})
         spec (:agent-spec ctx)]
@@ -21,6 +22,21 @@
             str
             str/trim
             not-empty)))
+
+(defn current-actor-id
+  "The actor whose credentials this call may read, or nil.
+
+   Two sources, and the order matters. An explicit actor scope wins because it
+   is per-unit-of-work and cannot be another request's: agent-context is a
+   process-global atom, so on a concurrent surface a leftover or interleaved
+   value there could otherwise be read as this call's actor. Preferring the
+   scope means the narrower claim always beats the wider one.
+
+   The agent-spawn path sets only agent-context, so it stays as the fallback and
+   keeps working unchanged."
+  []
+  (or (actor-scope/current-actor-id)
+      (agent-context-actor-id)))
 
 (defn- normalize-credential
   [payload]

--- a/backend/src/cljs/knoxx/backend/domain/actor/credentials.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/actor/credentials.cljs
@@ -4,8 +4,8 @@
    Tool credentials are actor-owned state. Do not read API keys from process
    env vars here; missing credentials should be fixed in Admin → Actors."
   (:require [clojure.string :as str]
+            [knoxx.backend.domain.actor.acting :as actor-acting]
             [knoxx.backend.domain.agent.agent-context :as agent-context]
-            [knoxx.backend.infra.actor.scope :as actor-scope]
             [knoxx.backend.infra.auth.authz :as authz]
             [knoxx.backend.infra.db.policy :as policy-db]))
 
@@ -37,8 +37,8 @@
    Outside any scope nobody has said anything, so the agent-spawn path's
    agent-context is consulted and keeps working unchanged."
   []
-  (if (actor-scope/in-scope?)
-    (actor-scope/current-actor-id)
+  (if (actor-acting/in-scope?)
+    (actor-acting/current-actor-id)
     (agent-context-actor-id)))
 
 (defn- normalize-credential

--- a/backend/src/cljs/knoxx/backend/domain/bluesky/bluesky.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/bluesky/bluesky.cljs
@@ -4,7 +4,7 @@
             [knoxx.backend.domain.bluesky.client :as bsky-client]
             [knoxx.backend.infra.auth.authz :refer [ctx-tool-allowed?]]
             [knoxx.backend.domain.text :refer [clip-text tool-text-result]]
-            [knoxx.backend.domain.actor.credentials :as actor-credentials]
+            [knoxx.backend.infra.actor.credentials :as actor-credentials]
             [knoxx.backend.domain.media :as media]
             [knoxx.backend.domain.tools :refer [maybe-tool-update! create-tool-obj]]))
 

--- a/backend/src/cljs/knoxx/backend/domain/discord/tools.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/discord/tools.cljs
@@ -9,7 +9,7 @@
             [knoxx.backend.infra.svg-render :as svg-render]
             [knoxx.backend.domain.text :refer [sanitize-svg-content tool-text-result]]
 
-            [knoxx.backend.domain.actor.credentials :as actor-credentials]
+            [knoxx.backend.infra.actor.credentials :as actor-credentials]
             [knoxx.backend.domain.media :as media]
             [knoxx.backend.domain.tools :refer [maybe-tool-update! create-tool-obj]]))
 

--- a/backend/src/cljs/knoxx/backend/domain/media.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/media.cljs
@@ -4,7 +4,7 @@
   (:require [clojure.string :as str]
             [knoxx.backend.infra.document-state :refer [normalize-relative-path]]
             [knoxx.backend.domain.text :refer [tool-text-result]]
-            [knoxx.backend.domain.actor.credentials :as actor-credentials]
+            [knoxx.backend.infra.actor.credentials :as actor-credentials]
             [knoxx.backend.domain.media.remote-client :as remote-client]
             ["node:child_process" :refer [execFile]]
             ["node:crypto" :as crypto]

--- a/backend/src/cljs/knoxx/backend/domain/twitch.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/twitch.cljs
@@ -3,7 +3,7 @@
   (:require [clojure.string :as str]
             [knoxx.backend.infra.auth.authz :refer [ctx-tool-allowed?]]
             [knoxx.backend.domain.text :refer [tool-text-result]]
-            [knoxx.backend.domain.actor.credentials :as actor-credentials]
+            [knoxx.backend.infra.actor.credentials :as actor-credentials]
             [knoxx.backend.domain.tools :refer [maybe-tool-update! create-tool-obj]]))
 
 (defonce ^:private twitch-connections

--- a/backend/src/cljs/knoxx/backend/extern/async_local_storage.cljs
+++ b/backend/src/cljs/knoxx/backend/extern/async_local_storage.cljs
@@ -1,0 +1,31 @@
+(ns knoxx.backend.extern.async-local-storage
+  "Extern adapter owning Node's AsyncLocalStorage boundary.
+
+   All raw interop with node:async_hooks is born and dies here; callers upstream
+   speak CLJS values only.
+
+   Why this exists rather than a global atom: a store created here keeps a
+   separate value per asynchronous execution context, and that value survives
+   `await`. A plain atom does not. Two concurrent requests interleaving at any
+   await point would read each other's value, which for request-scoped identity
+   means one caller acting as another. The distinction only shows up under
+   concurrency, so it cannot be found by testing one request at a time."
+  (:require ["node:async_hooks" :as async-hooks]))
+
+(defn create-store
+  "A new AsyncLocalStorage instance."
+  []
+  (new (.-AsyncLocalStorage async-hooks)))
+
+(defn run-with
+  "Call f with no arguments inside a context where this store holds value.
+
+   Returns whatever f returns, including a promise: the context follows the
+   promise chain, so an async f still sees value after every await."
+  [^js store value f]
+  (.run store value f))
+
+(defn current
+  "The value this store holds in the calling context, or nil outside one."
+  [^js store]
+  (.getStore store))

--- a/backend/src/cljs/knoxx/backend/infra/actor/acting.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/actor/acting.cljs
@@ -1,4 +1,4 @@
-(ns knoxx.backend.domain.actor.acting
+(ns knoxx.backend.infra.actor.acting
   "The actor a unit of work is currently acting as.
 
    Distinct from domain.actor.scope, which matches a principal against a
@@ -21,12 +21,12 @@
    actor is making a claim, and that claim has to be able to win over a
    process-global that happens to hold one.
 
-   Lives in domain rather than infra because \"which actor is in effect\" is
-   domain vocabulary, and because domain.actor.credentials must be able to read
-   it — a domain namespace requiring infra would be a layering violation. The
-   storage mechanism is externalised to extern.async-local-storage, which is
-   where that interop is born; this namespace exchanges CLJS values only and
-   carries no transport concern."
+   Lives in infra because entering and reading ambient request-local state is an
+   effect, whatever it is wrapped in. It was briefly in domain to spare
+   infra.actor.credentials a domain-to-infra require; the honest fix was to move
+   the credential resolver here too, since it performs a database read and was
+   never domain either. The raw Node interop still lives in
+   extern.async-local-storage; this namespace exchanges CLJS values only."
   (:require [clojure.string :as str]
             [knoxx.backend.extern.async-local-storage :as als]))
 

--- a/backend/src/cljs/knoxx/backend/infra/actor/acting.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/actor/acting.cljs
@@ -41,7 +41,12 @@
   (some-> value str str/trim not-empty))
 
 (defn run-as!
-  "Call f with no arguments with actor-id in scope for the duration.
+  "Call f with no arguments with this actor in scope for the duration.
+
+   Takes either an actor id or a map of {:actor-id, :org-id}. The org matters
+   because actor_id is not unique across orgs: a credential lookup that knows
+   only the actor can resolve another tenant's membership and return its secret.
+   Carrying the request's org means the lookup is scoped to it.
 
    A scope is entered even when actor-id is blank, and that is the whole point:
    it records \"this work has *no* actor\" as a positive fact rather than an
@@ -54,8 +59,14 @@
 
    Nested scopes shadow: the innermost wins, including when the innermost has no
    actor."
-  [actor-id f]
-  (als/run-with store {:actor-id (normalize-actor-id actor-id)} f))
+  [actor-or-map f]
+  (let [{:keys [actor-id org-id]} (if (map? actor-or-map)
+                                    actor-or-map
+                                    {:actor-id actor-or-map})]
+    (als/run-with store
+                  {:actor-id (normalize-actor-id actor-id)
+                   :org-id   (normalize-actor-id org-id)}
+                  f)))
 
 (defn in-scope?
   "True when the caller is inside a scope, whether or not it names an actor.
@@ -64,6 +75,11 @@
    Only the second may fall back to another source."
   []
   (some? (als/current store)))
+
+(defn current-org-id
+  "The org in scope, or nil. Scopes a credential lookup to one tenant."
+  []
+  (normalize-actor-id (:org-id (als/current store))))
 
 (defn current-actor-id
   "The actor id in scope, or nil.

--- a/backend/src/cljs/knoxx/backend/infra/actor/acting.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/actor/acting.cljs
@@ -43,10 +43,11 @@
 (defn run-as!
   "Call f with no arguments with this actor in scope for the duration.
 
-   Takes either an actor id or a map of {:actor-id, :org-id}. The org matters
-   because actor_id is not unique across orgs: a credential lookup that knows
-   only the actor can resolve another tenant's membership and return its secret.
-   Carrying the request's org means the lookup is scoped to it.
+   Takes either an actor id or a map of {:actor-id, :org-id, :membership-id}.
+   The membership id matters most: actor_id is unique nowhere, not even within an
+   org, so a lookup keyed on the actor alone can resolve a different member's
+   membership and return their secret. A membership id turns that search into a
+   lookup, and the org narrows it when no membership is known.
 
    A scope is entered even when actor-id is blank, and that is the whole point:
    it records \"this work has *no* actor\" as a positive fact rather than an
@@ -60,12 +61,13 @@
    Nested scopes shadow: the innermost wins, including when the innermost has no
    actor."
   [actor-or-map f]
-  (let [{:keys [actor-id org-id]} (if (map? actor-or-map)
-                                    actor-or-map
-                                    {:actor-id actor-or-map})]
+  (let [{:keys [actor-id org-id membership-id]} (if (map? actor-or-map)
+                                                  actor-or-map
+                                                  {:actor-id actor-or-map})]
     (als/run-with store
-                  {:actor-id (normalize-actor-id actor-id)
-                   :org-id   (normalize-actor-id org-id)}
+                  {:actor-id      (normalize-actor-id actor-id)
+                   :org-id        (normalize-actor-id org-id)
+                   :membership-id (normalize-actor-id membership-id)}
                   f)))
 
 (defn in-scope?
@@ -77,9 +79,20 @@
   (some? (als/current store)))
 
 (defn current-org-id
-  "The org in scope, or nil. Scopes a credential lookup to one tenant."
+  "The org in scope, or nil. Narrows a credential lookup to one tenant."
   []
   (normalize-actor-id (:org-id (als/current store))))
+
+(defn current-membership-id
+  "The membership in scope, or nil. Identifies the credential owner exactly."
+  []
+  (normalize-actor-id (:membership-id (als/current store))))
+
+(defn current-lookup-scope
+  "What a credential lookup needs to name one owner and no other."
+  []
+  {:org-id        (current-org-id)
+   :membership-id (current-membership-id)})
 
 (defn current-actor-id
   "The actor id in scope, or nil.

--- a/backend/src/cljs/knoxx/backend/infra/actor/credentials.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/actor/credentials.cljs
@@ -1,11 +1,20 @@
-(ns knoxx.backend.domain.actor.credentials
+(ns knoxx.backend.infra.actor.credentials
   "Resolve per-actor tool credentials from the policy DB.
 
    Tool credentials are actor-owned state. Do not read API keys from process
-   env vars here; missing credentials should be fixed in Admin → Actors."
+   env vars here; missing credentials should be fixed in Admin → Actors.
+
+   In infra, not domain: this reads the policy database and consults ambient
+   request state, and it always did — it sat under domain.* while requiring
+   infra.auth.authz and infra.db.policy, which made the layering violation
+   invisible rather than absent. Its callers are the tool implementations
+   (bluesky, discord, media, twitch), which are themselves effectful namespaces
+   filed under domain.*; moving this makes those edges visible to the layer gate
+   instead of laundering them through a domain-sounding name. See
+   knoxx-layer-enforcement-gate."
   (:require [clojure.string :as str]
-            [knoxx.backend.domain.actor.acting :as actor-acting]
             [knoxx.backend.domain.agent.agent-context :as agent-context]
+            [knoxx.backend.infra.actor.acting :as actor-acting]
             [knoxx.backend.infra.auth.authz :as authz]
             [knoxx.backend.infra.db.policy :as policy-db]))
 

--- a/backend/src/cljs/knoxx/backend/infra/actor/credentials.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/actor/credentials.cljs
@@ -68,13 +68,13 @@
        (js/Error. "Actor credentials require the Knoxx policy database."))
 
       :else
-      ;; The org comes from the same scope as the actor, so a credential lookup
-      ;; cannot resolve another tenant's membership that happens to share this
-      ;; actor id. nil outside a scope, which leaves the lookup as it was for the
-      ;; agent-spawn path — and that path now fails closed on an ambiguous id
-      ;; rather than choosing.
+      ;; The membership and org come from the same scope as the actor, so a
+      ;; lookup cannot land on a different member who shares this actor id.
+      ;; Empty outside a scope, which leaves the agent-spawn path as it was —
+      ;; and that path now refuses an ambiguous actor rather than choosing.
       (let [result (await (policy-db/get-actor-credential!
-                           db actor-id provider (actor-acting/current-org-id)))]
+                           db actor-id provider
+                           (actor-acting/current-lookup-scope)))]
         (if-let [credential (normalize-credential result)]
           credential
           (throw (js/Error. (str "No active " provider " credentials configured for actor " actor-id ". Configure them in Admin → Actors."))))))))

--- a/backend/src/cljs/knoxx/backend/infra/actor/credentials.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/actor/credentials.cljs
@@ -68,7 +68,13 @@
        (js/Error. "Actor credentials require the Knoxx policy database."))
 
       :else
-      (let [result (await (policy-db/get-actor-credential! db actor-id provider))]
+      ;; The org comes from the same scope as the actor, so a credential lookup
+      ;; cannot resolve another tenant's membership that happens to share this
+      ;; actor id. nil outside a scope, which leaves the lookup as it was for the
+      ;; agent-spawn path — and that path now fails closed on an ambiguous id
+      ;; rather than choosing.
+      (let [result (await (policy-db/get-actor-credential!
+                           db actor-id provider (actor-acting/current-org-id)))]
         (if-let [credential (normalize-credential result)]
           credential
           (throw (js/Error. (str "No active " provider " credentials configured for actor " actor-id ". Configure them in Admin → Actors."))))))))

--- a/backend/src/cljs/knoxx/backend/infra/actor/scope.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/actor/scope.cljs
@@ -1,0 +1,42 @@
+(ns knoxx.backend.infra.actor.scope
+  "The actor a unit of work is running as, scoped to that work.
+
+   Tool credentials are actor-owned, so something has to say which actor a tool
+   call belongs to. The agent runtime answers that with agent-context, but it is
+   only set on the agent-spawn path and it is a process-global atom — fine for a
+   single turn loop, wrong for a concurrent HTTP surface where two requests can
+   interleave at any await.
+
+   This is the surface-neutral answer: enter a scope for one unit of work, read
+   it from anywhere inside, and it is unreachable outside. Nothing here decides
+   *which* actor is permitted — that is law.mcp-oauth's job — only which one is
+   currently in effect."
+  (:require [clojure.string :as str]
+            [knoxx.backend.extern.async-local-storage :as als]))
+
+(defonce ^:private store (als/create-store))
+
+(defn normalize-actor-id
+  "An actor id as a non-blank trimmed string, or nil.
+
+   nil rather than \"\" on purpose: a blank actor id must never read as an
+   actor, and returning the empty string invites a caller to pass it on."
+  [value]
+  (some-> value str str/trim not-empty))
+
+(defn run-as!
+  "Call f with no arguments with actor-id in scope for the duration.
+
+   A blank actor-id enters no scope at all rather than an empty one, so a caller
+   that could not resolve an actor cannot accidentally establish one — the
+   failure surfaces where the credential is read, with a message about the
+   missing actor, instead of as a lookup for actor \"\"."
+  [actor-id f]
+  (if-let [actor (normalize-actor-id actor-id)]
+    (als/run-with store {:actor-id actor} f)
+    (f)))
+
+(defn current-actor-id
+  "The actor id in scope, or nil when there is none."
+  []
+  (normalize-actor-id (:actor-id (als/current store))))

--- a/backend/src/cljs/knoxx/backend/infra/actor/scope.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/actor/scope.cljs
@@ -10,7 +10,12 @@
    This is the surface-neutral answer: enter a scope for one unit of work, read
    it from anywhere inside, and it is unreachable outside. Nothing here decides
    *which* actor is permitted — that is law.mcp-oauth's job — only which one is
-   currently in effect."
+   currently in effect.
+
+   The distinction that matters: **being in a scope with no actor is not the
+   same as being outside a scope.** A caller that has established there is no
+   actor is making a claim, and that claim has to be able to win over a
+   process-global that happens to hold one."
   (:require [clojure.string :as str]
             [knoxx.backend.extern.async-local-storage :as als]))
 
@@ -27,16 +32,32 @@
 (defn run-as!
   "Call f with no arguments with actor-id in scope for the duration.
 
-   A blank actor-id enters no scope at all rather than an empty one, so a caller
-   that could not resolve an actor cannot accidentally establish one — the
-   failure surfaces where the credential is read, with a message about the
-   missing actor, instead of as a lookup for actor \"\"."
+   A scope is entered even when actor-id is blank, and that is the whole point:
+   it records \"this work has *no* actor\" as a positive fact rather than an
+   absence. Entering no scope would leave the caller indistinguishable from code
+   that never established anything, and readers fall back to the process-global
+   agent-context in that case — so an actor-less MCP call could pick up whatever
+   actor a concurrent agent turn happened to be running as, and use its
+   credentials. That is the exact leak this namespace exists to prevent,
+   arriving through the fallback instead of through the store.
+
+   Nested scopes shadow: the innermost wins, including when the innermost has no
+   actor."
   [actor-id f]
-  (if-let [actor (normalize-actor-id actor-id)]
-    (als/run-with store {:actor-id actor} f)
-    (f)))
+  (als/run-with store {:actor-id (normalize-actor-id actor-id)} f))
+
+(defn in-scope?
+  "True when the caller is inside a scope, whether or not it names an actor.
+
+   Readers need this to tell \"no actor, definitively\" from \"nobody said\".
+   Only the second may fall back to another source."
+  []
+  (some? (als/current store)))
 
 (defn current-actor-id
-  "The actor id in scope, or nil when there is none."
+  "The actor id in scope, or nil.
+
+   nil is ambiguous on its own — no actor, or no scope — so pair it with
+   in-scope? whenever the difference decides whether to consult a fallback."
   []
   (normalize-actor-id (:actor-id (als/current store))))

--- a/backend/src/cljs/knoxx/backend/infra/auth/authz.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/auth/authz.cljs
@@ -90,6 +90,18 @@
 (defn ctx-membership-id [ctx] (or (:membership-id ctx) (:membershipId ctx) (get-in ctx [:membership :id])))
 (defn ctx-actor-id [ctx] (or (:actor-id ctx) (:actorId ctx) (get-in ctx [:membership :actor-id]) (get-in ctx [:actor :id])))
 
+(defn ctx-actor-binding
+  "The membership's stored actor id, or nil when none is assigned.
+
+   Distinct from ctx-actor-id, which falls back to a role-derived default and so
+   is never nil — it answers \"which actor label applies\", not \"was an actor
+   assigned\". Only the binding may decide authority: a token minted from the
+   default would carry credential scope for system_admin or workspace_user that
+   nobody granted, and clearing the stored id would not revoke it, because the
+   default takes over and still matches."
+  [ctx]
+  (or (:actor-binding ctx) (:actorBinding ctx) (get-in ctx [:actor :binding])))
+
 (defn ctx-role-slugs
   [ctx]
   (into #{}

--- a/backend/src/cljs/knoxx/backend/infra/db/policy.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/db/policy.cljs
@@ -1382,16 +1382,16 @@
 (defn ^:async get-actor-credential!
   "An actor's active credential for a provider.
 
-   org-id scopes the membership lookup: actor_id is not unique across orgs, so
-   without it an actor id present in two orgs resolves to an arbitrary one and
-   returns that org's secret. Callers holding a request context should pass its
-   org."
+   scope narrows the membership lookup: {:org-id, :membership-id}. actor_id is
+   unique nowhere — not even within an org — so an unnarrowed lookup refuses an
+   ambiguous actor rather than returning some member's secret. A caller holding a
+   request context should pass its membership id, which is exact."
   ([policy-context actor-id provider] (get-actor-credential! policy-context actor-id provider nil))
-  ([_policy-context actor-id provider org-id]
+  ([_policy-context actor-id provider scope]
    (when-let [db (await (ensure-mongo-policy-db!))]
      {:credential (mongo-actor-creds/credential-row->response
                    (await (mongo-actor-creds/get-actor-credential-by-actor-and-provider!
-                           db actor-id provider org-id)))})))
+                           db actor-id provider scope)))})))
 
 ;; ---------------------------------------------------------------------------
 ;; Initialisation

--- a/backend/src/cljs/knoxx/backend/infra/db/policy.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/db/policy.cljs
@@ -493,12 +493,18 @@
 (defn- request-context-map
   [membership-row membership detailed-roles]
   (let [{:keys [permissions tool-policies role-slugs]} (request-policy-summary membership detailed-roles)
-        actor-id (or (normalize-actor-id (:actor_id membership-row))
+        ;; The membership's *stored* actor binding, or nil. Kept separate from
+        ;; actor-id below, which falls back to a role-derived default and is
+        ;; therefore never nil — so it cannot answer "was an actor assigned?".
+        ;; Anything deciding authority (which credentials a token may read) must
+        ;; use the binding; the default is a display and role convenience.
+        actor-binding (normalize-actor-id (:actor_id membership-row))
+        actor-id (or actor-binding
                      (default-membership-actor-id role-slugs))]
     {:user (request-user-map membership-row)
      :org (request-org-map membership-row)
      :membership (request-membership-map membership actor-id)
-     :actor {:id actor-id}
+     :actor {:id actor-id :binding actor-binding}
      :roles detailed-roles
      :role-slugs role-slugs
      :permissions permissions

--- a/backend/src/cljs/knoxx/backend/infra/db/policy.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/db/policy.cljs
@@ -1380,10 +1380,18 @@
                             payload))
 
 (defn ^:async get-actor-credential!
-  [_policy-context actor-id provider]
-  (when-let [db (await (ensure-mongo-policy-db!))]
-    {:credential (mongo-actor-creds/credential-row->response
-                  (await (mongo-actor-creds/get-actor-credential-by-actor-and-provider! db actor-id provider)))}))
+  "An actor's active credential for a provider.
+
+   org-id scopes the membership lookup: actor_id is not unique across orgs, so
+   without it an actor id present in two orgs resolves to an arbitrary one and
+   returns that org's secret. Callers holding a request context should pass its
+   org."
+  ([policy-context actor-id provider] (get-actor-credential! policy-context actor-id provider nil))
+  ([_policy-context actor-id provider org-id]
+   (when-let [db (await (ensure-mongo-policy-db!))]
+     {:credential (mongo-actor-creds/credential-row->response
+                   (await (mongo-actor-creds/get-actor-credential-by-actor-and-provider!
+                           db actor-id provider org-id)))})))
 
 ;; ---------------------------------------------------------------------------
 ;; Initialisation

--- a/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
@@ -615,9 +615,10 @@
            request raw-req raw-res token-record]}]
   (let [token-ctx (await (resolve-token-context! policy-db token-record))
         acting    {:actor-id (call-actor-id token-record token-ctx)
-                   ;; From the resolved context, so the credential lookup is
-                   ;; scoped to the org this token belongs to.
-                   :org-id   (authz/ctx-org-id token-ctx)}
+                   ;; From the resolved context, so a credential lookup names
+                   ;; this token's owner exactly rather than searching by actor.
+                   :org-id        (authz/ctx-org-id token-ctx)
+                   :membership-id (authz/ctx-membership-id token-ctx)}
         server    (new McpServer (clj->js {:name "knoxx" :version "0.1.0"}))
         transport (new StreamableHTTPServerTransport (transport/stateless-transport-options))]
     (register-tools! server z (granted-tools runtime config token-ctx token-record) acting)

--- a/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
@@ -4,9 +4,12 @@
             [malli.core :as m]
             [malli.error :as me]
             [knoxx.backend.shape.app-shapes :refer [route!]]
+            [knoxx.backend.infra.actor.scope :as actor-scope]
             [knoxx.backend.infra.auth.authz :as authz]
             [knoxx.backend.infra.auth.session :as auth-session]
             [knoxx.backend.infra.db.policy :as db-policy]
+            [knoxx.backend.infra.routes.mcp.consent :as consent]
+            [knoxx.backend.infra.routes.mcp.transport :as transport]
             [knoxx.backend.domain.mcp.mcp-expose :as mcp-expose]
             [knoxx.backend.infra.stores.mongo-mcp-oauth :as mongo-mcp]
             [knoxx.backend.law.mcp-oauth :as law]
@@ -76,31 +79,6 @@
   [^js crypto verifier]
   (base64url (-> (.createHash crypto "sha256") (.update (str verifier)) (.digest))))
 
-(defn- bearer-token
-  [req]
-  (let [raw (str (or (some-> req (aget "headers") (aget "authorization")) ""))
-        m (.match raw (js/RegExp. "^Bearer\\s+(.+)$" "i"))]
-    (when m (str/trim (aget m 1)))))
-
-(defn- resolve-session-id
-  [req]
-  (let [headers (or (aget req "headers") (js/Object.))
-        header-id (aget headers "mcp-session-id")
-        q (or (aget req "query") (js/Object.))
-        query-id (aget q "sessionId")]
-    (cond
-      (and (string? header-id) (not (str/blank? header-id))) header-id
-      (and (string? query-id) (not (str/blank? query-id))) query-id
-      :else nil)))
-
-(defn- safe
-  [s]
-  (-> (str (or s ""))
-      (.replaceAll "&" "&amp;")
-      (.replaceAll "<" "&lt;")
-      (.replaceAll ">" "&gt;")
-      (.replaceAll "\"" "&quot;")))
-
 (defn- normalize-tool-selection
   [raw]
   (cond
@@ -113,9 +91,6 @@
 
 (defn- text-send! [reply status body]
   (-> (.code reply status) (.send body)))
-
-(defn- protected-resource-metadata-url [base]
-  (.toString (js/URL. "/.well-known/oauth-protected-resource" base)))
 
 (defn- protected-resource-metadata
   "RFC 9728 metadata for the MCP resource. One document, served at every
@@ -135,51 +110,9 @@
                          "protected resource metadata failed its contract")))
     payload))
 
-(defn- www-authenticate-challenge [base]
-  (str "Bearer realm=\"mcp\", resource_metadata=\""
-       (protected-resource-metadata-url base) "\""))
-
-(defn- challenge-unauthorized! [^js reply base]
-  (-> (reply-header! reply "WWW-Authenticate" (www-authenticate-challenge base))
-      (.code 401) (.send "Unauthorized")))
-
-(defn stateless-transport-options
-  "Options that actually select the MCP SDK's stateless mode.
-
-   The key must be ABSENT, not undefined. (clj->js {:sessionIdGenerator
-   js/undefined}) emits {sessionIdGenerator: null}, and the SDK selects
-   stateless only on === undefined — so null selected *stateful* mode, where
-   everything after initialize is rejected with \"Server not initialized\" and a
-   client sees no tools. SDK 1.18/1.24/1.29/1.30 all read null as stateful."
-  []
-  #js {})
-
-(defn- transport-handle-request!
-  ([^js t req reply]      (.handleRequest t req reply))
-  ([^js t req reply body] (.handleRequest t req reply body)))
-
 (defn- tool-execute! [^js tool params] (.execute tool "mcp" params nil nil nil))
 
 (defn- reply-header! [^js reply name value] (.header reply name value))
-
-(defn- ensure-streamable-accept!
-  [req]
-  (let [raw         (aget req "raw")
-        headers     (or (aget raw "headers") (js/Object.))
-        raw-headers (or (aget raw "rawHeaders") (js/Array.))
-        accept-value "application/json, text/event-stream"
-        accept      (str/lower-case (str (or (aget headers "accept") "")))
-        has-json?   (str/includes? accept "application/json")
-        has-sse?    (str/includes? accept "text/event-stream")]
-    (when (or (str/blank? accept) (not has-json?) (not has-sse?))
-      (aset headers "accept" accept-value)
-      (aset raw "headers" headers)
-      (let [filtered (->> (partition 2 (array-seq raw-headers))
-                          (remove (fn [[k _]] (= "accept" (str/lower-case (str k)))))
-                          (mapcat identity)
-                          vec)]
-        (aset raw "rawHeaders" (clj->js (conj filtered "accept" accept-value)))))
-    req))
 
 ;; Fastify's default error handler reads `statusCode` off the thrown object and
 ;; falls back to 500. A bare ex-info keeps its status in ex-data, where Fastify
@@ -227,9 +160,9 @@
   "Returns a Fastify preHandler hook that extracts bearer token onto request.bearerToken."
   [base]
   (fn [req reply done]
-    (let [token (bearer-token req)]
+    (let [token (transport/bearer-token req)]
       (if (str/blank? token)
-        (challenge-unauthorized! reply base)
+        (transport/challenge-unauthorized! reply base)
         (do (aset req "bearerToken" token) (done))))))
 
 ;; ──────────────────────────────────────────────────────────────
@@ -349,71 +282,6 @@
          (filter #(contains? available %))
          vec)))
 
-(defn- tool-checkbox-html [tools selected]
-  (->> (array-seq tools)
-       (map (fn [tool]
-              (let [n       (str (or (aget tool "name") ""))
-                    label   (str (or (aget tool "label") (aget tool "name") (aget tool "description") n))
-                    desc    (str (or (aget tool "description") ""))
-                    checked (if (contains? selected n) "checked" "")]
-                (str "\n        <label style=\"display:block; margin: 6px 0;\">\n"
-                     "          <input type=\"checkbox\" name=\"tool\" value=\"" (safe n) "\" " checked " />\n"
-                     "          <span style=\"font-weight:600;\">" (safe label) "</span>\n"
-                     "          <span style=\"color:#666;\">(" (safe n) ")</span>\n"
-                     "          <div style=\"color:#444; margin-left: 22px;\">" (safe desc) "</div>\n"
-                     "        </label>\n"))))
-       (str/join "\n")))
-
-(defn- authorization-consent-html
-  [{:keys [base auth-context client-id redirect-uri state code-challenge requested-scope tools selected]}]
-  ;; The auth context is a CLJS map, so it must be read with the shared
-  ;; accessors rather than aget. Reaching in with (aget ctx "user" "email")
-  ;; both missed the value and threw outright — aget compiles to
-  ;; ctx["user"]["email"], and the intermediate is undefined, so the `or`
-  ;; fallback never got the chance to run and the consent page 500'd.
-  (let [confirm-url (js/URL. "/api/mcp/oauth/authorize/confirm" base)
-        user-email  (str (or (authz/ctx-user-email auth-context) ""))
-        org-slug    (str (or (authz/ctx-org-slug auth-context) ""))]
-    (.set (.-searchParams confirm-url) "client_id" client-id)
-    (.set (.-searchParams confirm-url) "redirect_uri" redirect-uri)
-    (when state (.set (.-searchParams confirm-url) "state" state))
-    (.set (.-searchParams confirm-url) "code_challenge" code-challenge)
-    (.set (.-searchParams confirm-url) "code_challenge_method" "S256")
-    (when-not (str/blank? (str (or requested-scope "")))
-      (.set (.-searchParams confirm-url) "scope" requested-scope))
-    (str "<!doctype html>\n<html><head><meta charset=\"utf-8\" />\n"
-         "<title>Authorize MCP Client</title>\n"
-         "<style>body{font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial;margin:24px;}"
-         ".box{max-width:920px;} .meta{color:#555;margin-bottom:12px;}"
-         ".tools{border:1px solid #ddd;border-radius:8px;padding:12px 16px;}"
-         ".actions{margin-top:18px;display:flex;gap:12px;}"
-         "button{padding:8px 14px;border-radius:8px;border:1px solid #333;background:#111;color:#fff;cursor:pointer;}"
-         "a{color:#0b67d0;}"
-         "</style></head><body><div class=\"box\">\n"
-         "<h1>Authorize MCP Client</h1>\n"
-         "<div class=\"meta\">\n"
-         "<div><strong>Client:</strong> "      (safe client-id)    "</div>\n"
-         "<div><strong>Redirect URI:</strong> " (safe redirect-uri) "</div>\n"
-         "<div><strong>User:</strong> "         (safe user-email)   "</div>\n"
-         "<div><strong>Org:</strong> "          (safe org-slug)     "</div>\n"
-         "</div>\n"
-         "<form method=\"GET\" action=\"" (safe (.-pathname confirm-url)) "\">\n"
-         "<input type=\"hidden\" name=\"client_id\" value=\""           (safe client-id)    "\" />\n"
-         "<input type=\"hidden\" name=\"redirect_uri\" value=\""         (safe redirect-uri) "\" />\n"
-         "<input type=\"hidden\" name=\"state\" value=\""               (safe (or state "")) "\" />\n"
-         "<input type=\"hidden\" name=\"code_challenge\" value=\""       (safe code-challenge) "\" />\n"
-         "<input type=\"hidden\" name=\"code_challenge_method\" value=\"S256\" />\n"
-         "<input type=\"hidden\" name=\"scope\" value=\""               (safe requested-scope) "\" />\n"
-         "<h2>Capabilities</h2>\n"
-         "<p>Select exactly which Knoxx tools this client can call. You can always revoke tokens later.</p>\n"
-         "<div class=\"tools\">\n"
-         (tool-checkbox-html tools selected)
-         "</div>\n"
-         "<div class=\"actions\">\n"
-         "<button type=\"submit\">Authorize</button>\n"
-         "<a href=\"/\">Cancel</a>\n"
-         "</div></form></div></body></html>")))
-
 (defn- ^:async load-token-record! [access-token]
   (if (str/blank? (str access-token))
     nil
@@ -432,6 +300,24 @@
                        (aget token-record "orgSlug")
                        (assoc "x-knoxx-org-slug" (aget token-record "orgSlug")))]
     (db-policy/resolve-context! policy-context headers-like)))
+
+(defn- call-actor-id
+  "The actor this request's tool calls run as, or nil when it has none.
+
+   Resolved from the context the token maps to, not from the token, so a
+   membership whose actor was reassigned or cleared takes effect immediately
+   instead of at token expiry. The token's own copy is only consulted to refuse
+   a token that names a different actor than its membership now resolves to —
+   see law/token-actor-honourable? for why that is a refusal and not a silent
+   preference for one side."
+  [token-record token-ctx]
+  (let [claimed (actor-scope/normalize-actor-id (aget token-record "actorId"))
+        current (actor-scope/normalize-actor-id (authz/ctx-actor-id token-ctx))]
+    (when-not (law/token-actor-honourable? claimed current)
+      (throw (http-error 403 "actor_reassigned"
+                         (str "This token was authorized to act as " claimed
+                              ", which is no longer this membership's actor."))))
+    current))
 
 (defn- apply-zod-description [^js schema-node ^js schema-json]
   (let [description (some-> (aget schema-json "description") str str/trim not-empty)]
@@ -542,7 +428,7 @@
       (let [tools    (available-tools runtime config auth-context)
             selected (let [explicit (selected-tools-from-scope tools scope)]
                        (if (seq explicit) explicit (default-selected-tools (tool-name-set tools))))
-            html     (authorization-consent-html
+            html     (consent/page
                       {:base base :auth-context auth-context
                        :client-id client-id :redirect-uri redirect-uri
                        :state state :code-challenge code-challenge
@@ -576,12 +462,23 @@
                   ;; one is legitimate.
                   (throw (http-error 400 "missing_identity"
                                      "Session has no membership or user identity to authorize with")))
+              ;; The actor comes from the resolved context, never from the
+              ;; query — the client is on the other side of a redirect it
+              ;; controls, so an actorId it echoed back would be its own choice
+              ;; of identity. law/actor-grantable? then confirms the membership
+              ;; may name it, which today means it must be the membership's own.
+              actor-id      (let [claimed (str (or (authz/ctx-actor-id auth-context) ""))]
+                              (when (law/actor-grantable? claimed claimed) claimed))
               code          (.randomUUID crypto)
-              payload       {:code code :clientId client-id :redirectUri redirect-uri
-                             :codeChallenge code-challenge :codeChallengeMethod "S256"
-                             :tools requested
-                             :membershipId membership-id :userEmail user-email :orgSlug org-slug
-                             :createdAt (.toISOString (js/Date.))}]
+              payload       (cond-> {:code code :clientId client-id :redirectUri redirect-uri
+                                     :codeChallenge code-challenge :codeChallengeMethod "S256"
+                                     :tools requested
+                                     :membershipId membership-id :userEmail user-email :orgSlug org-slug
+                                     :createdAt (.toISOString (js/Date.))}
+                              ;; Absent rather than blank when there is no
+                              ;; actor. A blank would round-trip as an actor
+                              ;; that exists and owns nothing.
+                              actor-id (assoc :actorId actor-id))]
           (await (mongo-mcp/set-code! code (js/JSON.stringify (clj->js payload)) code-ttl))
           (let [redir (js/URL. redirect-uri)]
             (.set (.-searchParams redir) "code" code)
@@ -611,13 +508,19 @@
   (let [access-token  (.randomUUID crypto)
         membership-id (:membershipId record)
         tools         (vec (:tools record))
-        token-value   {:accessToken access-token :clientId client-id
-                       :membershipId membership-id
-                       :userEmail    (:userEmail record)
-                       :orgSlug      (:orgSlug record)
-                       :tools        tools
-                       :createdAt    (.toISOString (js/Date.))
-                       :expiresAt    (.toISOString (js/Date. (+ (.now js/Date) (* token-ttl 1000))))}]
+        actor-id      (actor-scope/normalize-actor-id (:actorId record))
+        token-value   (cond-> {:accessToken access-token :clientId client-id
+                               :membershipId membership-id
+                               :userEmail    (:userEmail record)
+                               :orgSlug      (:orgSlug record)
+                               :tools        tools
+                               :createdAt    (.toISOString (js/Date.))
+                               :expiresAt    (.toISOString (js/Date. (+ (.now js/Date) (* token-ttl 1000))))}
+                        ;; Copied from the claimed code, so the actor a token
+                        ;; acts as is the one the user saw on the consent page.
+                        ;; Still re-checked against the membership on every
+                        ;; call — see law/token-actor-honourable?.
+                        actor-id (assoc :actorId actor-id))]
     (await (mongo-mcp/set-token! access-token (js/JSON.stringify (clj->js token-value)) token-ttl membership-id))
     {:access_token access-token :token_type "Bearer"
      :scope        (str/join " " tools)
@@ -673,7 +576,7 @@
 
 (defroute mcp-handle-session! [base bearer-token-guard] "GET" "/mcp" [bearer-token-guard]
   (let [bearer     (aget request "bearerToken")
-        session-id (resolve-session-id request)]
+        session-id (transport/resolve-session-id request)]
     (cond
       (str/blank? (str session-id))
       (text-send! reply 400 "Missing mcp-session-id")
@@ -682,13 +585,13 @@
       (let [{:keys [transport token]} (get @mcp-sessions* session-id)]
         (cond
           (nil? transport)                   (text-send! reply 404 (str "Invalid mcp-session-id: " session-id))
-          (not= (str bearer) (str token))    (challenge-unauthorized! reply base)
-          :else (do (ensure-streamable-accept! request)
-                    (transport-handle-request! transport (aget request "raw") (aget reply "raw"))))))))
+          (not= (str bearer) (str token))    (transport/challenge-unauthorized! reply base)
+          :else (do (transport/ensure-streamable-accept! request)
+                    (transport/handle-request! transport (aget request "raw") (aget reply "raw"))))))))
 
 (defroute mcp-handle-delete-session! [base bearer-token-guard] "DELETE" "/mcp" [bearer-token-guard]
   (let [bearer     (aget request "bearerToken")
-        session-id (resolve-session-id request)]
+        session-id (transport/resolve-session-id request)]
     (cond
       (str/blank? (str session-id))
       (text-send! reply 400 "Missing mcp-session-id")
@@ -697,9 +600,73 @@
       (let [{:keys [transport token]} (get @mcp-sessions* session-id)]
         (cond
           (nil? transport)                   (text-send! reply 404 (str "Invalid mcp-session-id: " session-id))
-          (not= (str bearer) (str token))    (challenge-unauthorized! reply base)
-          :else (do (ensure-streamable-accept! request)
-                    (transport-handle-request! transport (aget request "raw") (aget reply "raw"))))))))
+          (not= (str bearer) (str token))    (transport/challenge-unauthorized! reply base)
+          :else (do (transport/ensure-streamable-accept! request)
+                    (transport/handle-request! transport (aget request "raw") (aget reply "raw"))))))))
+
+(defn- tool-config-js
+  "The MCP registerTool config for one tool object. Pure interop assembly."
+  [z ^js tool name]
+  (let [shape  (or (when z (typebox->zod-shape z (or (aget tool "parameters") (js/Object.)))) (js-obj))
+        config (clj->js {:description (str (or (aget tool "description") (aget tool "label") name))
+                         :inputSchema shape})]
+    (when-let [title (some-> (or (aget tool "label") (aget tool "title")) str str/trim not-empty)]
+      (aset config "title" title))
+    ;; A tool's own annotations win, else the declared table.
+    ;; See law.mcp-tool-annotations for why absence is bad.
+    (if-let [annotations (aget tool "annotations")]
+      (aset config "annotations" annotations)
+      ;; name may be sanitized (web.read -> web_read).
+      (when-let [declared (or (tool-annotations/for-tool name)
+                              (tool-annotations/for-tool (aget tool "originalName")))]
+        (aset config "annotations" (clj->js declared))))
+    (when-let [meta (aget tool "_meta")]
+      (aset config "_meta" meta))
+    config))
+
+(defn- register-tools!
+  "Register every granted tool on a fresh MCP server, bound to one actor.
+
+   Each handler runs inside that actor's scope, so domain.actor.credentials
+   resolves the actor without the MCP surface having to impersonate an agent
+   spawn. The scope is entered per call rather than per request because the SDK
+   invokes handlers itself: wrapping the request would put the awaits that
+   matter outside it."
+  [^js server z tools actor-id]
+  (doseq [^js tool (array-seq tools)]
+    (when-let [name (some-> (aget tool "name") str str/trim not-empty)]
+      (.registerTool server name
+                     (tool-config-js z tool name)
+                     (fn [params]
+                       (actor-scope/run-as! actor-id #(tool-execute! tool params)))))))
+
+(defn- granted-tools
+  "The tools this token was granted, out of those its context can reach.
+
+   The intersection is the whole authorization: a token carries the names ticked
+   on the consent page, and a tool absent from either side is not registered.
+   One consequence worth knowing — a token whose grant list is empty registers
+   nothing, so initialize advertises no tool capability and tools/list answers
+   \"Method not found\". That is correct, and it reads like a broken server."
+  [runtime config token-ctx ^js token-record]
+  (let [allowed (into #{} (map str) (array-seq (or (aget token-record "tools") (js/Array.))))]
+    (->> (available-tools runtime config token-ctx)
+         array-seq
+         (filter (fn [^js t] (contains? allowed (str (aget t "name")))))
+         into-array)))
+
+(defn- ^:async serve-mcp-post!
+  "Answer one authenticated MCP POST on a per-request server and transport."
+  [{:keys [config runtime policy-db McpServer StreamableHTTPServerTransport z
+           request raw-req raw-res token-record]}]
+  (let [token-ctx (await (resolve-token-context! policy-db token-record))
+        actor-id  (call-actor-id token-record token-ctx)
+        server    (new McpServer (clj->js {:name "knoxx" :version "0.1.0"}))
+        transport (new StreamableHTTPServerTransport (transport/stateless-transport-options))]
+    (register-tools! server z (granted-tools runtime config token-ctx token-record) actor-id)
+    (await (.connect server transport))
+    (transport/ensure-streamable-accept! request)
+    (transport/handle-request! transport raw-req raw-res (aget request "body"))))
 
 (defroute mcp-handle-post! [base config runtime code-ttl token-ttl policy-db McpServer StreamableHTTPServerTransport z] "POST" "/mcp" []
   (let [^js request request
@@ -707,57 +674,25 @@
     (.hijack reply)
     (let [^js raw-req (aget request "raw")
           ^js raw-res (aget reply "raw")
-          bearer  (bearer-token request)]
-      (if (str/blank? bearer)
-        (do (.writeHead raw-res 401 (clj->js {"WWW-Authenticate" (www-authenticate-challenge base)
-                                               "Content-Type" "text/plain"}))
-            (.end raw-res "Unauthorized"))
-        (try
-          (let [token-record (await (load-token-record! bearer))]
-            (if-not token-record
-              (do (.writeHead raw-res 401 (clj->js {"WWW-Authenticate" (www-authenticate-challenge base)
-                                                     "Content-Type" "text/plain"}))
-                  (.end raw-res "Unauthorized"))
-              (let [token-ctx (await (resolve-token-context! policy-db token-record))
-                    all-tools (available-tools runtime config token-ctx)
-                    allowed   (into #{} (map str) (array-seq (or (aget token-record "tools") (js/Array.))))
-                    effective (->> (array-seq all-tools)
-                                   (filter (fn [t] (contains? allowed (str (aget t "name")))))
-                                   into-array)
-                    server    (new McpServer (clj->js {:name "knoxx" :version "0.1.0"}))
-                    transport (new StreamableHTTPServerTransport
-                                   (stateless-transport-options))]
-                (doseq [tool (array-seq effective)]
-                  (let [n (some-> (aget tool "name") str str/trim not-empty)
-                        s (or (when z (typebox->zod-shape z (or (aget tool "parameters") (js/Object.)))) (js-obj))]
-                    (when n
-                      (let [tool-config (clj->js {:description (str (or (aget tool "description") (aget tool "label") n))
-                                                  :inputSchema s})]
-                        (when-let [title (some-> (or (aget tool "label") (aget tool "title")) str str/trim not-empty)]
-                          (aset tool-config "title" title))
-                        ;; A tool's own annotations win, else the declared table.
-                        ;; See law.mcp-tool-annotations for why absence is bad.
-                        (if-let [annotations (aget tool "annotations")]
-                          (aset tool-config "annotations" annotations)
-                          ;; n may be sanitized (web.read -> web_read).
-                          (when-let [declared (or (tool-annotations/for-tool n)
-                                                  (tool-annotations/for-tool
-                                                   (aget tool "originalName")))]
-                            (aset tool-config "annotations" (clj->js declared))))
-                        (when-let [meta (aget tool "_meta")]
-                          (aset tool-config "_meta" meta))
-                        (.registerTool server n
-                                       tool-config
-                                       (fn [params] (tool-execute! tool params)))))))
-                (await (.connect server transport))
-                (ensure-streamable-accept! request)
-                (transport-handle-request! transport raw-req raw-res (aget request "body")))))
-          (catch :default err
-            (.error js/console "[knoxx-mcp] post failed" err)
-            (when-not (.-headersSent raw-res)
-              (.writeHead raw-res 500 (clj->js {"Content-Type" "application/json"}))
-              (.end raw-res (js/JSON.stringify (clj->js {:error "mcp_post_failed"
-                                                          :detail (or (.-message err) (str err))}))))))))))
+          bearer      (transport/bearer-token request)]
+      (try
+        (let [token-record (when-not (str/blank? bearer)
+                             (await (load-token-record! bearer)))]
+          (if-not token-record
+            (transport/unauthorized! base raw-res)
+            (await (serve-mcp-post!
+                    {:config config :runtime runtime :policy-db policy-db
+                     :McpServer McpServer
+                     :StreamableHTTPServerTransport StreamableHTTPServerTransport
+                     :z z :request request :raw-req raw-req :raw-res raw-res
+                     :token-record token-record}))))
+        (catch :default err
+          (.error js/console "[knoxx-mcp] post failed" err)
+          (when-not (.-headersSent raw-res)
+            (let [status (or (aget err "statusCode") 500)]
+              (.writeHead raw-res status (clj->js {"Content-Type" "application/json"}))
+              (.end raw-res (js/JSON.stringify (clj->js {:error (or (aget err "code") "mcp_post_failed")
+                                                         :detail (or (.-message err) (str err))}))))))))))
 
 (def ^:private route-registrars
   "Every MCP route, in registration order. Kept as data so adding one is a line

--- a/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
@@ -4,7 +4,7 @@
             [malli.core :as m]
             [malli.error :as me]
             [knoxx.backend.shape.app-shapes :refer [route!]]
-            [knoxx.backend.infra.actor.scope :as actor-scope]
+            [knoxx.backend.domain.actor.acting :as actor-acting]
             [knoxx.backend.infra.auth.authz :as authz]
             [knoxx.backend.infra.auth.session :as auth-session]
             [knoxx.backend.infra.db.policy :as db-policy]
@@ -198,8 +198,8 @@
    there is no window in which a token acts as an actor its membership has
    dropped."
   [token-record token-ctx]
-  (let [claimed (actor-scope/normalize-actor-id (aget token-record "actorId"))
-        current (actor-scope/normalize-actor-id (authz/ctx-actor-id token-ctx))]
+  (let [claimed (actor-acting/normalize-actor-id (aget token-record "actorId"))
+        current (actor-acting/normalize-actor-id (authz/ctx-actor-id token-ctx))]
     (when-not (law/token-actor-honourable? claimed current)
       (throw (params/http-error 403 "actor_reassigned"
                          (str "This token was authorized to act as " claimed
@@ -369,7 +369,7 @@
   (let [membership-id (str (or (authz/ctx-membership-id auth-context) ""))
         user-email    (str (or (authz/ctx-user-email auth-context) ""))
         org-slug      (str (or (authz/ctx-org-slug auth-context) ""))
-        actor-id      (actor-scope/normalize-actor-id (authz/ctx-actor-id auth-context))]
+        actor-id      (actor-acting/normalize-actor-id (authz/ctx-actor-id auth-context))]
     (ensure-consent-identity! membership-id user-email)
     (ensure-consent-actor-unchanged! displayed-actor actor-id)
     (cond-> {:code code :clientId client-id :redirectUri redirect-uri
@@ -426,7 +426,7 @@
   (let [access-token  (.randomUUID crypto)
         membership-id (:membershipId record)
         tools         (vec (:tools record))
-        actor-id      (actor-scope/normalize-actor-id (:actorId record))
+        actor-id      (actor-acting/normalize-actor-id (:actorId record))
         token-value   (cond-> {:accessToken access-token :clientId client-id
                                :membershipId membership-id
                                :userEmail    (:userEmail record)
@@ -554,14 +554,14 @@
    A nil actor-id still enters a scope — one that says there is no actor. It has
    to: without it a credential read falls back to the process-global
    agent-context, and an actor-less token would borrow whatever actor a
-   concurrent agent turn is running as. See actor-scope/run-as!."
+   concurrent agent turn is running as. See actor-acting/run-as!."
   [^js server z tools actor-id]
   (doseq [^js tool (array-seq tools)]
     (when-let [name (some-> (aget tool "name") str str/trim not-empty)]
       (.registerTool server name
                      (tool-config-js z tool name)
                      (fn [params]
-                       (actor-scope/run-as! actor-id #(tool-execute! tool params)))))))
+                       (actor-acting/run-as! actor-id #(tool-execute! tool params)))))))
 
 (defn- granted-tools
   "The tools this token was granted, out of those its context can reach.

--- a/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
@@ -9,6 +9,7 @@
             [knoxx.backend.infra.auth.session :as auth-session]
             [knoxx.backend.infra.db.policy :as db-policy]
             [knoxx.backend.infra.routes.mcp.consent :as consent]
+            [knoxx.backend.infra.routes.mcp.params :as params]
             [knoxx.backend.infra.routes.mcp.transport :as transport]
             [knoxx.backend.domain.mcp.mcp-expose :as mcp-expose]
             [knoxx.backend.infra.stores.mongo-mcp-oauth :as mongo-mcp]
@@ -21,45 +22,9 @@
             ["zod" :refer [z]])
   (:require-macros [knoxx.backend.macros :refer [defroute]]))
 
-(declare typebox->zod-shape reply-header! http-error)
+(declare typebox->zod-shape reply-header!)
 
 (defonce ^:private mcp-sessions* (atom {}))
-
-(def ^:private RegisterClientBody
-  [:map
-   [:redirect-uris [:vector string?]]
-   [:client-name {:optional true} string?]])
-
-(def ^:private AuthorizeQuery
-  [:map
-   [:client-id string?]
-   [:redirect-uri string?]
-   [:state {:optional true} [:maybe string?]]
-   [:code-challenge string?]
-   [:code-challenge-method string?]
-   [:scope {:optional true} [:maybe string?]]])
-
-(def ^:private AuthorizeConfirmQuery
-  [:map
-   [:client-id string?]
-   [:redirect-uri string?]
-   [:state {:optional true} [:maybe string?]]
-   [:code-challenge string?]
-   [:code-challenge-method string?]
-   [:scope {:optional true} [:maybe string?]]
-   [:selected-tools [:vector string?]]])
-
-(def ^:private TokenExchangeBody
-  [:map
-   [:grant-type string?]
-   [:code string?]
-   [:code-verifier string?]
-   [:client-id string?]
-   [:redirect-uri string?]])
-
-(def ^:private RevokeTokenParams
-  [:map
-   [:token-id string?]])
 
 (defn- env [k default] (or (aget js/process.env k) default))
 
@@ -78,13 +43,6 @@
 (defn- pkce-challenge
   [^js crypto verifier]
   (base64url (-> (.createHash crypto "sha256") (.update (str verifier)) (.digest))))
-
-(defn- normalize-tool-selection
-  [raw]
-  (cond
-    (nil? raw) []
-    (array? raw) (mapv str (array-seq raw))
-    :else [(str raw)]))
 
 (defn- json-send! [reply status payload]
   (-> (.code reply status) (.send (clj->js payload))))
@@ -106,40 +64,13 @@
                  :scopes_supported         ["mcp:tools"]
                  :bearer_methods_supported ["header"]}]
     (when-not (law/valid-protected-resource-metadata? payload)
-      (throw (http-error 500 "metadata_unavailable"
+      (throw (params/http-error 500 "metadata_unavailable"
                          "protected resource metadata failed its contract")))
     payload))
 
 (defn- tool-execute! [^js tool params] (.execute tool "mcp" params nil nil nil))
 
 (defn- reply-header! [^js reply name value] (.header reply name value))
-
-;; Fastify's default error handler reads `statusCode` off the thrown object and
-;; falls back to 500. A bare ex-info keeps its status in ex-data, where Fastify
-;; cannot see it, so every client error here reported as 500. Stamp it where
-;; Fastify looks.
-(defn- http-error
-  ([status error detail]      (http-error status error detail nil))
-  ([status error detail data]
-   (let [e (ex-info detail (merge {:status status :error error :detail detail} data))]
-     (aset e "statusCode" status)
-     ;; And the code where a hijacked route looks. /mcp writes its own response,
-     ;; so it reads the error off the object rather than through Fastify — and
-     ;; ex-data is invisible from JS, so without this every refusal reported as
-     ;; mcp_post_failed and a client could not tell actor_reassigned from a
-     ;; crash.
-     (aset e "code" error)
-     e)))
-
-(defn- validation-detail [schema value]
-  (some-> (m/explain schema value) me/humanize pr-str))
-
-(defn- validate! [schema value {:keys [status error detail]}]
-  (if (m/validate schema value)
-    value
-    (throw (http-error (or status 400)
-                       (or error "invalid_request")
-                       (or detail (validation-detail schema value) "Invalid request")))))
 
 (defn- ^:async browser-auth-ctx!
   [req policy-db config]
@@ -172,75 +103,19 @@
         (do (aset req "bearerToken" token) (done))))))
 
 ;; ──────────────────────────────────────────────────────────────
-;; Parsers
-;; ──────────────────────────────────────────────────────────────
-
-(defn- parse-register-client-body [req]
-  (let [body   (or (aget req "body") (js/Object.))
-        value  {:redirect-uris (if (array? (aget body "redirect_uris"))
-                                 (mapv str (array-seq (aget body "redirect_uris")))
-                                 [])
-                :client-name (some-> (aget body "client_name") str)}
-        parsed (validate! RegisterClientBody value
-                          {:status 400 :error "invalid_client_metadata"
-                           :detail "redirect_uris is required"})]
-    (when (empty? (:redirect-uris parsed))
-      (throw (http-error 400 "invalid_client_metadata" "redirect_uris is required")))
-    parsed))
-
-(defn- parse-authorize-query [req]
-  (let [q (or (aget req "query") (js/Object.))]
-    (validate! AuthorizeQuery
-               {:client-id             (str (or (aget q "client_id") ""))
-                :redirect-uri          (str (or (aget q "redirect_uri") ""))
-                :state                 (when-let [s (aget q "state")] (str s))
-                :code-challenge        (str (or (aget q "code_challenge") ""))
-                :code-challenge-method (str (or (aget q "code_challenge_method") "S256"))
-                :scope                 (when-let [scope (aget q "scope")] (str scope))}
-               {:status 400 :error "invalid_request"})))
-
-(defn- parse-authorize-confirm-query [req]
-  (let [q (or (aget req "query") (js/Object.))]
-    (validate! AuthorizeConfirmQuery
-               {:client-id             (str (or (aget q "client_id") ""))
-                :redirect-uri          (str (or (aget q "redirect_uri") ""))
-                :state                 (when-let [s (aget q "state")] (str s))
-                :code-challenge        (str (or (aget q "code_challenge") ""))
-                :code-challenge-method (str (or (aget q "code_challenge_method") "S256"))
-                :scope                 (when-let [scope (aget q "scope")] (str scope))
-                :selected-tools        (normalize-tool-selection (aget q "tool"))}
-               {:status 400 :error "invalid_request"})))
-
-(defn- parse-token-exchange-body [req]
-  (let [body (or (aget req "body") (js/Object.))]
-    (validate! TokenExchangeBody
-               {:grant-type    (str (or (aget body "grant_type") (aget body "grantType") ""))
-                :code          (str (or (aget body "code") ""))
-                :code-verifier (str (or (aget body "code_verifier") (aget body "codeVerifier") ""))
-                :client-id     (str (or (aget body "client_id") (aget body "clientId") ""))
-                :redirect-uri  (str (or (aget body "redirect_uri") (aget body "redirectUri") ""))}
-               {:status 400 :error "invalid_request"})))
-
-(defn- parse-revoke-token-params [req]
-  (let [params (or (aget req "params") (js/Object.))]
-    (validate! RevokeTokenParams
-               {:token-id (str (or (aget params "tokenId") ""))}
-               {:status 400 :error "invalid_request"})))
-
-;; ──────────────────────────────────────────────────────────────
 ;; Business logic helpers
 ;; ──────────────────────────────────────────────────────────────
 
 (defn- ensure-oauth-request! [{:keys [client-id redirect-uri code-challenge code-challenge-method]}]
   (when (or (str/blank? client-id) (str/blank? redirect-uri)
             (str/blank? code-challenge) (not= code-challenge-method "S256"))
-    (throw (http-error 400 "invalid_request"
+    (throw (params/http-error 400 "invalid_request"
                        "Missing required OAuth parameters (client_id, redirect_uri, code_challenge, S256)"))))
 
 (defn- ensure-oauth-confirm-request! [{:keys [client-id redirect-uri code-challenge code-challenge-method]}]
   (when (or (str/blank? client-id) (str/blank? redirect-uri)
             (str/blank? code-challenge) (not= code-challenge-method "S256"))
-    (throw (http-error 400 "invalid_request" "Missing required OAuth parameters"))))
+    (throw (params/http-error 400 "invalid_request" "Missing required OAuth parameters"))))
 
 (defn- ^:async get-registered-client [client-id]
   (if (str/blank? (str client-id))
@@ -257,7 +132,7 @@
 
 (defn- ensure-redirect-uri-allowed! [client redirect-uri error-code]
   (when (and client (not (redirect-uri-allowed? client redirect-uri)))
-    (throw (http-error 400 error-code "redirect_uri not allowed for registered client"))))
+    (throw (params/http-error 400 error-code "redirect_uri not allowed for registered client"))))
 
 (defn- available-tools [runtime config auth-context]
   (or (mcp-expose/create-knoxx-custom-tools-js runtime config auth-context) (js/Array.)))
@@ -326,7 +201,7 @@
   (let [claimed (actor-scope/normalize-actor-id (aget token-record "actorId"))
         current (actor-scope/normalize-actor-id (authz/ctx-actor-id token-ctx))]
     (when-not (law/token-actor-honourable? claimed current)
-      (throw (http-error 403 "actor_reassigned"
+      (throw (params/http-error 403 "actor_reassigned"
                          (str "This token was authorized to act as " claimed
                               ", which is no longer this membership's actor."))))
     (when claimed current)))
@@ -416,7 +291,7 @@
 ;; preHandler-mode routes
 
 (defroute mcp-register-client! [crypto] "POST" "/api/mcp/oauth/register" []
-  (let [{:keys [redirect-uris client-name]} (parse-register-client-body request)
+  (let [{:keys [redirect-uris client-name]} (params/parse-register-client-body request)
         client-id (.randomUUID crypto)
         client    {:client_id                  client-id
                    :client_name                (or client-name "mcp-client")
@@ -429,11 +304,11 @@
       (await (mongo-mcp/set-client! client-id (js/JSON.stringify (clj->js client))))
       (json-send! reply 201 client)
       (catch :default err
-        (throw (http-error 500 "registration_failed" (or (.-message err) (str err))))))))
+        (throw (params/http-error 500 "registration_failed" (or (.-message err) (str err))))))))
 
 (defroute mcp-authorize-client! [base config runtime browser-auth-guard] "GET" "/api/mcp/oauth/authorize" [browser-auth-guard]
   (let [auth-context (aget request "authContext")
-        {:keys [client-id redirect-uri state code-challenge scope] :as params} (parse-authorize-query request)]
+        {:keys [client-id redirect-uri state code-challenge scope] :as params} (params/parse-authorize-query request)]
     (ensure-oauth-request! params)
     (let [client (await (get-registered-client client-id))]
       (ensure-redirect-uri-allowed! client redirect-uri "invalid_request")
@@ -447,59 +322,81 @@
                        :requested-scope (or scope "") :tools tools :selected selected})]
         (.send (reply-header! reply "content-type" "text/html; charset=utf-8") html)))))
 
+(defn- ensure-consent-identity!
+  "Refuse a confirmation whose session cannot carry an authorization.
+
+   The consent page tolerates a partly-resolved context so a render cannot
+   crash, but those empty-string fallbacks must never be minted: the code is
+   copied verbatim into the access token, and a token with a blank membership
+   carries no authorization identity while still being a valid bearer token.
+
+   org-slug is deliberately not required — it is descriptive rather than an
+   authorization key, and a membership without one is legitimate."
+  [membership-id user-email]
+  (when (or (str/blank? membership-id) (str/blank? user-email))
+    (throw (params/http-error 400 "missing_identity"
+                       "Session has no membership or user identity to authorize with"))))
+
+(defn- ensure-consent-actor-unchanged!
+  "Refuse when the membership's actor moved while the consent page was open.
+
+   Minting now would authorize an actor the user never saw, and every later call
+   would accept it, because it matches the membership. See
+   law/consent-actor-unchanged? for why the page's value is a witness rather
+   than identity."
+  [displayed-actor actor-id]
+  (when-not (law/consent-actor-unchanged? displayed-actor actor-id)
+    (let [named (fn [v] (or (not-empty (str/trim (str (or v "")))) "no actor"))]
+      (throw (params/http-error 400 "actor_changed"
+                         (str "This membership now acts as " (named actor-id)
+                              ", not " (named displayed-actor)
+                              " as shown. Reload the authorization page and review it."))))))
+
+(defn- authorization-code-payload
+  "The code record to persist for an approved consent.
+
+   The actor is read from the resolved context and never from the query: the
+   client is on the other side of a redirect it controls, so an actorId it
+   echoed back would be the client choosing its own identity. No grant is
+   evaluated here — a membership carries one actor — which is why
+   law/actor-grantable? is reached only through consent-actor-unchanged?, with
+   the membership's actor on one side and the displayed one on the other.
+
+   Normalized here rather than only in persist-access-token!, so the code record
+   and the token minted from it cannot hold two spellings of one actor."
+  [{:keys [code client-id redirect-uri code-challenge requested auth-context
+           displayed-actor]}]
+  (let [membership-id (str (or (authz/ctx-membership-id auth-context) ""))
+        user-email    (str (or (authz/ctx-user-email auth-context) ""))
+        org-slug      (str (or (authz/ctx-org-slug auth-context) ""))
+        actor-id      (actor-scope/normalize-actor-id (authz/ctx-actor-id auth-context))]
+    (ensure-consent-identity! membership-id user-email)
+    (ensure-consent-actor-unchanged! displayed-actor actor-id)
+    (cond-> {:code code :clientId client-id :redirectUri redirect-uri
+             :codeChallenge code-challenge :codeChallengeMethod "S256"
+             :tools requested
+             :membershipId membership-id :userEmail user-email :orgSlug org-slug
+             :createdAt (.toISOString (js/Date.))}
+      ;; Absent rather than blank when there is no actor. A blank would
+      ;; round-trip as an actor that exists and owns nothing.
+      actor-id (assoc :actorId actor-id))))
+
 (defroute mcp-authorize-confirm! [base crypto config runtime code-ttl token-ttl browser-auth-guard] "GET" "/api/mcp/oauth/authorize/confirm" [browser-auth-guard]
   (let [auth-context (aget request "authContext")
-        {:keys [client-id redirect-uri state code-challenge selected-tools] :as params}
-        (parse-authorize-confirm-query request)]
+        {:keys [client-id redirect-uri state code-challenge selected-tools
+                displayed-actor] :as params}
+        (params/parse-authorize-confirm-query request)]
     (ensure-oauth-confirm-request! params)
     (let [client (await (get-registered-client client-id))]
       (ensure-redirect-uri-allowed! client redirect-uri "invalid_request")
       (let [requested (requested-tools runtime config auth-context selected-tools)]
         (when (empty? requested)
-          (throw (http-error 400 "invalid_scope" "No valid tools selected")))
-        ;; Same CLJS-map accessors as the consent page; see the note there.
-        (let [membership-id (str (or (authz/ctx-membership-id auth-context) ""))
-              user-email    (str (or (authz/ctx-user-email auth-context) ""))
-              org-slug      (str (or (authz/ctx-org-slug auth-context) ""))
-              _ (when (or (str/blank? membership-id) (str/blank? user-email))
-                  ;; The empty-string fallbacks above exist so a partly-resolved
-                  ;; context cannot crash the render, but they must not be
-                  ;; minted into a credential: the code is copied verbatim into
-                  ;; the access token by persist-access-token!, and a token with
-                  ;; a blank membership carries no authorization identity while
-                  ;; still being a valid bearer token. Refuse instead.
-                  ;;
-                  ;; org-slug is deliberately not required — it is descriptive
-                  ;; rather than an authorization key, and a membership without
-                  ;; one is legitimate.
-                  (throw (http-error 400 "missing_identity"
-                                     "Session has no membership or user identity to authorize with")))
-              ;; No grant is evaluated here, and calling law/actor-grantable?
-              ;; with this value on both sides would only have tested for a
-              ;; blank while reading as a check. The actor is the membership's
-              ;; own by construction: it is read from the resolved context and
-              ;; never from the query, because the client is on the other side
-              ;; of a redirect it controls and an actorId it echoed back would
-              ;; be the client choosing its own identity.
-              ;;
-              ;; When a request may name a *different* actor, that is where
-              ;; law/actor-grantable? belongs — called with the membership's
-              ;; actor and the requested one.
-              ;;
-              ;; Normalized here rather than only in persist-access-token!, so
-              ;; the code record and the token minted from it cannot hold two
-              ;; spellings of the same actor.
-              actor-id      (actor-scope/normalize-actor-id (authz/ctx-actor-id auth-context))
-              code          (.randomUUID crypto)
-              payload       (cond-> {:code code :clientId client-id :redirectUri redirect-uri
-                                     :codeChallenge code-challenge :codeChallengeMethod "S256"
-                                     :tools requested
-                                     :membershipId membership-id :userEmail user-email :orgSlug org-slug
-                                     :createdAt (.toISOString (js/Date.))}
-                              ;; Absent rather than blank when there is no
-                              ;; actor. A blank would round-trip as an actor
-                              ;; that exists and owns nothing.
-                              actor-id (assoc :actorId actor-id))]
+          (throw (params/http-error 400 "invalid_scope" "No valid tools selected")))
+        (let [code    (.randomUUID crypto)
+              payload (authorization-code-payload
+                       {:code code :client-id client-id :redirect-uri redirect-uri
+                        :code-challenge code-challenge :requested requested
+                        :auth-context auth-context :displayed-actor displayed-actor})]
           (await (mongo-mcp/set-code! code (js/JSON.stringify (clj->js payload)) code-ttl))
           (let [redir (js/URL. redirect-uri)]
             (.set (.-searchParams redir) "code" code)
@@ -519,9 +416,9 @@
   ;; Whether the result admits the exchange is law's decision, so both rules
   ;; live in one pure place that every future caller shares.
   (when-not (law/code-bound-to? record client-id redirect-uri)
-    (throw (http-error 400 "invalid_grant" "Client/redirect mismatch")))
+    (throw (params/http-error 400 "invalid_grant" "Client/redirect mismatch")))
   (when-not (law/pkce-verified? record (pkce-challenge crypto code-verifier))
-    (throw (http-error 400 "invalid_grant" "PKCE verification failed"))))
+    (throw (params/http-error 400 "invalid_grant" "PKCE verification failed"))))
 
 (defn- ^:async persist-access-token!
   "Mint and store an access token from a claimed code record (a CLJS map)."
@@ -548,11 +445,11 @@
      :expires_in   token-ttl}))
 
 (defroute mcp-exchange-token! [crypto token-ttl] "POST" "/api/mcp/oauth/token" []
-  (let [{:keys [grant-type code code-verifier client-id redirect-uri]} (parse-token-exchange-body request)]
+  (let [{:keys [grant-type code code-verifier client-id redirect-uri]} (params/parse-token-exchange-body request)]
     (when (or (not= grant-type "authorization_code")
               (str/blank? code) (str/blank? code-verifier)
               (str/blank? client-id) (str/blank? redirect-uri))
-      (throw (http-error 400 "invalid_request" "Missing required token exchange parameters")))
+      (throw (params/http-error 400 "invalid_request" "Missing required token exchange parameters")))
     (let [client (await (get-registered-client client-id))]
       (ensure-redirect-uri-allowed! client redirect-uri "invalid_grant")
       ;; Validate against a peek, then claim. Single use is enforced by the
@@ -561,11 +458,11 @@
       ;; told the code is spent. The token is minted from the claimed record,
       ;; not the peeked one, so its contents cannot have changed in between.
       (let [peeked (await (mongo-mcp/peek-code! code))]
-        (when-not peeked (throw (http-error 400 "invalid_grant" "Unknown or expired code")))
+        (when-not peeked (throw (params/http-error 400 "invalid_grant" "Unknown or expired code")))
         (ensure-code-bindings! crypto peeked client-id redirect-uri code-verifier)
         (let [record (await (mongo-mcp/consume-code! code))]
           (when-not record
-            (throw (http-error 400 "invalid_grant" "Authorization code already used")))
+            (throw (params/http-error 400 "invalid_grant" "Authorization code already used")))
           (json-send! reply 200
                       (await (persist-access-token! crypto token-ttl client-id record))))))))
 
@@ -573,16 +470,16 @@
   (let [auth-context  (aget request "authContext")
         membership-id (str (or (authz/ctx-membership-id auth-context) ""))]
     (when (str/blank? membership-id)
-      (throw (http-error 400 "missing_membership" "No membership available for this session")))
+      (throw (params/http-error 400 "missing_membership" "No membership available for this session")))
     (let [records (await (mongo-mcp/list-tokens-for-membership! membership-id))]
       (json-send! reply 200 {:ok true :tokens (->> records (remove nil?) into-array)}))))
 
 (defroute mcp-revoke-user-token! [browser-auth-guard] "DELETE" "/api/mcp/tokens/:tokenId" [browser-auth-guard]
   (let [auth-context  (aget request "authContext")
-        {:keys [token-id]}    (parse-revoke-token-params request)
+        {:keys [token-id]}    (params/parse-revoke-token-params request)
         membership-id         (str (or (authz/ctx-membership-id auth-context) ""))]
     (when (or (str/blank? membership-id) (str/blank? token-id))
-      (throw (http-error 400 "invalid_request" "membership and tokenId are required")))
+      (throw (params/http-error 400 "invalid_request" "membership and tokenId are required")))
     ;; Scoped to the caller's membership. Deleting by token value alone let any
     ;; authenticated caller revoke someone else's token if they learned its
     ;; value — the listing route is per-membership, but nothing stopped a
@@ -592,7 +489,7 @@
     ;; token exists for anyone else.
     (let [revoked (await (mongo-mcp/delete-token-for-membership! token-id membership-id))]
       (when-not revoked
-        (throw (http-error 404 "not_found" "No such token for this membership")))
+        (throw (params/http-error 404 "not_found" "No such token for this membership")))
       (json-send! reply 200 {:ok true}))))
 
 (defroute mcp-handle-session! [base bearer-token-guard] "GET" "/mcp" [bearer-token-guard]
@@ -692,9 +589,9 @@
    client already has its response, and a teardown error must not replace it."
   [^js raw-res ^js server]
   (.once raw-res "close"
-         (fn []
+         (^:async fn []
            (try
-             (some-> (.close server) (.catch (fn [_] nil)))
+             (await (.close server))
              (catch :default _ nil)))))
 
 (defn- ^:async serve-mcp-post!

--- a/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
@@ -123,6 +123,12 @@
   ([status error detail data]
    (let [e (ex-info detail (merge {:status status :error error :detail detail} data))]
      (aset e "statusCode" status)
+     ;; And the code where a hijacked route looks. /mcp writes its own response,
+     ;; so it reads the error off the object rather than through Fastify — and
+     ;; ex-data is invisible from JS, so without this every refusal reported as
+     ;; mcp_post_failed and a client could not tell actor_reassigned from a
+     ;; crash.
+     (aset e "code" error)
      e)))
 
 (defn- validation-detail [schema value]
@@ -304,12 +310,18 @@
 (defn- call-actor-id
   "The actor this request's tool calls run as, or nil when it has none.
 
-   Resolved from the context the token maps to, not from the token, so a
-   membership whose actor was reassigned or cleared takes effect immediately
-   instead of at token expiry. The token's own copy is only consulted to refuse
-   a token that names a different actor than its membership now resolves to —
-   see law/token-actor-honourable? for why that is a refusal and not a silent
-   preference for one side."
+   A token gets an actor only if it *carries* one. A token that carries none —
+   every token minted before actors were carried — stays actor-less rather than
+   inheriting whatever its membership resolves to now: the actor decides which
+   Discord and Bluesky account a call posts from, and that token's consent
+   screen never named one. Granting it the membership's actor would hand an
+   already-issued credential a power its holder never agreed to, silently.
+
+   When the token does carry one, the value used is the membership's current
+   actor, and law/token-actor-honourable? has already refused the case where the
+   two disagree. So a reassignment is a refusal rather than a quiet switch, and
+   there is no window in which a token acts as an actor its membership has
+   dropped."
   [token-record token-ctx]
   (let [claimed (actor-scope/normalize-actor-id (aget token-record "actorId"))
         current (actor-scope/normalize-actor-id (authz/ctx-actor-id token-ctx))]
@@ -317,7 +329,7 @@
       (throw (http-error 403 "actor_reassigned"
                          (str "This token was authorized to act as " claimed
                               ", which is no longer this membership's actor."))))
-    current))
+    (when claimed current)))
 
 (defn- apply-zod-description [^js schema-node ^js schema-json]
   (let [description (some-> (aget schema-json "description") str str/trim not-empty)]
@@ -462,13 +474,22 @@
                   ;; one is legitimate.
                   (throw (http-error 400 "missing_identity"
                                      "Session has no membership or user identity to authorize with")))
-              ;; The actor comes from the resolved context, never from the
-              ;; query — the client is on the other side of a redirect it
-              ;; controls, so an actorId it echoed back would be its own choice
-              ;; of identity. law/actor-grantable? then confirms the membership
-              ;; may name it, which today means it must be the membership's own.
-              actor-id      (let [claimed (str (or (authz/ctx-actor-id auth-context) ""))]
-                              (when (law/actor-grantable? claimed claimed) claimed))
+              ;; No grant is evaluated here, and calling law/actor-grantable?
+              ;; with this value on both sides would only have tested for a
+              ;; blank while reading as a check. The actor is the membership's
+              ;; own by construction: it is read from the resolved context and
+              ;; never from the query, because the client is on the other side
+              ;; of a redirect it controls and an actorId it echoed back would
+              ;; be the client choosing its own identity.
+              ;;
+              ;; When a request may name a *different* actor, that is where
+              ;; law/actor-grantable? belongs — called with the membership's
+              ;; actor and the requested one.
+              ;;
+              ;; Normalized here rather than only in persist-access-token!, so
+              ;; the code record and the token minted from it cannot hold two
+              ;; spellings of the same actor.
+              actor-id      (actor-scope/normalize-actor-id (authz/ctx-actor-id auth-context))
               code          (.randomUUID crypto)
               payload       (cond-> {:code code :clientId client-id :redirectUri redirect-uri
                                      :codeChallenge code-challenge :codeChallengeMethod "S256"
@@ -655,6 +676,27 @@
          (filter (fn [^js t] (contains? allowed (str (aget t "name")))))
          into-array)))
 
+(defn- close-when-response-ends!
+  "Tear down a per-request MCP server once its response is finished.
+
+   Stateless mode requires a fresh server and transport per exchange, so without
+   this every POST leaves both behind for the process lifetime.
+
+   Closing the *server* is enough and closing the transport as well would be a
+   double close: in SDK 1.29 McpServer.close -> Server.close ->
+   Protocol.close -> transport.close.
+
+   Bound to the response's close event rather than run after handle-request!
+   returns, because a response may still be streaming when the handler resolves;
+   closing then would cut it off. Failures are swallowed deliberately — the
+   client already has its response, and a teardown error must not replace it."
+  [^js raw-res ^js server]
+  (.once raw-res "close"
+         (fn []
+           (try
+             (some-> (.close server) (.catch (fn [_] nil)))
+             (catch :default _ nil)))))
+
 (defn- ^:async serve-mcp-post!
   "Answer one authenticated MCP POST on a per-request server and transport."
   [{:keys [config runtime policy-db McpServer StreamableHTTPServerTransport z
@@ -665,6 +707,7 @@
         transport (new StreamableHTTPServerTransport (transport/stateless-transport-options))]
     (register-tools! server z (granted-tools runtime config token-ctx token-record) actor-id)
     (await (.connect server transport))
+    (close-when-response-ends! raw-res server)
     (transport/ensure-streamable-accept! request)
     (transport/handle-request! transport raw-req raw-res (aget request "body"))))
 

--- a/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
@@ -549,7 +549,12 @@
    resolves the actor without the MCP surface having to impersonate an agent
    spawn. The scope is entered per call rather than per request because the SDK
    invokes handlers itself: wrapping the request would put the awaits that
-   matter outside it."
+   matter outside it.
+
+   A nil actor-id still enters a scope — one that says there is no actor. It has
+   to: without it a credential read falls back to the process-global
+   agent-context, and an actor-less token would borrow whatever actor a
+   concurrent agent turn is running as. See actor-scope/run-as!."
   [^js server z tools actor-id]
   (doseq [^js tool (array-seq tools)]
     (when-let [name (some-> (aget tool "name") str str/trim not-empty)]

--- a/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
@@ -565,13 +565,13 @@
    to: without it a credential read falls back to the process-global
    agent-context, and an actor-less token would borrow whatever actor a
    concurrent agent turn is running as. See actor-acting/run-as!."
-  [^js server z tools actor-id]
+  [^js server z tools acting]
   (doseq [^js tool (array-seq tools)]
     (when-let [name (some-> (aget tool "name") str str/trim not-empty)]
       (.registerTool server name
                      (tool-config-js z tool name)
                      (fn [params]
-                       (actor-acting/run-as! actor-id #(tool-execute! tool params)))))))
+                       (actor-acting/run-as! acting #(tool-execute! tool params)))))))
 
 (defn- granted-tools
   "The tools this token was granted, out of those its context can reach.
@@ -614,10 +614,13 @@
   [{:keys [config runtime policy-db McpServer StreamableHTTPServerTransport z
            request raw-req raw-res token-record]}]
   (let [token-ctx (await (resolve-token-context! policy-db token-record))
-        actor-id  (call-actor-id token-record token-ctx)
+        acting    {:actor-id (call-actor-id token-record token-ctx)
+                   ;; From the resolved context, so the credential lookup is
+                   ;; scoped to the org this token belongs to.
+                   :org-id   (authz/ctx-org-id token-ctx)}
         server    (new McpServer (clj->js {:name "knoxx" :version "0.1.0"}))
         transport (new StreamableHTTPServerTransport (transport/stateless-transport-options))]
-    (register-tools! server z (granted-tools runtime config token-ctx token-record) actor-id)
+    (register-tools! server z (granted-tools runtime config token-ctx token-record) acting)
     (await (.connect server transport))
     (close-when-response-ends! raw-res server)
     (transport/ensure-streamable-accept! request)

--- a/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
@@ -4,7 +4,7 @@
             [malli.core :as m]
             [malli.error :as me]
             [knoxx.backend.shape.app-shapes :refer [route!]]
-            [knoxx.backend.domain.actor.acting :as actor-acting]
+            [knoxx.backend.infra.actor.acting :as actor-acting]
             [knoxx.backend.infra.auth.authz :as authz]
             [knoxx.backend.infra.auth.session :as auth-session]
             [knoxx.backend.infra.db.policy :as db-policy]
@@ -193,13 +193,15 @@
    already-issued credential a power its holder never agreed to, silently.
 
    When the token does carry one, the value used is the membership's current
-   actor, and law/token-actor-honourable? has already refused the case where the
-   two disagree. So a reassignment is a refusal rather than a quiet switch, and
+   stored binding — not ctx-actor-id, whose role-derived default is never nil and
+   would therefore let a cleared assignment keep matching — and
+   law/token-actor-honourable? has already refused the case where the two
+   disagree. So a reassignment is a refusal rather than a quiet switch, and
    there is no window in which a token acts as an actor its membership has
    dropped."
   [token-record token-ctx]
   (let [claimed (actor-acting/normalize-actor-id (aget token-record "actorId"))
-        current (actor-acting/normalize-actor-id (authz/ctx-actor-id token-ctx))]
+        current (actor-acting/normalize-actor-id (authz/ctx-actor-binding token-ctx))]
     (when-not (law/token-actor-honourable? claimed current)
       (throw (params/http-error 403 "actor_reassigned"
                          (str "This token was authorized to act as " claimed
@@ -362,6 +364,13 @@
    law/actor-grantable? is reached only through consent-actor-unchanged?, with
    the membership's actor on one side and the displayed one on the other.
 
+   Read from ctx-actor-binding, not ctx-actor-id. The latter falls back to a
+   role-derived default and is never nil, so it would mint every token an actor:
+   a membership with none assigned would get credential scope for system_admin
+   or workspace_user that nobody granted, and clearing the stored id could not
+   revoke it, because the default takes over and still matches. Only an actor
+   somebody actually assigned may authorize credentials.
+
    Normalized here rather than only in persist-access-token!, so the code record
    and the token minted from it cannot hold two spellings of one actor."
   [{:keys [code client-id redirect-uri code-challenge requested auth-context
@@ -369,7 +378,8 @@
   (let [membership-id (str (or (authz/ctx-membership-id auth-context) ""))
         user-email    (str (or (authz/ctx-user-email auth-context) ""))
         org-slug      (str (or (authz/ctx-org-slug auth-context) ""))
-        actor-id      (actor-acting/normalize-actor-id (authz/ctx-actor-id auth-context))]
+        actor-id      (actor-acting/normalize-actor-id
+                       (authz/ctx-actor-binding auth-context))]
     (ensure-consent-identity! membership-id user-email)
     (ensure-consent-actor-unchanged! displayed-actor actor-id)
     (cond-> {:code code :clientId client-id :redirectUri redirect-uri

--- a/backend/src/cljs/knoxx/backend/infra/routes/mcp/consent.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/mcp/consent.cljs
@@ -106,6 +106,13 @@
          "<input type=\"hidden\" name=\"code_challenge\" value=\"" (escape code-challenge) "\" />\n"
          "<input type=\"hidden\" name=\"code_challenge_method\" value=\"S256\" />\n"
          "<input type=\"hidden\" name=\"scope\" value=\""         (escape requested-scope) "\" />\n"
+         ;; A witness of what this page showed, not identity. The confirmation
+         ;; refuses when the membership's actor moved while the page was open —
+         ;; otherwise a token is minted for an actor the user never saw, and it
+         ;; is honoured, because it matches the membership. See
+         ;; law/consent-actor-unchanged?. Blank when there is no actor, and the
+         ;; confirmation treats blank-to-named as a change too.
+         "<input type=\"hidden\" name=\"actor_id\" value=\""      (escape actor-id) "\" />\n"
          "<h2>Capabilities</h2>\n"
          "<p>Select exactly which Knoxx tools this client can call. You can always revoke tokens later.</p>\n"
          "<div class=\"tools\">\n"

--- a/backend/src/cljs/knoxx/backend/infra/routes/mcp/consent.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/mcp/consent.cljs
@@ -87,7 +87,10 @@
                                             code-challenge requested-scope))
         user-email (str (or (authz/ctx-user-email auth-context) ""))
         org-slug   (str (or (authz/ctx-org-slug auth-context) ""))
-        actor-id   (str (or (authz/ctx-actor-id auth-context) ""))]
+        ;; The stored binding, not ctx-actor-id: the latter substitutes a
+        ;; role-derived default, so the no-actor warning below could never
+        ;; render and the page would name an actor nobody assigned.
+        actor-id   (str (or (authz/ctx-actor-binding auth-context) ""))]
     (str "<!doctype html>\n<html><head><meta charset=\"utf-8\" />\n"
          "<title>Authorize MCP Client</title>\n"
          "<style>" styles "</style></head><body><div class=\"box\">\n"

--- a/backend/src/cljs/knoxx/backend/infra/routes/mcp/consent.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/mcp/consent.cljs
@@ -1,0 +1,117 @@
+(ns knoxx.backend.infra.routes.mcp.consent
+  "The MCP authorization consent page.
+
+   String building only — no I/O, no policy. It renders what the route already
+   decided: which tools are on offer, which are pre-ticked, and which actor the
+   resulting token will act as. Extracted from infra.routes.mcp so that page
+   markup stops competing for room with the OAuth logic."
+  (:require [clojure.string :as str]
+            [knoxx.backend.infra.auth.authz :as authz]))
+
+(defn escape
+  "HTML-escape a value for interpolation into an attribute or text node."
+  [s]
+  (-> (str (or s ""))
+      (.replaceAll "&" "&amp;")
+      (.replaceAll "<" "&lt;")
+      (.replaceAll ">" "&gt;")
+      (.replaceAll "\"" "&quot;")))
+
+(def ^:private styles
+  (str "body{font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial;margin:24px;}"
+       ".box{max-width:920px;} .meta{color:#555;margin-bottom:12px;}"
+       ".tools{border:1px solid #ddd;border-radius:8px;padding:12px 16px;}"
+       ".actions{margin-top:18px;display:flex;gap:12px;}"
+       ".warn{border:1px solid #d9822b;background:#fff8f0;border-radius:8px;padding:10px 14px;margin:12px 0;color:#7a4a10;}"
+       "button{padding:8px 14px;border-radius:8px;border:1px solid #333;background:#111;color:#fff;cursor:pointer;}"
+       "a{color:#0b67d0;}"))
+
+(defn- tool-checkbox-html
+  [tools selected]
+  (->> (array-seq tools)
+       (map (fn [tool]
+              (let [n       (str (or (aget tool "name") ""))
+                    label   (str (or (aget tool "label") (aget tool "name") (aget tool "description") n))
+                    desc    (str (or (aget tool "description") ""))
+                    checked (if (contains? selected n) "checked" "")]
+                (str "\n        <label style=\"display:block; margin: 6px 0;\">\n"
+                     "          <input type=\"checkbox\" name=\"tool\" value=\"" (escape n) "\" " checked " />\n"
+                     "          <span style=\"font-weight:600;\">" (escape label) "</span>\n"
+                     "          <span style=\"color:#666;\">(" (escape n) ")</span>\n"
+                     "          <div style=\"color:#444; margin-left: 22px;\">" (escape desc) "</div>\n"
+                     "        </label>\n"))))
+       (str/join "\n")))
+
+(defn- actor-html
+  "How the page reports the actor the token will act as.
+
+   Shown rather than chosen: a membership carries exactly one actor, so there is
+   nothing to pick. It is still displayed, because it decides which account a
+   Discord or Bluesky call will post from, and that is not something to leave
+   implicit on a consent screen.
+
+   When there is no actor, say so and say what it costs. A token can still be
+   issued — the read/search tools need no credential — but every
+   credential-backed tool will fail at call time, and a user should learn that
+   here rather than from an error later."
+  [actor-id]
+  (if (str/blank? (str (or actor-id "")))
+    (str "<div class=\"warn\"><strong>No actor</strong> is bound to this session, so"
+         " tools that use stored credentials (Discord, Bluesky) will fail when called."
+         " Assign an actor to this membership in Admin → Actors first if you need them.</div>\n")
+    (str "<div><strong>Acting as:</strong> " (escape actor-id) "</div>\n")))
+
+(defn- confirm-url
+  [base client-id redirect-uri state code-challenge requested-scope]
+  (let [url (js/URL. "/api/mcp/oauth/authorize/confirm" base)]
+    (.set (.-searchParams url) "client_id" client-id)
+    (.set (.-searchParams url) "redirect_uri" redirect-uri)
+    (when state (.set (.-searchParams url) "state" state))
+    (.set (.-searchParams url) "code_challenge" code-challenge)
+    (.set (.-searchParams url) "code_challenge_method" "S256")
+    (when-not (str/blank? (str (or requested-scope "")))
+      (.set (.-searchParams url) "scope" requested-scope))
+    url))
+
+(defn page
+  "The consent page HTML.
+
+   The auth context is a CLJS map, so it must be read with the shared accessors
+   rather than aget. Reaching in with (aget ctx \"user\" \"email\") both missed
+   the value and threw outright — aget compiles to ctx[\"user\"][\"email\"], and
+   the intermediate is undefined, so the `or` fallback never got the chance to
+   run and the page 500'd."
+  [{:keys [base auth-context client-id redirect-uri state code-challenge
+           requested-scope tools selected]}]
+  (let [action     (.-pathname (confirm-url base client-id redirect-uri state
+                                            code-challenge requested-scope))
+        user-email (str (or (authz/ctx-user-email auth-context) ""))
+        org-slug   (str (or (authz/ctx-org-slug auth-context) ""))
+        actor-id   (str (or (authz/ctx-actor-id auth-context) ""))]
+    (str "<!doctype html>\n<html><head><meta charset=\"utf-8\" />\n"
+         "<title>Authorize MCP Client</title>\n"
+         "<style>" styles "</style></head><body><div class=\"box\">\n"
+         "<h1>Authorize MCP Client</h1>\n"
+         "<div class=\"meta\">\n"
+         "<div><strong>Client:</strong> "       (escape client-id)    "</div>\n"
+         "<div><strong>Redirect URI:</strong> " (escape redirect-uri) "</div>\n"
+         "<div><strong>User:</strong> "         (escape user-email)   "</div>\n"
+         "<div><strong>Org:</strong> "          (escape org-slug)     "</div>\n"
+         "</div>\n"
+         (actor-html actor-id)
+         "<form method=\"GET\" action=\"" (escape action) "\">\n"
+         "<input type=\"hidden\" name=\"client_id\" value=\""     (escape client-id)     "\" />\n"
+         "<input type=\"hidden\" name=\"redirect_uri\" value=\""   (escape redirect-uri)  "\" />\n"
+         "<input type=\"hidden\" name=\"state\" value=\""         (escape (or state "")) "\" />\n"
+         "<input type=\"hidden\" name=\"code_challenge\" value=\"" (escape code-challenge) "\" />\n"
+         "<input type=\"hidden\" name=\"code_challenge_method\" value=\"S256\" />\n"
+         "<input type=\"hidden\" name=\"scope\" value=\""         (escape requested-scope) "\" />\n"
+         "<h2>Capabilities</h2>\n"
+         "<p>Select exactly which Knoxx tools this client can call. You can always revoke tokens later.</p>\n"
+         "<div class=\"tools\">\n"
+         (tool-checkbox-html tools selected)
+         "</div>\n"
+         "<div class=\"actions\">\n"
+         "<button type=\"submit\">Authorize</button>\n"
+         "<a href=\"/\">Cancel</a>\n"
+         "</div></form></div></body></html>")))

--- a/backend/src/cljs/knoxx/backend/infra/routes/mcp/params.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/mcp/params.cljs
@@ -92,10 +92,18 @@
 
 (defn parse-register-client-body [req]
   (let [body   (or (aget req "body") (js/Object.))
-        value  {:redirect-uris (if (array? (aget body "redirect_uris"))
-                                 (mapv str (array-seq (aget body "redirect_uris")))
-                                 [])
-                :client-name (some-> (aget body "client_name") str)}
+        ;; :client-name is omitted rather than set to nil when absent.
+        ;; {:optional true} governs whether the key must be present, not what a
+        ;; present value may be — so a nil under a `string?` entry fails, and a
+        ;; registration that simply did not send client_name was rejected as
+        ;; invalid_client_metadata. Omitting keeps the schema honest instead of
+        ;; widening it to [:maybe string?], which would legitimise a nil name.
+        name   (some-> (aget body "client_name") str str/trim not-empty)
+        value  (cond-> {:redirect-uris (if (array? (aget body "redirect_uris"))
+                                         (mapv str (array-seq (aget body "redirect_uris")))
+                                         [])}
+                 ;; A whitespace-only name is not a name either.
+                 name (assoc :client-name name))
         parsed (validate! RegisterClientBody value
                           {:status 400 :error "invalid_client_metadata"
                            :detail "redirect_uris is required"})]

--- a/backend/src/cljs/knoxx/backend/infra/routes/mcp/params.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/mcp/params.cljs
@@ -1,0 +1,145 @@
+(ns knoxx.backend.infra.routes.mcp.params
+  "Request shapes for the MCP OAuth endpoints, their parsers, and the HTTP error
+   a failed parse raises.
+
+   Every shape is Malli and every parser validates before returning, so a route
+   body never sees a half-formed request. Extracted from infra.routes.mcp with
+   http-error, because the parsers and the error they throw are one concern and
+   splitting them would have left a cycle."
+  (:require [clojure.string :as str]
+            [malli.core :as m]
+            [malli.error :as me]))
+
+(def RegisterClientBody
+  [:map
+   [:redirect-uris [:vector string?]]
+   [:client-name {:optional true} string?]])
+
+(def AuthorizeQuery
+  [:map
+   [:client-id string?]
+   [:redirect-uri string?]
+   [:state {:optional true} [:maybe string?]]
+   [:code-challenge string?]
+   [:code-challenge-method string?]
+   [:scope {:optional true} [:maybe string?]]])
+
+(def AuthorizeConfirmQuery
+  [:map
+   [:client-id string?]
+   [:redirect-uri string?]
+   [:state {:optional true} [:maybe string?]]
+   [:code-challenge string?]
+   [:code-challenge-method string?]
+   [:scope {:optional true} [:maybe string?]]
+   [:selected-tools [:vector string?]]
+   ;; What the consent page displayed as the acting actor. Blank is legitimate —
+   ;; a membership may have none. Checked against the context, never trusted as
+   ;; identity; see law/consent-actor-unchanged?.
+   [:displayed-actor {:optional true} [:maybe string?]]])
+
+(def TokenExchangeBody
+  [:map
+   [:grant-type string?]
+   [:code string?]
+   [:code-verifier string?]
+   [:client-id string?]
+   [:redirect-uri string?]])
+
+(def RevokeTokenParams
+  [:map
+   [:token-id string?]])
+
+
+;; Fastify's default error handler reads `statusCode` off the thrown object and
+;; falls back to 500. A bare ex-info keeps its status in ex-data, where Fastify
+;; cannot see it, so every client error here reported as 500. Stamp it where
+;; Fastify looks.
+(defn http-error
+  ([status error detail]      (http-error status error detail nil))
+  ([status error detail data]
+   (let [e (ex-info detail (merge {:status status :error error :detail detail} data))]
+     (aset e "statusCode" status)
+     ;; And the code where a hijacked route looks. /mcp writes its own response,
+     ;; so it reads the error off the object rather than through Fastify — and
+     ;; ex-data is invisible from JS, so without this every refusal reported as
+     ;; mcp_post_failed and a client could not tell actor_reassigned from a
+     ;; crash.
+     (aset e "code" error)
+     e)))
+
+(defn- validation-detail [schema value]
+  (some-> (m/explain schema value) me/humanize pr-str))
+
+(defn- validate! [schema value {:keys [status error detail]}]
+  (if (m/validate schema value)
+    value
+    (throw (http-error (or status 400)
+                       (or error "invalid_request")
+                       (or detail (validation-detail schema value) "Invalid request")))))
+
+
+(defn- normalize-tool-selection
+  [raw]
+  (cond
+    (nil? raw) []
+    (array? raw) (mapv str (array-seq raw))
+    :else [(str raw)]))
+
+;; ──────────────────────────────────────────────────────────────
+;; Parsers
+;; ──────────────────────────────────────────────────────────────
+
+(defn parse-register-client-body [req]
+  (let [body   (or (aget req "body") (js/Object.))
+        value  {:redirect-uris (if (array? (aget body "redirect_uris"))
+                                 (mapv str (array-seq (aget body "redirect_uris")))
+                                 [])
+                :client-name (some-> (aget body "client_name") str)}
+        parsed (validate! RegisterClientBody value
+                          {:status 400 :error "invalid_client_metadata"
+                           :detail "redirect_uris is required"})]
+    (when (empty? (:redirect-uris parsed))
+      (throw (http-error 400 "invalid_client_metadata" "redirect_uris is required")))
+    parsed))
+
+(defn parse-authorize-query [req]
+  (let [q (or (aget req "query") (js/Object.))]
+    (validate! AuthorizeQuery
+               {:client-id             (str (or (aget q "client_id") ""))
+                :redirect-uri          (str (or (aget q "redirect_uri") ""))
+                :state                 (when-let [s (aget q "state")] (str s))
+                :code-challenge        (str (or (aget q "code_challenge") ""))
+                :code-challenge-method (str (or (aget q "code_challenge_method") "S256"))
+                :scope                 (when-let [scope (aget q "scope")] (str scope))}
+               {:status 400 :error "invalid_request"})))
+
+(defn parse-authorize-confirm-query [req]
+  (let [q (or (aget req "query") (js/Object.))]
+    (validate! AuthorizeConfirmQuery
+               {:client-id             (str (or (aget q "client_id") ""))
+                :redirect-uri          (str (or (aget q "redirect_uri") ""))
+                :state                 (when-let [s (aget q "state")] (str s))
+                :code-challenge        (str (or (aget q "code_challenge") ""))
+                :code-challenge-method (str (or (aget q "code_challenge_method") "S256"))
+                :scope                 (when-let [scope (aget q "scope")] (str scope))
+                :selected-tools        (normalize-tool-selection (aget q "tool"))
+                :displayed-actor       (str (or (aget q "actor_id") ""))}
+               {:status 400 :error "invalid_request"})))
+
+(defn parse-token-exchange-body [req]
+  (let [body (or (aget req "body") (js/Object.))]
+    (validate! TokenExchangeBody
+               {:grant-type    (str (or (aget body "grant_type") (aget body "grantType") ""))
+                :code          (str (or (aget body "code") ""))
+                :code-verifier (str (or (aget body "code_verifier") (aget body "codeVerifier") ""))
+                :client-id     (str (or (aget body "client_id") (aget body "clientId") ""))
+                :redirect-uri  (str (or (aget body "redirect_uri") (aget body "redirectUri") ""))}
+               {:status 400 :error "invalid_request"})))
+
+(defn parse-revoke-token-params [req]
+  (let [params (or (aget req "params") (js/Object.))]
+    (validate! RevokeTokenParams
+               {:token-id (str (or (aget params "tokenId") ""))}
+               {:status 400 :error "invalid_request"})))
+

--- a/backend/src/cljs/knoxx/backend/infra/routes/mcp/transport.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/mcp/transport.cljs
@@ -1,0 +1,92 @@
+(ns knoxx.backend.infra.routes.mcp.transport
+  "The MCP Streamable HTTP transport boundary.
+
+   Everything here is about the wire, not about authorization: reading a bearer
+   token off a request, naming the session, making the SDK's transport behave,
+   and answering an unauthenticated caller with the challenge RFC 9728 expects.
+   Extracted from infra.routes.mcp so the OAuth flow and the transport quirks
+   stop sharing one file.
+
+   Nothing here decides who may call anything."
+  (:require [clojure.string :as str]))
+
+(defn bearer-token
+  "The bearer credential on a request, or nil."
+  [req]
+  (let [raw (str (or (some-> req (aget "headers") (aget "authorization")) ""))
+        m   (.match raw (js/RegExp. "^Bearer\\s+(.+)$" "i"))]
+    (when m (str/trim (aget m 1)))))
+
+(defn resolve-session-id
+  "The MCP session id, from the header or the query, or nil."
+  [req]
+  (let [headers   (or (aget req "headers") (js/Object.))
+        header-id (aget headers "mcp-session-id")
+        q         (or (aget req "query") (js/Object.))
+        query-id  (aget q "sessionId")]
+    (cond
+      (and (string? header-id) (not (str/blank? header-id))) header-id
+      (and (string? query-id) (not (str/blank? query-id)))   query-id
+      :else nil)))
+
+(defn protected-resource-metadata-url [base]
+  (.toString (js/URL. "/.well-known/oauth-protected-resource" base)))
+
+(defn www-authenticate-challenge
+  "The WWW-Authenticate value that points a client at our resource metadata."
+  [base]
+  (str "Bearer realm=\"mcp\", resource_metadata=\""
+       (protected-resource-metadata-url base) "\""))
+
+(defn challenge-unauthorized!
+  "Refuse via Fastify's reply object."
+  [^js reply base]
+  (-> (.header reply "WWW-Authenticate" (www-authenticate-challenge base))
+      (.code 401)
+      (.send "Unauthorized")))
+
+(defn unauthorized!
+  "Refuse via the raw response, for a route that has hijacked the reply."
+  [base ^js raw-res]
+  (.writeHead raw-res 401 (clj->js {"WWW-Authenticate" (www-authenticate-challenge base)
+                                    "Content-Type"     "text/plain"}))
+  (.end raw-res "Unauthorized"))
+
+(defn stateless-transport-options
+  "Options that actually select the MCP SDK's stateless mode.
+
+   The key must be ABSENT, not undefined. (clj->js {:sessionIdGenerator
+   js/undefined}) emits {sessionIdGenerator: null}, and the SDK selects
+   stateless only on === undefined — so null selected *stateful* mode, where
+   everything after initialize is rejected with \"Server not initialized\" and a
+   client sees no tools. SDK 1.18/1.24/1.29/1.30 all read null as stateful."
+  []
+  #js {})
+
+(defn handle-request!
+  ([^js t req reply]      (.handleRequest t req reply))
+  ([^js t req reply body] (.handleRequest t req reply body)))
+
+(defn ensure-streamable-accept!
+  "Force the Accept header the SDK requires, in both places it reads it.
+
+   A client that sends only application/json is otherwise rejected by the
+   transport, so this normalizes rather than refuses. rawHeaders is rewritten as
+   well as headers because the SDK reads whichever it reaches first."
+  [req]
+  (let [raw          (aget req "raw")
+        headers      (or (aget raw "headers") (js/Object.))
+        raw-headers  (or (aget raw "rawHeaders") (js/Array.))
+        accept-value "application/json, text/event-stream"
+        accept       (str/lower-case (str (or (aget headers "accept") "")))
+        has-json?    (str/includes? accept "application/json")
+        has-sse?     (str/includes? accept "text/event-stream")]
+    (when (or (str/blank? accept) (not has-json?) (not has-sse?))
+      (aset headers "accept" accept-value)
+      (aset raw "headers" headers)
+      (let [filtered (->> (partition 2 (array-seq raw-headers))
+                          (remove (fn [[k _]] (= "accept" (str/lower-case (str k)))))
+                          (mapcat identity)
+                          vec)]
+        (aset raw "rawHeaders" (clj->js (conj filtered "accept" accept-value)))))
+    req))

--- a/backend/src/cljs/knoxx/backend/infra/stores/mongo_policy_actor_credentials.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/stores/mongo_policy_actor_credentials.cljs
@@ -132,14 +132,44 @@
           (filterv #(not (str/blank? (str (:actor_id %)))))
           vec))))
 
+(defn ^:async resolve-actor-membership!
+  "The membership an actor id names, scoped to an org when one is given.
+
+   actor_id is NOT unique across orgs — knoxx_memberships indexes it
+   non-uniquely — so an unscoped findOne returns an arbitrary org's membership
+   and, downstream, that org's credentials. Callers that know which org the
+   request belongs to must say so.
+
+   When no org is given and the id is ambiguous this throws rather than
+   choosing. Failing closed is the only safe reading: the alternative is
+   returning one tenant's credential to another, silently and unrepeatably."
+  [db actor-id org-id]
+  (let [memberships (.collection db "knoxx_memberships")
+        org         (some-> org-id str str/trim not-empty)
+        query       (cond-> {"actor_id" (str actor-id)}
+                      org (assoc "org_id" org))
+        matches     (keywordize (await (.toArray (.find memberships (clj->js query)))))]
+    (cond
+      (empty? matches) nil
+      (= 1 (count matches)) (first matches)
+      org (first matches)
+      :else (throw (js/Error.
+                    (str "Actor " actor-id " names " (count matches)
+                         " memberships across orgs; an org must be given to"
+                         " resolve its credentials."))))))
+
 (defn ^:async get-actor-credential-by-actor-and-provider!
   "Single active credential for an actor + provider, joined with memberships + orgs.
    Mirrors the PG actor-credential-select-query: ... WHERE m.actor_id = ?
-   AND ac.provider = ? AND ac.status = 'active' ... LIMIT 1."
-  ([actor-id provider] (get-actor-credential-by-actor-and-provider! (mongo-client/get-db) actor-id provider))
-  ([db actor-id provider]
-   (let [memberships (.collection db "knoxx_memberships")
-         membership (keywordize (await (.findOne memberships #js {"actor_id" (str actor-id)})))]
+   AND ac.provider = ? AND ac.status = 'active' ... LIMIT 1.
+
+   org-id scopes the membership lookup. Pass it whenever the caller knows which
+   org the request belongs to; see resolve-actor-membership! for why omitting it
+   is only safe when the actor id is unambiguous."
+  ([actor-id provider] (get-actor-credential-by-actor-and-provider! (mongo-client/get-db) actor-id provider nil))
+  ([db actor-id provider] (get-actor-credential-by-actor-and-provider! db actor-id provider nil))
+  ([db actor-id provider org-id]
+   (let [membership (await (resolve-actor-membership! db actor-id org-id))]
      (when membership
        (let [coll (credentials-coll db)
              cursor (.find coll #js {"user_id" (:user_id membership)

--- a/backend/src/cljs/knoxx/backend/infra/stores/mongo_policy_actor_credentials.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/stores/mongo_policy_actor_credentials.cljs
@@ -31,6 +31,7 @@
     [knoxx.backend.infra.system-instance :as system-instance]))
 
 (def ACTOR_CREDENTIALS_COLLECTION "knoxx_actor_credentials")
+(def ^:private MEMBERSHIPS_COLLECTION "knoxx_memberships")
 
 (defn- credentials-coll [db] (.collection db ACTOR_CREDENTIALS_COLLECTION))
 
@@ -133,43 +134,66 @@
           vec))))
 
 (defn ^:async resolve-actor-membership!
-  "The membership an actor id names, scoped to an org when one is given.
+  "The membership an actor id names, or nil.
 
-   actor_id is NOT unique across orgs — knoxx_memberships indexes it
-   non-uniquely — so an unscoped findOne returns an arbitrary org's membership
-   and, downstream, that org's credentials. Callers that know which org the
-   request belongs to must say so.
+   Takes {:actor-id, :org-id, :membership-id}; the last two are optional and both
+   narrow the answer. Never chooses between candidates: an actor id that names
+   more than one membership throws, because the alternative is returning one
+   member's user_id and reading their Discord or Bluesky secret for somebody
+   else's request — silently, unrepeatably, and identically to success.
 
-   When no org is given and the id is ambiguous this throws rather than
-   choosing. Failing closed is the only safe reading: the alternative is
-   returning one tenant's credential to another, silently and unrepeatably."
-  [db actor-id org-id]
-  (let [memberships (.collection db "knoxx_memberships")
+   Why choosing is unsafe at every level of scoping: knoxx_memberships is unique
+   only on (user_id, org_id). actor_id carries a plain lookup index and
+   set-membership-actor-id! writes whatever it is given, so two memberships in
+   *one* org can share an actor id. Scoping to the org narrows the ambiguity
+   without removing it.
+
+   :membership-id is the exact answer and the one to prefer. It is unique, an MCP
+   token carries it, and using it turns a search into a lookup. The actor is then
+   verified against that membership rather than used to find it: a token whose
+   actor and membership disagree is refused, not reconciled."
+  [db {:keys [actor-id org-id membership-id]}]
+  (let [memberships (.collection db MEMBERSHIPS_COLLECTION)
+        actor       (some-> actor-id str str/trim not-empty)
         org         (some-> org-id str str/trim not-empty)
-        query       (cond-> {"actor_id" (str actor-id)}
-                      org (assoc "org_id" org))
-        matches     (keywordize (await (.toArray (.find memberships (clj->js query)))))]
-    (cond
-      (empty? matches) nil
-      (= 1 (count matches)) (first matches)
-      org (first matches)
-      :else (throw (js/Error.
-                    (str "Actor " actor-id " names " (count matches)
-                         " memberships across orgs; an org must be given to"
-                         " resolve its credentials."))))))
+        membership  (some-> membership-id str str/trim not-empty)]
+    (when actor
+      (if membership
+        (let [doc (keywordize (await (.findOne memberships #js {"membership_id" membership})))]
+          (when doc
+            (when-not (= (str (:actor_id doc)) actor)
+              (throw (js/Error.
+                      (str "Membership " membership " acts as "
+                           (or (not-empty (str (:actor_id doc))) "no actor")
+                           ", not " actor
+                           "; refusing to resolve credentials for a mismatch."))))
+            doc))
+        (let [query   (cond-> {"actor_id" actor}
+                        org (assoc "org_id" org))
+              matches (keywordize (await (.toArray (.find memberships (clj->js query)))))]
+          (cond
+            (empty? matches)      nil
+            (= 1 (count matches)) (first matches)
+            :else
+            (throw (js/Error.
+                    (str "Actor " actor " names " (count matches) " memberships"
+                         (if org (str " in org " org) " across orgs")
+                         "; a membership id is required to resolve its"
+                         " credentials unambiguously.")))))))))
 
 (defn ^:async get-actor-credential-by-actor-and-provider!
   "Single active credential for an actor + provider, joined with memberships + orgs.
    Mirrors the PG actor-credential-select-query: ... WHERE m.actor_id = ?
    AND ac.provider = ? AND ac.status = 'active' ... LIMIT 1.
 
-   org-id scopes the membership lookup. Pass it whenever the caller knows which
-   org the request belongs to; see resolve-actor-membership! for why omitting it
-   is only safe when the actor id is unambiguous."
+   scope narrows the membership lookup: {:org-id, :membership-id}. Pass the
+   membership id whenever the caller has one — it is exact — and the org
+   otherwise. See resolve-actor-membership! for why an unnarrowed lookup refuses
+   an ambiguous actor rather than choosing."
   ([actor-id provider] (get-actor-credential-by-actor-and-provider! (mongo-client/get-db) actor-id provider nil))
-  ([db actor-id provider] (get-actor-credential-by-actor-and-provider! db actor-id provider nil))
-  ([db actor-id provider org-id]
-   (let [membership (await (resolve-actor-membership! db actor-id org-id))]
+  ([db actor-id provider scope]
+   (let [membership (await (resolve-actor-membership!
+                            db (assoc (or scope {}) :actor-id actor-id)))]
      (when membership
        (let [coll (credentials-coll db)
              cursor (.find coll #js {"user_id" (:user_id membership)

--- a/backend/src/cljs/knoxx/backend/law/mcp_oauth.cljs
+++ b/backend/src/cljs/knoxx/backend/law/mcp_oauth.cljs
@@ -52,6 +52,47 @@
          (not (str/blank? actual))
          (= expected actual))))
 
+(defn actor-grantable?
+  "True when a membership may authorize a token to act as this actor.
+
+   Today a membership carries exactly one actor, so the only grantable actor is
+   its own. That is a policy statement, not a limitation of the data: a
+   membership is the thing an authenticated session resolves to, and nothing in
+   the policy DB says which *other* actors a user may assume. Until such a
+   grant exists, the honest rule is identity.
+
+   Kept as a named rule rather than an inline `=` so that widening it later is
+   one edit in law with one place to test, instead of a search for every
+   comparison. Both arguments must name an actor: a blank on either side is not
+   a match, so a context that failed to resolve an actor cannot authorize one.
+
+   Deliberately not an authorization *decision* about tools — this says only
+   which actor may be named, never what that actor may do."
+  [membership-actor-id requested-actor-id]
+  (let [own       (str/trim (str (or membership-actor-id "")))
+        requested (str/trim (str (or requested-actor-id "")))]
+    (and (not (str/blank? own))
+         (not (str/blank? requested))
+         (= own requested))))
+
+(defn token-actor-honourable?
+  "True when a presented token's actor is still the one its membership resolves to.
+
+   Re-checked on every call rather than trusted from the token, because the two
+   can drift: a membership's actor_id can be reassigned after a token is minted,
+   and the token is a bearer credential that outlives that edit. Honouring the
+   token's copy would let a revoked or reassigned identity keep reading the old
+   actor's credentials for the rest of the token's lifetime.
+
+   A token carrying no actor is honourable — it simply has none, and the
+   credential read will fail on the missing actor with a message that says so.
+   That keeps tokens minted before actors were carried working for every tool
+   that needs no credential, rather than invalidating them all at once."
+  [token-actor-id membership-actor-id]
+  (let [claimed (str/trim (str (or token-actor-id "")))]
+    (or (str/blank? claimed)
+        (actor-grantable? membership-actor-id claimed))))
+
 (def ProtectedResourceMetadata
   "RFC 9728 protected resource metadata, as served to an unauthenticated client.
 

--- a/backend/src/cljs/knoxx/backend/law/mcp_oauth.cljs
+++ b/backend/src/cljs/knoxx/backend/law/mcp_oauth.cljs
@@ -75,6 +75,35 @@
          (not (str/blank? requested))
          (= own requested))))
 
+(defn consent-actor-unchanged?
+  "True when the actor a consent page displayed is still the membership's actor.
+
+   Guards the window between rendering the page and clicking Authorize. An admin
+   can reassign or clear a membership's actor in that window, and the
+   confirmation recomputes the actor from a fresh context — so without this a
+   token is minted for an actor the page never showed, and because later calls
+   only compare the token against the membership's *current* actor, that token is
+   then honoured for credential-backed tools. The user consented to posting as
+   one account and got another.
+
+   The displayed value reaches this from a form field, so it is client-controlled
+   and is treated as a *witness of what was shown*, never as identity. The actor
+   actually minted is always the one the context resolved. A client that forges a
+   match therefore gains nothing — a match asserts \"nothing changed\", which is
+   either true or causes the mismatch it was trying to hide. It can only cause a
+   refusal, never an escalation.
+
+   Both blank is unchanged: a membership with no actor renders the page's
+   no-actor warning, and consenting to that is legitimate. Blank on one side only
+   is a change — an actor appearing is as much a change as one being replaced,
+   because the page warned that credential-backed tools would fail."
+  [displayed-actor-id membership-actor-id]
+  (let [shown (str/trim (str (or displayed-actor-id "")))
+        now   (str/trim (str (or membership-actor-id "")))]
+    (if (and (str/blank? shown) (str/blank? now))
+      true
+      (actor-grantable? now shown))))
+
 (defn token-actor-honourable?
   "True when a presented token's actor is still the one its membership resolves to.
 

--- a/backend/src/cljs/knoxx/backend/law/mcp_oauth.cljs
+++ b/backend/src/cljs/knoxx/backend/law/mcp_oauth.cljs
@@ -86,12 +86,19 @@
    then honoured for credential-backed tools. The user consented to posting as
    one account and got another.
 
-   The displayed value reaches this from a form field, so it is client-controlled
-   and is treated as a *witness of what was shown*, never as identity. The actor
-   actually minted is always the one the context resolved. A client that forges a
-   match therefore gains nothing — a match asserts \"nothing changed\", which is
-   either true or causes the mismatch it was trying to hide. It can only cause a
-   refusal, never an escalation.
+   **Scope, stated precisely: this is a race guard, not a CSRF defence.** The
+   displayed value reaches this from a form field, so a hostile client can send
+   whatever it likes — including the membership's current actor, which passes.
+   What it cannot do is escalate through this rule: the actor minted is always
+   the one the context resolved, so a forged match asserts \"nothing changed\",
+   which is either true or is the mismatch it was hiding.
+
+   So this stops the benign case — an admin reassigning the actor while a page
+   sits open — and does nothing against a crafted confirm URL. That is a
+   separate and larger hole: /authorize/confirm is a GET that mints a code from
+   a session cookie with no server-side consent state, so a crafted URL can mint
+   a code for tools no page ever displayed, actor or not. It predates this rule
+   and is not fixed by it. See knoxx-mcp-consent-server-side-state.
 
    Both blank is unchanged: a membership with no actor renders the page's
    no-actor warning, and consenting to that is legitimate. Blank on one side only

--- a/backend/test/cljs/knoxx/backend/actor_credential_org_scope_test.cljs
+++ b/backend/test/cljs/knoxx/backend/actor_credential_org_scope_test.cljs
@@ -20,12 +20,15 @@
   (every? (fn [[k v]] (= (get doc k) v)) (js->clj query)))
 
 (defn- collection-double
-  "A collection handle exposing only find/toArray over fixed documents."
+  "A collection handle exposing find/toArray and findOne over fixed documents."
   [docs]
-  #js {:find (fn [query]
-               #js {:toArray (fn []
-                               (js/Promise.resolve
-                                (clj->js (filterv #(matches? query %) docs))))})})
+  #js {:find    (fn [query]
+                  #js {:toArray (fn []
+                                  (js/Promise.resolve
+                                   (clj->js (filterv #(matches? query %) docs))))})
+       :findOne (fn [query]
+                  (js/Promise.resolve
+                   (some-> (first (filterv #(matches? query %) docs)) clj->js)))})
 
 (defn- db-double
   [memberships]
@@ -40,8 +43,8 @@
 
 (deftest ^:async an-org-selects-its-own-membership
   (testing "each org resolves to its own membership, not to whichever is first"
-    (let [a (await (store/resolve-actor-membership! (db-double two-orgs) "open_hax" "org-a"))
-          b (await (store/resolve-actor-membership! (db-double two-orgs) "open_hax" "org-b"))]
+    (let [a (await (store/resolve-actor-membership! (db-double two-orgs) {:actor-id "open_hax" :org-id "org-a"}))
+          b (await (store/resolve-actor-membership! (db-double two-orgs) {:actor-id "open_hax" :org-id "org-b"}))]
       (is (= "user-a" (:user_id a)))
       (is (= "user-b" (:user_id b)))
       (is (not= (:user_id a) (:user_id b))
@@ -51,20 +54,68 @@
   (testing "returning an arbitrary tenant's membership is the bug; refusing is
             the only safe reading"
     (is (thrown? js/Error
-                 (await (store/resolve-actor-membership! (db-double two-orgs) "open_hax" nil))))))
+                 (await (store/resolve-actor-membership! (db-double two-orgs) {:actor-id "open_hax"}))))))
 
 (deftest ^:async an-unambiguous-actor-resolves-without-an-org
   (testing "the agent-spawn path passes no org and must keep working"
     (let [one [{"actor_id" "open_hax" "org_id" "org-a" "user_id" "user-a"}]
-          m   (await (store/resolve-actor-membership! (db-double one) "open_hax" nil))]
+          m   (await (store/resolve-actor-membership! (db-double one) {:actor-id "open_hax"}))]
       (is (= "user-a" (:user_id m))))))
 
 (deftest ^:async an-unknown-actor-resolves-to-nothing
-  (is (nil? (await (store/resolve-actor-membership! (db-double two-orgs) "nobody" nil))))
-  (is (nil? (await (store/resolve-actor-membership! (db-double two-orgs) "open_hax" "org-c")))
+  (is (nil? (await (store/resolve-actor-membership! (db-double two-orgs) {:actor-id "nobody"}))))
+  (is (nil? (await (store/resolve-actor-membership! (db-double two-orgs) {:actor-id "open_hax" :org-id "org-c"})))
       "an actor that exists, but not in this org"))
 
 (deftest ^:async a-blank-org-is-treated-as-no-org
   (testing "so it cannot be used to smuggle past the ambiguity check"
     (is (thrown? js/Error
-                 (await (store/resolve-actor-membership! (db-double two-orgs) "open_hax" "   "))))))
+                 (await (store/resolve-actor-membership! (db-double two-orgs) {:actor-id "open_hax" :org-id "   "}))))))
+
+;; ─────────────────────────────────────────────────────────
+;; Same-org duplicates, and the membership id that ends the search.
+;;
+;; Scoping to the org narrows the ambiguity without removing it: memberships are
+;; unique only on (user_id, org_id), actor_id carries a plain lookup index, and
+;; set-membership-actor-id! writes whatever it is given — so two members of ONE
+;; org can share an actor id. Choosing between them means reading one member's
+;; Discord or Bluesky secret for the other's request.
+;; ─────────────────────────────────────────────────────────
+
+(def ^:private two-in-one-org
+  [{"actor_id" "open_hax" "org_id" "org-a" "user_id" "user-1" "membership_id" "m-1"}
+   {"actor_id" "open_hax" "org_id" "org-a" "user_id" "user-2" "membership_id" "m-2"}])
+
+(deftest ^:async duplicates-within-one-org-fail-closed
+  (testing "an org scope is not enough to disambiguate, so it must refuse"
+    (is (thrown? js/Error
+                 (await (store/resolve-actor-membership!
+                         (db-double two-in-one-org)
+                         {:actor-id "open_hax" :org-id "org-a"}))))))
+
+(deftest ^:async a-membership-id-resolves-exactly
+  (testing "each member's own membership, with the duplicate present"
+    (let [db (db-double two-in-one-org)
+          m1 (await (store/resolve-actor-membership! db {:actor-id "open_hax" :membership-id "m-1"}))
+          m2 (await (store/resolve-actor-membership! db {:actor-id "open_hax" :membership-id "m-2"}))]
+      (is (= "user-1" (:user_id m1)))
+      (is (= "user-2" (:user_id m2))))))
+
+(deftest ^:async a-membership-whose-actor-disagrees-is-refused
+  (testing "the actor is verified against the membership, never used to find it —
+            a token whose two halves disagree is refused, not reconciled"
+    (is (thrown? js/Error
+                 (await (store/resolve-actor-membership!
+                         (db-double two-in-one-org)
+                         {:actor-id "discord_automation" :membership-id "m-1"}))))))
+
+(deftest ^:async an-unknown-membership-resolves-to-nothing
+  (is (nil? (await (store/resolve-actor-membership!
+                    (db-double two-in-one-org)
+                    {:actor-id "open_hax" :membership-id "m-nope"})))))
+
+(deftest ^:async no-actor-resolves-to-nothing
+  (testing "a scope with a membership but no actor must not resolve an owner"
+    (is (nil? (await (store/resolve-actor-membership!
+                      (db-double two-in-one-org)
+                      {:actor-id nil :membership-id "m-1"}))))))

--- a/backend/test/cljs/knoxx/backend/actor_credential_org_scope_test.cljs
+++ b/backend/test/cljs/knoxx/backend/actor_credential_org_scope_test.cljs
@@ -1,0 +1,70 @@
+(ns knoxx.backend.actor-credential-org-scope-test
+  "Resolving an actor's membership when the same actor id exists in two orgs.
+
+   knoxx_memberships indexes actor_id non-uniquely, and the credential reader
+   resolved the membership with `findOne {actor_id}` alone. With one actor id
+   present in two orgs that returns whichever document Mongo happens to hand
+   back first, and the credential read that follows is keyed on that
+   membership's user_id and org_id — so one tenant's MCP token could be served
+   another tenant's Discord or Bluesky secret. Non-deterministic, unrepeatable,
+   and invisible in any log.
+
+   Exercised against a collection double rather than live Mongo, because the bug
+   is in which document is selected, not in the driver."
+  (:require [cljs.test :refer [deftest is testing]]
+            [knoxx.backend.infra.stores.mongo-policy-actor-credentials :as store]))
+
+(defn- matches?
+  "The subset of Mongo query semantics this store uses: equality on every key."
+  [query doc]
+  (every? (fn [[k v]] (= (get doc k) v)) (js->clj query)))
+
+(defn- collection-double
+  "A collection handle exposing only find/toArray over fixed documents."
+  [docs]
+  #js {:find (fn [query]
+               #js {:toArray (fn []
+                               (js/Promise.resolve
+                                (clj->js (filterv #(matches? query %) docs))))})})
+
+(defn- db-double
+  [memberships]
+  #js {:collection (fn [name]
+                     (if (= name "knoxx_memberships")
+                       (collection-double memberships)
+                       (collection-double [])))})
+
+(def ^:private two-orgs
+  [{"actor_id" "open_hax" "org_id" "org-a" "user_id" "user-a" "membership_id" "m-a"}
+   {"actor_id" "open_hax" "org_id" "org-b" "user_id" "user-b" "membership_id" "m-b"}])
+
+(deftest ^:async an-org-selects-its-own-membership
+  (testing "each org resolves to its own membership, not to whichever is first"
+    (let [a (await (store/resolve-actor-membership! (db-double two-orgs) "open_hax" "org-a"))
+          b (await (store/resolve-actor-membership! (db-double two-orgs) "open_hax" "org-b"))]
+      (is (= "user-a" (:user_id a)))
+      (is (= "user-b" (:user_id b)))
+      (is (not= (:user_id a) (:user_id b))
+          "if these ever match, one tenant is reading the other's credentials"))))
+
+(deftest ^:async an-ambiguous-actor-with-no-org-fails-closed
+  (testing "returning an arbitrary tenant's membership is the bug; refusing is
+            the only safe reading"
+    (is (thrown? js/Error
+                 (await (store/resolve-actor-membership! (db-double two-orgs) "open_hax" nil))))))
+
+(deftest ^:async an-unambiguous-actor-resolves-without-an-org
+  (testing "the agent-spawn path passes no org and must keep working"
+    (let [one [{"actor_id" "open_hax" "org_id" "org-a" "user_id" "user-a"}]
+          m   (await (store/resolve-actor-membership! (db-double one) "open_hax" nil))]
+      (is (= "user-a" (:user_id m))))))
+
+(deftest ^:async an-unknown-actor-resolves-to-nothing
+  (is (nil? (await (store/resolve-actor-membership! (db-double two-orgs) "nobody" nil))))
+  (is (nil? (await (store/resolve-actor-membership! (db-double two-orgs) "open_hax" "org-c")))
+      "an actor that exists, but not in this org"))
+
+(deftest ^:async a-blank-org-is-treated-as-no-org
+  (testing "so it cannot be used to smuggle past the ambiguity check"
+    (is (thrown? js/Error
+                 (await (store/resolve-actor-membership! (db-double two-orgs) "open_hax" "   "))))))

--- a/backend/test/cljs/knoxx/backend/mcp_actor_ascription_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_actor_ascription_test.cljs
@@ -12,6 +12,8 @@
    Two halves are tested here: the law that says which actor may be named, and
    the scope that carries it without leaking across concurrent work."
   (:require [cljs.test :refer [deftest is testing async]]
+            [knoxx.backend.domain.actor.credentials :as credentials]
+            [knoxx.backend.domain.agent.agent-context :as agent-context]
             [knoxx.backend.infra.actor.scope :as scope]
             [knoxx.backend.law.mcp-oauth :as law]))
 
@@ -84,16 +86,50 @@
 (deftest scope-does-not-outlive-a-run
   (scope/run-as! "open_hax" (fn [] nil))
   (is (nil? (scope/current-actor-id))
-      "a scope must not leak into the next unit of work"))
+      "a scope must not leak into the next unit of work")
+  (is (false? (scope/in-scope?))
+      "and the scope itself must not outlive it either"))
 
-(deftest scope-normalizes-and-refuses-blanks
+(deftest scope-normalizes-its-actor-id
   (testing "an id arrives trimmed"
     (is (= "open_hax" (scope/run-as! "  open_hax\n" #(scope/current-actor-id)))))
-  (testing "a blank enters no scope at all, so the failure surfaces at the
-            credential read rather than as a lookup for actor \"\""
+  (testing "a blank reads as no actor, never as the actor \"\""
     (is (nil? (scope/run-as! "" #(scope/current-actor-id))))
     (is (nil? (scope/run-as! "   " #(scope/current-actor-id))))
     (is (nil? (scope/run-as! nil #(scope/current-actor-id))))))
+
+;; ─────────────────────────────────────────────────────────
+;; "No actor" is a positive fact, not an absence.
+;;
+;; A reader that sees no actor in scope must be able to tell "this work has none"
+;; from "nobody said" — because only the second may consult the process-global
+;; agent-context. Collapsing them let an actor-less MCP call borrow whatever
+;; actor a concurrent agent turn was running as and spend its credentials, which
+;; is the same leak the scope exists to prevent, reached through the fallback.
+;; ─────────────────────────────────────────────────────────
+
+(deftest a-blank-actor-still-enters-a-scope
+  (testing "so a reader can tell definitive absence from nothing being said"
+    (is (true? (scope/run-as! nil #(scope/in-scope?))))
+    (is (true? (scope/run-as! "" #(scope/in-scope?))))
+    (is (true? (scope/run-as! "open_hax" #(scope/in-scope?))))))
+
+(deftest outside-every-scope-nothing-has-been-said
+  (is (false? (scope/in-scope?)))
+  (is (nil? (scope/current-actor-id))))
+
+(deftest an-actor-less-scope-shadows-an-outer-actor
+  (testing "the innermost claim wins even when it is 'no actor' — otherwise an
+            actor-less unit of work inherits an enclosing one's credentials"
+    (is (nil? (scope/run-as! "open_hax"
+                             #(scope/run-as! nil (fn [] (scope/current-actor-id))))))
+    (is (true? (scope/run-as! "open_hax"
+                              #(scope/run-as! nil (fn [] (scope/in-scope?))))))
+    (testing "and the outer actor is intact afterwards"
+      (is (= "open_hax"
+             (scope/run-as! "open_hax" (fn []
+                                         (scope/run-as! nil (fn [] nil))
+                                         (scope/current-actor-id))))))))
 
 (deftest scope-nests-innermost-first
   (is (= "inner"
@@ -236,3 +272,54 @@
     (is (law/consent-actor-unchanged? nil nil))
     (is (law/consent-actor-unchanged? "" ""))
     (is (law/consent-actor-unchanged? "   " nil))))
+
+;; ─────────────────────────────────────────────────────────
+;; The fallback must not be reachable from inside a scope.
+;;
+;; domain.actor.credentials/current-actor-id has two sources: the scope, and the
+;; process-global agent-context that the agent-spawn path sets. An actor-less MCP
+;; call is inside a scope that names no actor, and a concurrent agent turn may
+;; have left an unrelated actor in agent-context. If absence in the scope fell
+;; through to that global, the actor-less token would spend that turn's Discord
+;; and Bluesky credentials — with every visible check passing.
+;;
+;; Exercised through the real credentials fn, with agent-context genuinely set,
+;; because this is precisely the interaction between the two that no test of
+;; either alone can catch.
+;; ─────────────────────────────────────────────────────────
+
+(defn- with-agent-context
+  "Run f with agent-context holding an actor, then clear it.
+
+   set-context! only stores a context when session-id and conversation-id are
+   both present, so they are supplied."
+  [actor f]
+  (agent-context/set-context! {:session-id "s-1"
+                               :conversation-id "c-1"
+                               :agent-spec {:actor-id actor}})
+  (try (f) (finally (agent-context/clear-context!))))
+
+(deftest agent-context-supplies-the-actor-outside-any-scope
+  (testing "the agent-spawn path must keep working unchanged"
+    (with-agent-context "chat_primary"
+      (fn [] (is (= "chat_primary" (credentials/current-actor-id)))))))
+
+(deftest an-actor-less-scope-does-not-fall-back-to-agent-context
+  (with-agent-context "chat_primary"
+    (fn []
+      (is (nil? (scope/run-as! nil #(credentials/current-actor-id)))
+          "an actor-less MCP call must not borrow a concurrent agent turn's actor")
+      (is (nil? (scope/run-as! "" #(credentials/current-actor-id)))))))
+
+(deftest a-scoped-actor-outranks-agent-context
+  (with-agent-context "chat_primary"
+    (fn []
+      (is (= "open_hax" (scope/run-as! "open_hax" #(credentials/current-actor-id)))
+          "the narrower per-call claim must beat the process-global"))))
+
+(deftest agent-context-is-restored-after-a-scope
+  (with-agent-context "chat_primary"
+    (fn []
+      (scope/run-as! "open_hax" (fn [] nil))
+      (is (= "chat_primary" (credentials/current-actor-id))
+          "a scope must not disturb the agent turn it ran inside"))))

--- a/backend/test/cljs/knoxx/backend/mcp_actor_ascription_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_actor_ascription_test.cljs
@@ -11,7 +11,7 @@
 
    Two halves are tested here: the law that says which actor may be named, and
    the scope that carries it without leaking across concurrent work."
-  (:require [cljs.test :refer [deftest is testing async]]
+  (:require [cljs.test :refer [deftest is testing]]
             [knoxx.backend.domain.actor.acting :as acting]
             [knoxx.backend.domain.actor.credentials :as credentials]
             [knoxx.backend.domain.agent.agent-context :as agent-context]
@@ -168,26 +168,20 @@
   [actor]
   (acting/run-as! actor actor-after-awaits))
 
-(deftest scope-survives-an-await
-  (async done
-    ((^:async fn []
-       (let [seen (await (observe-actor "open_hax"))]
-         (is (= "open_hax" seen)
-             "the actor must still be readable after the awaits a credential
-              lookup performs")
-         (done))))))
+(deftest ^:async scope-survives-an-await
+  (let [seen (await (observe-actor "open_hax"))]
+    (is (= "open_hax" seen)
+        "the actor must still be readable after the awaits a credential lookup
+         performs")))
 
-(deftest concurrent-scopes-do-not-observe-each-other
-  (async done
-    ((^:async fn []
-       ;; All started before any resolves, so their awaits interleave.
-       (let [pending #js [(observe-actor "open_hax")
-                          (observe-actor "discord_automation")
-                          (observe-actor "chat_primary")]
-             seen    (await (js/Promise.all pending))]
-         (is (= ["open_hax" "discord_automation" "chat_primary"] (vec seen))
-             "each interleaved call must observe only its own actor")
-         (done))))))
+(deftest ^:async concurrent-scopes-do-not-observe-each-other
+  ;; All started before any resolves, so their awaits interleave.
+  (let [pending #js [(observe-actor "open_hax")
+                     (observe-actor "discord_automation")
+                     (observe-actor "chat_primary")]
+        seen    (await (js/Promise.all pending))]
+    (is (= ["open_hax" "discord_automation" "chat_primary"] (vec seen))
+        "each interleaved call must observe only its own actor")))
 
 ;; ─────────────────────────────────────────────────────────
 ;; A token gets an actor only if it carries one.

--- a/backend/test/cljs/knoxx/backend/mcp_actor_ascription_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_actor_ascription_test.cljs
@@ -12,9 +12,9 @@
    Two halves are tested here: the law that says which actor may be named, and
    the scope that carries it without leaking across concurrent work."
   (:require [cljs.test :refer [deftest is testing async]]
+            [knoxx.backend.domain.actor.acting :as acting]
             [knoxx.backend.domain.actor.credentials :as credentials]
             [knoxx.backend.domain.agent.agent-context :as agent-context]
-            [knoxx.backend.infra.actor.scope :as scope]
             [knoxx.backend.law.mcp-oauth :as law]))
 
 ;; ─────────────────────────────────────────────────────────
@@ -78,25 +78,25 @@
 ;; ─────────────────────────────────────────────────────────
 
 (deftest scope-is-empty-outside-a-run
-  (is (nil? (scope/current-actor-id))))
+  (is (nil? (acting/current-actor-id))))
 
 (deftest scope-reads-inside-a-run
-  (is (= "open_hax" (scope/run-as! "open_hax" #(scope/current-actor-id)))))
+  (is (= "open_hax" (acting/run-as! "open_hax" #(acting/current-actor-id)))))
 
 (deftest scope-does-not-outlive-a-run
-  (scope/run-as! "open_hax" (fn [] nil))
-  (is (nil? (scope/current-actor-id))
+  (acting/run-as! "open_hax" (fn [] nil))
+  (is (nil? (acting/current-actor-id))
       "a scope must not leak into the next unit of work")
-  (is (false? (scope/in-scope?))
+  (is (false? (acting/in-scope?))
       "and the scope itself must not outlive it either"))
 
 (deftest scope-normalizes-its-actor-id
   (testing "an id arrives trimmed"
-    (is (= "open_hax" (scope/run-as! "  open_hax\n" #(scope/current-actor-id)))))
+    (is (= "open_hax" (acting/run-as! "  open_hax\n" #(acting/current-actor-id)))))
   (testing "a blank reads as no actor, never as the actor \"\""
-    (is (nil? (scope/run-as! "" #(scope/current-actor-id))))
-    (is (nil? (scope/run-as! "   " #(scope/current-actor-id))))
-    (is (nil? (scope/run-as! nil #(scope/current-actor-id))))))
+    (is (nil? (acting/run-as! "" #(acting/current-actor-id))))
+    (is (nil? (acting/run-as! "   " #(acting/current-actor-id))))
+    (is (nil? (acting/run-as! nil #(acting/current-actor-id))))))
 
 ;; ─────────────────────────────────────────────────────────
 ;; "No actor" is a positive fact, not an absence.
@@ -110,35 +110,35 @@
 
 (deftest a-blank-actor-still-enters-a-scope
   (testing "so a reader can tell definitive absence from nothing being said"
-    (is (true? (scope/run-as! nil #(scope/in-scope?))))
-    (is (true? (scope/run-as! "" #(scope/in-scope?))))
-    (is (true? (scope/run-as! "open_hax" #(scope/in-scope?))))))
+    (is (true? (acting/run-as! nil #(acting/in-scope?))))
+    (is (true? (acting/run-as! "" #(acting/in-scope?))))
+    (is (true? (acting/run-as! "open_hax" #(acting/in-scope?))))))
 
 (deftest outside-every-scope-nothing-has-been-said
-  (is (false? (scope/in-scope?)))
-  (is (nil? (scope/current-actor-id))))
+  (is (false? (acting/in-scope?)))
+  (is (nil? (acting/current-actor-id))))
 
 (deftest an-actor-less-scope-shadows-an-outer-actor
   (testing "the innermost claim wins even when it is 'no actor' — otherwise an
             actor-less unit of work inherits an enclosing one's credentials"
-    (is (nil? (scope/run-as! "open_hax"
-                             #(scope/run-as! nil (fn [] (scope/current-actor-id))))))
-    (is (true? (scope/run-as! "open_hax"
-                              #(scope/run-as! nil (fn [] (scope/in-scope?))))))
+    (is (nil? (acting/run-as! "open_hax"
+                             #(acting/run-as! nil (fn [] (acting/current-actor-id))))))
+    (is (true? (acting/run-as! "open_hax"
+                              #(acting/run-as! nil (fn [] (acting/in-scope?))))))
     (testing "and the outer actor is intact afterwards"
       (is (= "open_hax"
-             (scope/run-as! "open_hax" (fn []
-                                         (scope/run-as! nil (fn [] nil))
-                                         (scope/current-actor-id))))))))
+             (acting/run-as! "open_hax" (fn []
+                                         (acting/run-as! nil (fn [] nil))
+                                         (acting/current-actor-id))))))))
 
 (deftest scope-nests-innermost-first
   (is (= "inner"
-         (scope/run-as! "outer" #(scope/run-as! "inner" (fn [] (scope/current-actor-id))))))
+         (acting/run-as! "outer" #(acting/run-as! "inner" (fn [] (acting/current-actor-id))))))
   (testing "and the outer scope is intact afterwards"
     (is (= "outer"
-           (scope/run-as! "outer" (fn []
-                                    (scope/run-as! "inner" (fn [] nil))
-                                    (scope/current-actor-id)))))))
+           (acting/run-as! "outer" (fn []
+                                    (acting/run-as! "inner" (fn [] nil))
+                                    (acting/current-actor-id)))))))
 
 ;; ─────────────────────────────────────────────────────────
 ;; The reason this is AsyncLocalStorage and not an atom.
@@ -161,12 +161,12 @@
   []
   (await (tick))
   (await (tick))
-  (scope/current-actor-id))
+  (acting/current-actor-id))
 
 (defn- observe-actor
   "Enter a scope and report what it observes once its awaits have resolved."
   [actor]
-  (scope/run-as! actor actor-after-awaits))
+  (acting/run-as! actor actor-after-awaits))
 
 (deftest scope-survives-an-await
   (async done
@@ -211,8 +211,8 @@
   [token-actor membership-actor]
   (when-not (law/token-actor-honourable? token-actor membership-actor)
     (throw (js/Error. "actor_reassigned")))
-  (when (scope/normalize-actor-id token-actor)
-    (scope/normalize-actor-id membership-actor)))
+  (when (acting/normalize-actor-id token-actor)
+    (acting/normalize-actor-id membership-actor)))
 
 (deftest a-token-carrying-an-actor-is-scoped-to-it
   (is (= "open_hax" (scoped-actor "open_hax" "open_hax"))))
@@ -307,19 +307,19 @@
 (deftest an-actor-less-scope-does-not-fall-back-to-agent-context
   (with-agent-context "chat_primary"
     (fn []
-      (is (nil? (scope/run-as! nil #(credentials/current-actor-id)))
+      (is (nil? (acting/run-as! nil #(credentials/current-actor-id)))
           "an actor-less MCP call must not borrow a concurrent agent turn's actor")
-      (is (nil? (scope/run-as! "" #(credentials/current-actor-id)))))))
+      (is (nil? (acting/run-as! "" #(credentials/current-actor-id)))))))
 
 (deftest a-scoped-actor-outranks-agent-context
   (with-agent-context "chat_primary"
     (fn []
-      (is (= "open_hax" (scope/run-as! "open_hax" #(credentials/current-actor-id)))
+      (is (= "open_hax" (acting/run-as! "open_hax" #(credentials/current-actor-id)))
           "the narrower per-call claim must beat the process-global"))))
 
 (deftest agent-context-is-restored-after-a-scope
   (with-agent-context "chat_primary"
     (fn []
-      (scope/run-as! "open_hax" (fn [] nil))
+      (acting/run-as! "open_hax" (fn [] nil))
       (is (= "chat_primary" (credentials/current-actor-id))
           "a scope must not disturb the agent turn it ran inside"))))

--- a/backend/test/cljs/knoxx/backend/mcp_actor_ascription_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_actor_ascription_test.cljs
@@ -362,3 +362,33 @@
     (is (not (law/token-actor-honourable? "workspace_user" nil))
         "a token carrying the synthesised default is refused once the binding is
          the thing being compared")))
+
+;; ─────────────────────────────────────────────────────────
+;; The scope carries the org, because actor_id is not unique across them.
+;;
+;; knoxx_memberships indexes actor_id non-uniquely, and the credential reader
+;; resolved the membership with findOne on {actor_id} alone — so with the same
+;; actor id in two orgs, one tenant's token could be handed the other's Discord
+;; or Bluesky secret. Scoping the lookup to the token's org closes it; failing
+;; closed on an ambiguous id with no org closes the remaining path.
+;; ─────────────────────────────────────────────────────────
+
+(deftest scope-carries-the-org-alongside-the-actor
+  (is (= ["open_hax" "org-1"]
+         (acting/run-as! {:actor-id "open_hax" :org-id "org-1"}
+                         #(vector (acting/current-actor-id) (acting/current-org-id))))))
+
+(deftest a-bare-actor-id-is-still-accepted
+  (testing "the agent-spawn shape keeps working, with no org to scope by"
+    (is (= "open_hax" (acting/run-as! "open_hax" #(acting/current-actor-id))))
+    (is (nil? (acting/run-as! "open_hax" #(acting/current-org-id))))))
+
+(deftest an-org-does-not-outlive-its-scope
+  (acting/run-as! {:actor-id "open_hax" :org-id "org-1"} (fn [] nil))
+  (is (nil? (acting/current-org-id))))
+
+(deftest an-actor-less-scope-carries-no-org-either
+  (testing "so a lookup cannot be scoped into succeeding without an actor"
+    (is (nil? (acting/run-as! {:actor-id nil :org-id "org-1"} #(acting/current-actor-id))))
+    (is (= "org-1" (acting/run-as! {:actor-id nil :org-id "org-1"} #(acting/current-org-id)))
+        "the org is still readable; it is the actor's absence that stops the read")))

--- a/backend/test/cljs/knoxx/backend/mcp_actor_ascription_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_actor_ascription_test.cljs
@@ -149,3 +149,43 @@
                           (vec seen))
                        "each interleaved call must observe only its own actor")
                    (done)))))))
+
+;; ─────────────────────────────────────────────────────────
+;; A token gets an actor only if it carries one.
+;;
+;; token-actor-honourable? admits an actor-less token so that tokens minted
+;; before this change keep working. That admission must not become a *grant*:
+;; if an actor-less token were then scoped to whatever its membership resolves
+;; to now, every already-issued token would silently gain the power to post as
+;; that actor on Discord and Bluesky, without its consent screen ever having
+;; named one. Honourable means "not refused", not "entitled".
+;;
+;; This is the rule call-actor-id implements; pinned here because the two
+;; predicates read as if honourable implied granted.
+;; ─────────────────────────────────────────────────────────
+
+(defn- scoped-actor
+  "What call-actor-id resolves for a token/membership pair, as law decides it.
+
+   Mirrors the route: refuse a mismatch, then take the membership's actor only
+   when the token itself carries one."
+  [token-actor membership-actor]
+  (when-not (law/token-actor-honourable? token-actor membership-actor)
+    (throw (js/Error. "actor_reassigned")))
+  (when (scope/normalize-actor-id token-actor)
+    (scope/normalize-actor-id membership-actor)))
+
+(deftest a-token-carrying-an-actor-is-scoped-to-it
+  (is (= "open_hax" (scoped-actor "open_hax" "open_hax"))))
+
+(deftest a-legacy-token-is-not-upgraded-to-the-memberships-actor
+  (testing "no actorId means no actor scope, even though the membership has one"
+    (is (nil? (scoped-actor nil "open_hax")))
+    (is (nil? (scoped-actor "" "open_hax")))
+    (is (nil? (scoped-actor "   " "open_hax")))))
+
+(deftest a-reassigned-membership-refuses-rather-than-switching
+  (is (thrown? js/Error (scoped-actor "open_hax" "discord_automation"))
+      "the call must be refused, not quietly re-pointed at the new actor")
+  (is (thrown? js/Error (scoped-actor "open_hax" nil))
+      "clearing the membership's actor must refuse too"))

--- a/backend/test/cljs/knoxx/backend/mcp_actor_ascription_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_actor_ascription_test.cljs
@@ -114,41 +114,44 @@
 ;; find. These two tests fail against an atom and pass against a real scope.
 ;; ─────────────────────────────────────────────────────────
 
-(defn- tick
+(defn- ^:async tick
   "Yield to the microtask queue, the way any awaited I/O would."
   []
-  (js/Promise.resolve nil))
+  (await (js/Promise.resolve nil)))
+
+(defn- ^:async actor-after-awaits
+  "The actor still in scope after two yields — one await per hop, as a
+   credential lookup would do."
+  []
+  (await (tick))
+  (await (tick))
+  (scope/current-actor-id))
+
+(defn- observe-actor
+  "Enter a scope and report what it observes once its awaits have resolved."
+  [actor]
+  (scope/run-as! actor actor-after-awaits))
 
 (deftest scope-survives-an-await
   (async done
-    (-> (scope/run-as! "open_hax"
-                       (fn []
-                         (-> (tick)
-                             (.then (fn [_] (tick)))
-                             (.then (fn [_] (scope/current-actor-id))))))
-        (.then (fn [seen]
-                 (is (= "open_hax" seen)
-                     "the actor must still be readable after the awaits a
-                      credential lookup performs")
-                 (done))))))
+    ((^:async fn []
+       (let [seen (await (observe-actor "open_hax"))]
+         (is (= "open_hax" seen)
+             "the actor must still be readable after the awaits a credential
+              lookup performs")
+         (done))))))
 
 (deftest concurrent-scopes-do-not-observe-each-other
   (async done
-    (let [observe (fn [actor]
-                    (scope/run-as! actor
-                                   (fn []
-                                     (-> (tick)
-                                         (.then (fn [_] (tick)))
-                                         (.then (fn [_] (scope/current-actor-id)))))))]
-      ;; Started before either resolves, so their awaits interleave.
-      (-> (js/Promise.all #js [(observe "open_hax")
-                               (observe "discord_automation")
-                               (observe "chat_primary")])
-          (.then (fn [seen]
-                   (is (= ["open_hax" "discord_automation" "chat_primary"]
-                          (vec seen))
-                       "each interleaved call must observe only its own actor")
-                   (done)))))))
+    ((^:async fn []
+       ;; All started before any resolves, so their awaits interleave.
+       (let [pending #js [(observe-actor "open_hax")
+                          (observe-actor "discord_automation")
+                          (observe-actor "chat_primary")]
+             seen    (await (js/Promise.all pending))]
+         (is (= ["open_hax" "discord_automation" "chat_primary"] (vec seen))
+             "each interleaved call must observe only its own actor")
+         (done))))))
 
 ;; ─────────────────────────────────────────────────────────
 ;; A token gets an actor only if it carries one.
@@ -189,3 +192,47 @@
       "the call must be refused, not quietly re-pointed at the new actor")
   (is (thrown? js/Error (scoped-actor "open_hax" nil))
       "clearing the membership's actor must refuse too"))
+
+;; ─────────────────────────────────────────────────────────
+;; law/consent-actor-unchanged? — the window between page and click
+;;
+;; The consent page shows which actor the token will act as. An admin can
+;; reassign or clear that actor while the page sits open, and the confirmation
+;; recomputes from a fresh context — so without this rule a token is minted for
+;; an actor the page never showed, and it is then honoured on every call because
+;; it matches the membership. The user consents to posting from one account and
+;; gets another.
+;;
+;; The displayed value arrives from a form field, so it is client-controlled. It
+;; is a witness of what was shown, never identity: the minted actor is always
+;; the context's. A forged match asserts "nothing changed", which is either true
+;; or is the very mismatch it was hiding — so a client can cause a refusal and
+;; never an escalation.
+;; ─────────────────────────────────────────────────────────
+
+(deftest consent-actor-unchanged-when-it-matches
+  (is (law/consent-actor-unchanged? "open_hax" "open_hax"))
+  (testing "and tolerates whitespace from the form round-trip"
+    (is (law/consent-actor-unchanged? "  open_hax " "open_hax"))))
+
+(deftest consent-actor-changed-when-reassigned
+  (is (not (law/consent-actor-unchanged? "open_hax" "discord_automation"))
+      "the page showed one account; the membership now posts from another"))
+
+(deftest consent-actor-changed-when-cleared
+  (is (not (law/consent-actor-unchanged? "open_hax" nil)))
+  (is (not (law/consent-actor-unchanged? "open_hax" ""))))
+
+(deftest consent-actor-changed-when-one-appears
+  (testing "an actor appearing is as much a change as one being replaced: the
+            page warned that credential-backed tools would fail, and the user
+            consented to that"
+    (is (not (law/consent-actor-unchanged? "" "open_hax")))
+    (is (not (law/consent-actor-unchanged? nil "open_hax")))))
+
+(deftest no-actor-either-side-is-unchanged
+  (testing "a membership with no actor renders the no-actor warning, and
+            consenting to that is legitimate — it must not be refused"
+    (is (law/consent-actor-unchanged? nil nil))
+    (is (law/consent-actor-unchanged? "" ""))
+    (is (law/consent-actor-unchanged? "   " nil))))

--- a/backend/test/cljs/knoxx/backend/mcp_actor_ascription_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_actor_ascription_test.cljs
@@ -12,9 +12,10 @@
    Two halves are tested here: the law that says which actor may be named, and
    the scope that carries it without leaking across concurrent work."
   (:require [cljs.test :refer [deftest is testing]]
-            [knoxx.backend.domain.actor.acting :as acting]
-            [knoxx.backend.domain.actor.credentials :as credentials]
+            [knoxx.backend.infra.actor.acting :as acting]
+            [knoxx.backend.infra.actor.credentials :as credentials]
             [knoxx.backend.domain.agent.agent-context :as agent-context]
+            [knoxx.backend.infra.auth.authz :as authz]
             [knoxx.backend.law.mcp-oauth :as law]))
 
 ;; ─────────────────────────────────────────────────────────
@@ -317,3 +318,47 @@
       (acting/run-as! "open_hax" (fn [] nil))
       (is (= "chat_primary" (credentials/current-actor-id))
           "a scope must not disturb the agent turn it ran inside"))))
+
+;; ─────────────────────────────────────────────────────────
+;; A synthesised actor is not an assigned one.
+;;
+;; infra.db.policy resolves a request context's actor as
+;;   (or stored-actor_id (default-membership-actor-id role-slugs))
+;; and that default NEVER returns nil — it is "system_admin" or
+;; "workspace_user". So ctx-actor-id answers "which actor label applies", not
+;; "was an actor assigned", and building authority on it would:
+;;
+;;   - mint every token an actor, giving a membership with none assigned
+;;     credential scope for system_admin or workspace_user that nobody granted;
+;;   - make clearing the stored actor_id un-revoking, because the default takes
+;;     over and still matches the token;
+;;   - make the consent page's no-actor warning unreachable, since the page
+;;     would always have a name to print.
+;;
+;; ctx-actor-binding is the stored value, or nil. Only it may decide authority.
+;; ─────────────────────────────────────────────────────────
+
+(deftest actor-binding-is-nil-when-none-is-assigned
+  (let [ctx {:actor {:id "workspace_user" :binding nil}}]
+    (is (= "workspace_user" (authz/ctx-actor-id ctx))
+        "the label still resolves, for display and role defaulting")
+    (is (nil? (authz/ctx-actor-binding ctx))
+        "but nothing was assigned, and authority must see that")))
+
+(deftest actor-binding-is-the-stored-value-when-assigned
+  (let [ctx {:actor {:id "open_hax" :binding "open_hax"}}]
+    (is (= "open_hax" (authz/ctx-actor-id ctx)))
+    (is (= "open_hax" (authz/ctx-actor-binding ctx)))))
+
+(deftest clearing-an-assignment-refuses-a-token-that-carried-it
+  (testing "stored open_hax, token minted for it, then the assignment is cleared
+            and the context falls back to the workspace_user default"
+    (let [after-clearing (authz/ctx-actor-binding {:actor {:id "workspace_user" :binding nil}})]
+      (is (nil? after-clearing))
+      (is (not (law/token-actor-honourable? "open_hax" after-clearing))
+          "the token must be refused, not silently re-pointed at the default")))
+  (testing "and reading the label instead would have refused for the wrong
+            reason — or passed, had the default happened to match"
+    (is (not (law/token-actor-honourable? "workspace_user" nil))
+        "a token carrying the synthesised default is refused once the binding is
+         the thing being compared")))

--- a/backend/test/cljs/knoxx/backend/mcp_actor_ascription_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_actor_ascription_test.cljs
@@ -1,0 +1,151 @@
+(ns knoxx.backend.mcp-actor-ascription-test
+  "Which actor an MCP tool call runs as, and how it is carried there.
+
+   The bug these pin: Discord and Bluesky tools over MCP resolved no actor at
+   all, so every credential read threw \"No current actor_id is available\". The
+   actor was knowable the whole time — knoxx_memberships carries actor_id — but
+   the OAuth code and token records never carried it, and
+   domain.actor.credentials read only agent-context, which the MCP surface never
+   sets. Verified in production on 2026-08-05 with a fully provisioned actor:
+   tools listed, credentials resolvable by actor_id, every call still failed.
+
+   Two halves are tested here: the law that says which actor may be named, and
+   the scope that carries it without leaking across concurrent work."
+  (:require [cljs.test :refer [deftest is testing async]]
+            [knoxx.backend.infra.actor.scope :as scope]
+            [knoxx.backend.law.mcp-oauth :as law]))
+
+;; ─────────────────────────────────────────────────────────
+;; law/actor-grantable? — which actor a membership may name
+;; ─────────────────────────────────────────────────────────
+
+(deftest actor-grantable-is-identity-today
+  (testing "a membership may name its own actor"
+    (is (law/actor-grantable? "open_hax" "open_hax")))
+  (testing "and no other, because no grant says otherwise"
+    (is (not (law/actor-grantable? "open_hax" "discord_automation")))))
+
+(deftest actor-grantable-refuses-blanks
+  (testing "a context that resolved no actor cannot authorize one"
+    (is (not (law/actor-grantable? "" "open_hax")))
+    (is (not (law/actor-grantable? nil "open_hax"))))
+  (testing "and a blank request is not satisfied by a real membership actor"
+    (is (not (law/actor-grantable? "open_hax" "")))
+    (is (not (law/actor-grantable? "open_hax" nil))))
+  (testing "two blanks are not a match either — otherwise a session with no
+            actor would authorize the actor \"\", which owns nothing and would
+            report as present"
+    (is (not (law/actor-grantable? "" "")))
+    (is (not (law/actor-grantable? nil nil)))))
+
+(deftest actor-grantable-ignores-surrounding-space
+  (testing "an id that round-tripped through a form field still matches"
+    (is (law/actor-grantable? "open_hax" "  open_hax  "))
+    (is (law/actor-grantable? " open_hax" "open_hax")))
+  (testing "but whitespace is not an actor"
+    (is (not (law/actor-grantable? "   " "   ")))))
+
+;; ─────────────────────────────────────────────────────────
+;; law/token-actor-honourable? — is a minted token's actor still valid
+;;
+;; A token is a bearer credential that outlives an edit to the membership it
+;; came from. If an admin reassigns or clears the membership's actor_id, a token
+;; that kept honouring its own copy would keep reading the old actor's
+;; credentials until it expired.
+;; ─────────────────────────────────────────────────────────
+
+(deftest token-actor-honourable-when-unchanged
+  (is (law/token-actor-honourable? "open_hax" "open_hax")))
+
+(deftest token-actor-not-honourable-after-reassignment
+  (testing "the membership now resolves to a different actor"
+    (is (not (law/token-actor-honourable? "open_hax" "discord_automation"))))
+  (testing "the membership's actor was cleared entirely"
+    (is (not (law/token-actor-honourable? "open_hax" "")))
+    (is (not (law/token-actor-honourable? "open_hax" nil)))))
+
+(deftest token-without-an-actor-is-honourable
+  (testing "a token minted before actors were carried keeps working; it simply
+            has no actor, and a credential read fails saying exactly that"
+    (is (law/token-actor-honourable? nil "open_hax"))
+    (is (law/token-actor-honourable? "" "open_hax"))
+    (is (law/token-actor-honourable? nil nil))))
+
+;; ─────────────────────────────────────────────────────────
+;; scope — carrying the actor to the credential read
+;; ─────────────────────────────────────────────────────────
+
+(deftest scope-is-empty-outside-a-run
+  (is (nil? (scope/current-actor-id))))
+
+(deftest scope-reads-inside-a-run
+  (is (= "open_hax" (scope/run-as! "open_hax" #(scope/current-actor-id)))))
+
+(deftest scope-does-not-outlive-a-run
+  (scope/run-as! "open_hax" (fn [] nil))
+  (is (nil? (scope/current-actor-id))
+      "a scope must not leak into the next unit of work"))
+
+(deftest scope-normalizes-and-refuses-blanks
+  (testing "an id arrives trimmed"
+    (is (= "open_hax" (scope/run-as! "  open_hax\n" #(scope/current-actor-id)))))
+  (testing "a blank enters no scope at all, so the failure surfaces at the
+            credential read rather than as a lookup for actor \"\""
+    (is (nil? (scope/run-as! "" #(scope/current-actor-id))))
+    (is (nil? (scope/run-as! "   " #(scope/current-actor-id))))
+    (is (nil? (scope/run-as! nil #(scope/current-actor-id))))))
+
+(deftest scope-nests-innermost-first
+  (is (= "inner"
+         (scope/run-as! "outer" #(scope/run-as! "inner" (fn [] (scope/current-actor-id))))))
+  (testing "and the outer scope is intact afterwards"
+    (is (= "outer"
+           (scope/run-as! "outer" (fn []
+                                    (scope/run-as! "inner" (fn [] nil))
+                                    (scope/current-actor-id)))))))
+
+;; ─────────────────────────────────────────────────────────
+;; The reason this is AsyncLocalStorage and not an atom.
+;;
+;; agent-context — the existing actor carrier — is a process-global atom whose
+;; own docstring says "best-effort, per-process". On a concurrent HTTP surface
+;; two calls interleave at every await, so a global would hand one caller the
+;; other's actor: a cross-tenant credential read that no single-request test can
+;; find. These two tests fail against an atom and pass against a real scope.
+;; ─────────────────────────────────────────────────────────
+
+(defn- tick
+  "Yield to the microtask queue, the way any awaited I/O would."
+  []
+  (js/Promise.resolve nil))
+
+(deftest scope-survives-an-await
+  (async done
+    (-> (scope/run-as! "open_hax"
+                       (fn []
+                         (-> (tick)
+                             (.then (fn [_] (tick)))
+                             (.then (fn [_] (scope/current-actor-id))))))
+        (.then (fn [seen]
+                 (is (= "open_hax" seen)
+                     "the actor must still be readable after the awaits a
+                      credential lookup performs")
+                 (done))))))
+
+(deftest concurrent-scopes-do-not-observe-each-other
+  (async done
+    (let [observe (fn [actor]
+                    (scope/run-as! actor
+                                   (fn []
+                                     (-> (tick)
+                                         (.then (fn [_] (tick)))
+                                         (.then (fn [_] (scope/current-actor-id)))))))]
+      ;; Started before either resolves, so their awaits interleave.
+      (-> (js/Promise.all #js [(observe "open_hax")
+                               (observe "discord_automation")
+                               (observe "chat_primary")])
+          (.then (fn [seen]
+                   (is (= ["open_hax" "discord_automation" "chat_primary"]
+                          (vec seen))
+                       "each interleaved call must observe only its own actor")
+                   (done)))))))

--- a/backend/test/cljs/knoxx/backend/mcp_params_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_params_test.cljs
@@ -1,0 +1,42 @@
+(ns knoxx.backend.mcp-params-test
+  "Request parsing for the MCP OAuth endpoints.
+
+   Malli's {:optional true} governs whether a key must be *present*, not what a
+   present value may be — so a nil under a `string?` entry fails validation. The
+   register-client parser built its map with `some->`, which yields nil when the
+   field is absent, so a dynamic client registration that simply omitted
+   client_name — which the spec permits — was rejected as invalid_client_metadata
+   and could never obtain a token."
+  (:require [cljs.test :refer [deftest is testing]]
+            [knoxx.backend.infra.routes.mcp.params :as params]))
+
+(defn- request
+  "A Fastify-shaped request carrying this body."
+  [body]
+  #js {:body (clj->js body)})
+
+(deftest register-client-accepts-a-body-without-a-client-name
+  (testing "client_name is optional in dynamic client registration"
+    (let [parsed (params/parse-register-client-body
+                  (request {:redirect_uris ["https://chatgpt.com/connector_platform_oauth_redirect"]}))]
+      (is (= ["https://chatgpt.com/connector_platform_oauth_redirect"]
+             (:redirect-uris parsed)))
+      (is (not (contains? parsed :client-name))
+          "absent must mean absent, not present-and-nil"))))
+
+(deftest register-client-keeps-a-client-name-when-given
+  (let [parsed (params/parse-register-client-body
+                (request {:redirect_uris ["https://x.test/cb"] :client_name "ChatGPT"}))]
+    (is (= "ChatGPT" (:client-name parsed)))))
+
+(deftest register-client-treats-a-blank-name-as-absent
+  (testing "a blank name is not a name, and must not fail the schema either"
+    (let [parsed (params/parse-register-client-body
+                  (request {:redirect_uris ["https://x.test/cb"] :client_name "   "}))]
+      (is (not (contains? parsed :client-name))))))
+
+(deftest register-client-still-requires-a-redirect-uri
+  (testing "the refusal that matters is kept"
+    (is (thrown? js/Error (params/parse-register-client-body (request {}))))
+    (is (thrown? js/Error (params/parse-register-client-body
+                           (request {:redirect_uris []}))))))

--- a/backend/test/cljs/knoxx/backend/mcp_schema_test.cljs
+++ b/backend/test/cljs/knoxx/backend/mcp_schema_test.cljs
@@ -13,6 +13,7 @@
    defect was that the value lacked zod's own methods."
   (:require [cljs.test :refer [deftest is testing]]
             [knoxx.backend.infra.routes.mcp :as mcp]
+            [knoxx.backend.infra.routes.mcp.transport :as transport]
             [knoxx.backend.domain.tools :as dtools]
             [knoxx.backend.law.mcp-tool-annotations :as ann]
             ["zod" :refer [z]]))
@@ -75,7 +76,7 @@
 
 (deftest stateless-options-omit-the-session-generator
   (testing "the key is absent, not null"
-    (let [opts (mcp/stateless-transport-options)]
+    (let [opts (transport/stateless-transport-options)]
       (is (false? (.hasOwnProperty opts "sessionIdGenerator"))
           "present-but-null is what selected stateful mode")
       (is (undefined? (aget opts "sessionIdGenerator")))

--- a/kanban/epics/knoxx-decouple-into-katamorph-contracts.md
+++ b/kanban/epics/knoxx-decouple-into-katamorph-contracts.md
@@ -1,78 +1,96 @@
 ---
 uuid: "knoxx-decouple-into-katamorph-contracts"
-title: "Disentangle Knoxx's tool products into Katamorph contracts, without taking the product down"
+title: "Knoxx constitutional compliance and actor awareness — comply in place, do not extract yet"
 status: incoming
 priority: P2
-labels: ["epics", "decouple", "katamorph"]
+labels: ["epics", "decouple", "katamorph", "compliance"]
 created_at: "2026-08-04T00:00:00Z"
 points: 0
 category: epics
 ---
-# Disentangle Knoxx's tool products into Katamorph contracts
+# Knoxx constitutional compliance and actor awareness
 
-## Purpose
+> **Scope correction, 2026-08-04.** An earlier draft of this epic proposed
+> disentangling Knoxx's tool sets *into* Katamorph contracts and eta-mu
+> packages. That duplicates an existing **P0** epic and contradicts a written
+> ownership decision. Corrected below. The end state is unchanged; the next step
+> is not extraction.
 
-Knoxx currently carries several things that are each close to a product in their
-own right — Discord agents, Bluesky agents, translation, the sandbox, voice, the
-CMS — inside one backend, with their layers mixed. The direction is:
+## The plan already exists upstream
 
-1. describe as much of each as practical as **Katamorph contracts** (EDN
-   declarations of identities, capabilities, policies, triggers, actions,
-   sources, stores, providers, agent config; Malli-validated boundaries;
-   effects injected rather than owned), and
-2. let **eta-mu** own each as a separate package.
+`eta-mu/kanban/epics/katamorph-canonical-cutover.md` — **P0, status
+breakdown** — is the cutover. Its directive: *one contract language, many
+interpreters*; katamorph describes the EDN contracts and every system (knoxx,
+sol, muse, rheos, eta-mu CLI) interprets that data. Its card 6 is
+**`knoxx-katamorph-cutover` (icebox) — "knoxx cuts over last; reference
+implementation may lag."**
 
-We are not there. The constraint that shapes every card under this epic: **the
-product has to keep working throughout.** No card here may be a flag-day
-rewrite.
+Its acceptance criteria are already 3 of 5 done: sol cut over, katamorph tagged
+with `ProviderContract`, and a `contract-redefinition-guard` exists. The two
+open items are `capability-schema-reconciliation` (**ready**) and
+`event-ledger-envelope-truth`.
 
-## Why now
+`muse/docs/design/contract-ownership-and-host-translation.md` states the
+sequencing directly:
 
-The MCP surface made the coupling visible rather than theoretical. Getting
-`https://knoxx.promethean.rest/mcp` working took eight defects across three
-repos, five of them one shape — a writer and a reader that only ever ran
-together against live infrastructure, so their contract drifted unnoticed. That
-is what an undeclared boundary costs. Katamorph's premise is that those
-boundaries should be data with a validator attached.
+> Knoxx is a downstream composition target. It remains deferred until these
+> parts work independently; **code should not be migrated into or out of Knoxx
+> to prove this architecture.**
 
-## Shape of the work
+## So what this epic is for
 
-- **Boundary first, extraction second.** Name and validate a tool set's
-  boundary in place before moving it. A namespace that has a contract can be
-  moved later by anyone; a namespace that only has behaviour cannot.
-- **One tool set at a time**, each independently shippable.
-- **Contracts before renames.** Several cards here want to rename things
-  (`semantic_*`); renaming across an undeclared boundary is how you get another
-  silent drift.
+Everything Knoxx can do *without* moving code: become internally lawful and
+actor-aware, so that when the upstream seams settle, extraction is mechanical
+rather than archaeological.
+
+- separate pure logic, effects, schemas and transformations in place
+- carry an actor through every tool call
+- make the constitution **enforceable**, not aspirational
+
+## Why compliance has not happened by itself
+
+The cutover epic already diagnosed the root cause, and it applies here verbatim:
+
+> contract discipline is only load-bearing in muse (build fails without the data
+> pipeline); in sol/knoxx contracts are optional config, so agents defined
+> schemas in place. **Fix = cutover + make it enforceable, not more
+> documentation.**
+
+Knoxx already has four gates — `lint` (clj-kondo, with fn-length and
+file-length as *errors*), `boundary:check`, `error-boundaries:check`,
+`lint:size`. None of them checks layer dependencies. That is the lever.
+
+## The build order to use
+
+From `muse/AGENTS.md`, which shares Knoxx's four-category table and adds the
+dependency order that makes disentangling incremental:
+
+```
+law → shape → extern → domain → infra
+```
+
+`law` first (describes a valid instance; no dependencies), `shape` pure
+morphisms depending only on law, `extern` decoding foreign data at the edge,
+`domain` pure decisions over shaped data, `infra` orchestrating effects. Any one
+tool set can be walked up that order without a flag day.
 
 ## Children
 
+- `knoxx-layer-enforcement-gate` — the lever; nothing else here sticks without it
 - `knoxx-mcp-actor-ascription`
 - `knoxx-deploy-actor-owning-local-credentials`
-- `knoxx-mcp-consent-permission-groups`
+- `knoxx-tool-namespace-boundary-audit`
+- `knoxx-mcp-consent-permission-groups` — blocked on `capability-schema-reconciliation`
 - `knoxx-translations-event-sourced`
 - `knoxx-translation-pipeline-validation`
 - `knoxx-voice-tools-remote-transport`
 - `knoxx-tool-vocabulary-rename`
 - `knoxx-cms-contract-validation`
-- `knoxx-tool-namespace-boundary-audit`
 
-## Non-goals
+## Explicit non-goals
 
-- Moving anything into eta-mu packages yet. That is the end state, not the next
-  step.
-- Rewriting the agent runtime.
-
-## Prior art on this board
-
-This epic is not the first pass at decoupling. Reconcile with, do not duplicate:
-
-- **`knoxx-contract-runtime-extraction`** (pending) — extract the contract
-  runtime core as a package. The eta-mu end state.
-- **`knoxx-runtime-decomposition-inventory`** (pending) — the existing
-  decomposition inventory.
-- **`knoxx-namespace-manifest-migration`**, **`knoxx-store-protocol`**,
-  **`knoxx-rich-action-registry`** — earlier moves in the same direction.
-
-If those cards already express the plan, this epic should become a thin wrapper
-that adds only the tool-set slices and the "stay live throughout" constraint.
+- Moving code into eta-mu or katamorph. Knoxx cuts over **last**, upstream first.
+- Adopting `katamorph.schema` here. Knoxx does not reference katamorph at all
+  today and consumes `open-hax.contract-runtime` instead; that swap belongs to
+  `knoxx-katamorph-cutover`, not this epic.
+- Any flag-day rewrite. The product stays live throughout.

--- a/kanban/epics/knoxx-decouple-into-katamorph-contracts.md
+++ b/kanban/epics/knoxx-decouple-into-katamorph-contracts.md
@@ -1,0 +1,78 @@
+---
+uuid: "knoxx-decouple-into-katamorph-contracts"
+title: "Disentangle Knoxx's tool products into Katamorph contracts, without taking the product down"
+status: incoming
+priority: P2
+labels: ["epics", "decouple", "katamorph"]
+created_at: "2026-08-04T00:00:00Z"
+points: 0
+category: epics
+---
+# Disentangle Knoxx's tool products into Katamorph contracts
+
+## Purpose
+
+Knoxx currently carries several things that are each close to a product in their
+own right — Discord agents, Bluesky agents, translation, the sandbox, voice, the
+CMS — inside one backend, with their layers mixed. The direction is:
+
+1. describe as much of each as practical as **Katamorph contracts** (EDN
+   declarations of identities, capabilities, policies, triggers, actions,
+   sources, stores, providers, agent config; Malli-validated boundaries;
+   effects injected rather than owned), and
+2. let **eta-mu** own each as a separate package.
+
+We are not there. The constraint that shapes every card under this epic: **the
+product has to keep working throughout.** No card here may be a flag-day
+rewrite.
+
+## Why now
+
+The MCP surface made the coupling visible rather than theoretical. Getting
+`https://knoxx.promethean.rest/mcp` working took eight defects across three
+repos, five of them one shape — a writer and a reader that only ever ran
+together against live infrastructure, so their contract drifted unnoticed. That
+is what an undeclared boundary costs. Katamorph's premise is that those
+boundaries should be data with a validator attached.
+
+## Shape of the work
+
+- **Boundary first, extraction second.** Name and validate a tool set's
+  boundary in place before moving it. A namespace that has a contract can be
+  moved later by anyone; a namespace that only has behaviour cannot.
+- **One tool set at a time**, each independently shippable.
+- **Contracts before renames.** Several cards here want to rename things
+  (`semantic_*`); renaming across an undeclared boundary is how you get another
+  silent drift.
+
+## Children
+
+- `knoxx-mcp-actor-ascription`
+- `knoxx-deploy-actor-owning-local-credentials`
+- `knoxx-mcp-consent-permission-groups`
+- `knoxx-translations-event-sourced`
+- `knoxx-translation-pipeline-validation`
+- `knoxx-voice-tools-remote-transport`
+- `knoxx-tool-vocabulary-rename`
+- `knoxx-cms-contract-validation`
+- `knoxx-tool-namespace-boundary-audit`
+
+## Non-goals
+
+- Moving anything into eta-mu packages yet. That is the end state, not the next
+  step.
+- Rewriting the agent runtime.
+
+## Prior art on this board
+
+This epic is not the first pass at decoupling. Reconcile with, do not duplicate:
+
+- **`knoxx-contract-runtime-extraction`** (pending) — extract the contract
+  runtime core as a package. The eta-mu end state.
+- **`knoxx-runtime-decomposition-inventory`** (pending) — the existing
+  decomposition inventory.
+- **`knoxx-namespace-manifest-migration`**, **`knoxx-store-protocol`**,
+  **`knoxx-rich-action-registry`** — earlier moves in the same direction.
+
+If those cards already express the plan, this epic should become a thin wrapper
+that adds only the tool-set slices and the "stay live throughout" constraint.

--- a/kanban/epics/knoxx-decouple-into-katamorph-contracts.md
+++ b/kanban/epics/knoxx-decouple-into-katamorph-contracts.md
@@ -87,6 +87,27 @@ tool set can be walked up that order without a flag day.
 - `knoxx-tool-vocabulary-rename`
 - `knoxx-cms-contract-validation`
 
+## The strategy: work, test, isolate, freeze
+
+Order matters, and it is not the order an agent naturally reaches for.
+
+1. **Get it working exactly as needed.** Not approximately. A feature that half
+   works cannot be frozen, and cannot be tested against a definition.
+2. **Aggressively test.** The recurring defect class here is a writer and a
+   reader that only ever ran together against live infrastructure. Tests at each
+   boundary, with a double, are what catch that — five of the eight MCP defects
+   would have been caught by one.
+3. **Isolate.** Remove all effectual code from all logical code. This is the
+   `law → shape → extern → domain → infra` walk, per tool set.
+4. **Freeze the feature.** Once isolated and tested, stop changing it. A frozen,
+   lawful feature is what makes extraction mechanical later — and what stops the
+   next agent from re-entangling it.
+
+**Start with the tools exposed by MCP and their actor contracts.** They are the
+smallest complete slice that exercises every layer: a law (who may act as whom),
+a shape (the tool/capability projection), an extern (the MCP SDK), a domain
+decision (is this grant admissible), and infra (the route).
+
 ## Explicit non-goals
 
 - Moving code into eta-mu or katamorph. Knoxx cuts over **last**, upstream first.

--- a/kanban/tasks/knoxx-cms-contract-validation.md
+++ b/kanban/tasks/knoxx-cms-contract-validation.md
@@ -25,7 +25,7 @@ The Knoxx deploy health gate (`digitalocean/services/knoxx/verify.sh`) probes
 reachable**. `deploy-stack.yml` sets `KNOXX_EXPECT_OPENPLANNER_REST=false` and
 deploys no OpenPlanner, so on every production deploy the gate logs:
 
-```
+```text
 knoxx: CMS surface skipped — no host OpenPlanner API at http://host.docker.internal:7777
 ```
 

--- a/kanban/tasks/knoxx-cms-contract-validation.md
+++ b/kanban/tasks/knoxx-cms-contract-validation.md
@@ -1,0 +1,66 @@
+---
+uuid: "knoxx-cms-contract-validation"
+title: "Exercise and validate the CMS contracts"
+status: incoming
+priority: P3
+labels: ["tasks", "5sp", "has-parent", "cms", "validation"]
+created_at: "2026-08-04T00:00:00Z"
+points: 5
+category: tasks
+---
+# Exercise and validate the CMS contracts
+
+> Parent epic: `knoxx-decouple-into-katamorph-contracts`
+
+## Purpose
+
+The CMS contracts have never been tested. The CMS surface is also the one part of
+Knoxx whose deploy check is *conditionally skipped*, so it has been shipping
+unverified by construction.
+
+## Verified as of 2026-08-04
+
+The Knoxx deploy health gate (`digitalocean/services/knoxx/verify.sh`) probes
+`/api/openplanner/v1/cms/documents?limit=1` **only when a host OpenPlanner API is
+reachable**. `deploy-stack.yml` sets `KNOXX_EXPECT_OPENPLANNER_REST=false` and
+deploys no OpenPlanner, so on every production deploy the gate logs:
+
+```
+knoxx: CMS surface skipped — no host OpenPlanner API at http://host.docker.internal:7777
+```
+
+So the CMS path is neither exercised in tests nor in the deploy gate.
+
+## Scope
+
+- Establish what the CMS contracts assert, and whether the runtime honours them
+  (`contracts/` + the CMS compatibility routes).
+- Decide the CMS's actual dependency story: it currently reaches a host
+  OpenPlanner HTTP service over `host.docker.internal:7777` that production does
+  not run. Either deploy that service, port the CMS path to the in-process Mongo
+  client the rest of Knoxx already uses, or drop the surface.
+- Once it has a dependency that exists in production, make the health gate
+  require it unconditionally instead of skipping.
+
+## Note
+
+This is the last REST-only OpenPlanner dependency in the deployed stack; chat,
+sessions, search and translation all run in-process through the SDK. Resolving it
+removes the `KNOXX_EXPECT_OPENPLANNER_REST` flag and a whole conditional branch
+from the deploy gate.
+
+## Done when
+
+- The CMS contracts have tests that fail when the runtime violates them.
+- The CMS surface has a dependency that exists in production.
+- The deploy gate asserts the CMS surface unconditionally.
+
+## Prior art on this board
+
+- **`knoxx-arch-migration-cms-routes-retirement`** (status: breakdown) — *Retire
+  Legacy CMS Backend Routes*. A retirement direction already exists, so "drop the
+  surface" is not a fresh option to weigh here: check that card first and treat
+  this one as validating whatever survives it. If retirement lands, most of this
+  card evaporates and the deploy gate's conditional CMS branch goes with it.
+- **`knoxx-cms-backend-routes`** (accepted) — the CRUD/publish endpoints this
+  would be validating.

--- a/kanban/tasks/knoxx-deploy-actor-owning-local-credentials.md
+++ b/kanban/tasks/knoxx-deploy-actor-owning-local-credentials.md
@@ -38,9 +38,18 @@ means the later cutover is a rename, not a redesign.
   `knoxx_actors` in Mongo, and/or the local PM2 Knoxx instance's policy DB.
 - Provision the equivalent actor on the production host through the deployment
   repo, so it is reproducible rather than hand-made.
-- Decide deliberately whether production shares the local actor's credentials or
-  gets its own. Sharing is faster; separate credentials mean a leak from the
-  public host does not burn the local one. **Recommend separate.**
+- ~~Decide deliberately whether production shares the local actor's credentials
+  or gets its own.~~ **Decided 2026-08-05: shared.** The title, purpose and
+  actor section all say "the same credentials", and that is what was asked for
+  and what shipped — the production actor holds the local `discord_automation`
+  actor's `discord_bot` and `bluesky` credentials verbatim.
+
+  The earlier "recommend separate" line contradicted the rest of this card, so
+  it is struck rather than left to be read as an open question. The risk it
+  named is real and does not go away by being decided: a leak from the public
+  host burns the local credentials too, because they are the same secret. That
+  is now a follow-up to rotate onto production-only credentials, not a choice
+  still to make — see the note below.
 
 ## Constraints
 
@@ -51,8 +60,19 @@ means the later cutover is a rename, not a redesign.
   deploy should write them to the policy DB, not export them as env vars —
   `domain.actor.credentials` deliberately refuses to read env.
 
+## Follow-up: production-only credentials
+
+Sharing was chosen for speed and is a standing risk, not a resolved one. A
+separate Discord bot token and Bluesky app-password for production would mean a
+compromise of the public host cannot be used against the local instance, and
+would make revocation independent. Rotating is cheap once the actor exists —
+both are a `PUT /api/admin/actors/:userId/credentials/:provider` away — so this
+wants its own card rather than a re-litigation of this one.
+
 ## Done when
 
 - A documented, repeatable step provisions the production actor.
 - A Discord or Bluesky tool call over MCP against production succeeds end to end.
 - The credential values exist only in Actions secrets and the policy DB.
+- The sharing decision is recorded, with the risk it carries named rather
+  than left implicit.

--- a/kanban/tasks/knoxx-deploy-actor-owning-local-credentials.md
+++ b/kanban/tasks/knoxx-deploy-actor-owning-local-credentials.md
@@ -8,7 +8,7 @@ created_at: "2026-08-04T00:00:00Z"
 points: 3
 category: tasks
 ---
-# Provision a production actor owning the local instance's credentials
+# Provision the `open-hax` production actor owning the local instance's credentials
 
 > Parent epic: `knoxx-decouple-into-katamorph-contracts`
 > Blocks: `knoxx-mcp-actor-ascription` is useless in production without this
@@ -18,6 +18,19 @@ category: tasks
 The deployed Knoxx has no actor holding Discord/Bluesky credentials, so even
 once MCP ascribes an actor there is nothing for it to resolve. The local PM2
 instance does have them.
+
+## The actor
+
+**`open-hax`** — the DigitalOcean deployment gets an actor with that id, owning
+the same credentials as the local PM2 deployment of knoxx.
+
+Its shape is already declared upstream: `katamorph.schema/ActorContract` carries
+`:actor/id`, `:actor/kind` (`:agent`), and — directly relevant here —
+`:actor/accounts` with `:discord {:username :user-id}` and
+`:bluesky {:handle :did}`. Model the production actor on that rather than on a
+knoxx-local shape, even though knoxx cannot require katamorph yet (its
+`contract-runtime` fork lacks `schema.cljs`). Matching the declared shape now
+means the later cutover is a rename, not a redesign.
 
 ## Scope
 

--- a/kanban/tasks/knoxx-deploy-actor-owning-local-credentials.md
+++ b/kanban/tasks/knoxx-deploy-actor-owning-local-credentials.md
@@ -1,0 +1,45 @@
+---
+uuid: "knoxx-deploy-actor-owning-local-credentials"
+title: "Provision a production actor owning the same tool credentials as the local instance"
+status: incoming
+priority: P1
+labels: ["tasks", "3sp", "has-parent", "deploy", "actors"]
+created_at: "2026-08-04T00:00:00Z"
+points: 3
+category: tasks
+---
+# Provision a production actor owning the local instance's credentials
+
+> Parent epic: `knoxx-decouple-into-katamorph-contracts`
+> Blocks: `knoxx-mcp-actor-ascription` is useless in production without this
+
+## Purpose
+
+The deployed Knoxx has no actor holding Discord/Bluesky credentials, so even
+once MCP ascribes an actor there is nothing for it to resolve. The local PM2
+instance does have them.
+
+## Scope
+
+- Discover the local actor and its credentials — `knoxx_actor_credentials` and
+  `knoxx_actors` in Mongo, and/or the local PM2 Knoxx instance's policy DB.
+- Provision the equivalent actor on the production host through the deployment
+  repo, so it is reproducible rather than hand-made.
+- Decide deliberately whether production shares the local actor's credentials or
+  gets its own. Sharing is faster; separate credentials mean a leak from the
+  public host does not burn the local one. **Recommend separate.**
+
+## Constraints
+
+- `open-hax/services` is a **public** repository. Credentials go in Actions
+  secrets and reach the host through the existing `env.template` → `rendered.env`
+  path, which already refuses to deploy a blank value. Nothing lands in git.
+- Credentials are actor-owned state in the policy DB, not process env. The
+  deploy should write them to the policy DB, not export them as env vars —
+  `domain.actor.credentials` deliberately refuses to read env.
+
+## Done when
+
+- A documented, repeatable step provisions the production actor.
+- A Discord or Bluesky tool call over MCP against production succeeds end to end.
+- The credential values exist only in Actions secrets and the policy DB.

--- a/kanban/tasks/knoxx-layer-enforcement-gate.md
+++ b/kanban/tasks/knoxx-layer-enforcement-gate.md
@@ -82,8 +82,21 @@ Practical shape:
   deleted by a fork-tax commit (`b3348eb1`), so `lint:size` cannot run at all —
   recovering it reports **50 errors repo-wide**, which is itself an argument for
   the ratchet rather than a cliff.
-- `domain.actor.credentials` requires `infra.auth.authz` and `infra.db.policy` —
-  a domain namespace depending on infra.
+- **The tool implementations are effectful namespaces filed under `domain.*`.**
+  `domain.bluesky.bluesky`, `domain.discord.tools`, `domain.media` and
+  `domain.twitch` now require `infra.actor.credentials`, because the credential
+  resolver moved to `infra` where it belongs — it reads the policy database. Those
+  four `domain -> infra` edges are **newly visible, not newly created**: they
+  already called a function that performed a database read, through a namespace
+  named `domain.actor.credentials` that hid it. Seed them in the allowlist and
+  fix them by moving the tool implementations to `infra`, or by passing resolved
+  credentials in, rather than by moving the resolver back.
+
+- ~~`domain.actor.credentials` requires `infra.auth.authz` and `infra.db.policy`~~
+  — resolved 2026-08-05 by moving it to `infra.actor.credentials`. Kept here as
+  the worked example: a violation can be *hidden* by a namespace name, and the
+  gate must key on the actual require graph, not on where someone filed a file.
+
 - Contract validation flows through `open-hax.contract-runtime`, not
   `katamorph.schema`; knoxx does not reference katamorph at all. Out of scope
   here (see `knoxx-katamorph-cutover` upstream) but the gate should not pretend

--- a/kanban/tasks/knoxx-layer-enforcement-gate.md
+++ b/kanban/tasks/knoxx-layer-enforcement-gate.md
@@ -53,9 +53,18 @@ Add a gate that fails on a layer violation. Rules, in dependency order
 
 Practical shape:
 
-- Start as a **ratchet, not a cliff.** Emit the current violation count, fail
-  only on an increase. A hard gate on day one fails the build immediately and
-  gets disabled; a ratchet gets adopted.
+- Start as a **ratchet, not a cliff.** A hard gate on day one fails the build
+  immediately and gets disabled; a ratchet gets adopted.
+- **Ratchet on violation identity, not on a count.** A count-only gate passes
+  when one allowlisted violation is removed and a different one is added in the
+  same commit — a new violation lands green, which is the exact failure the gate
+  exists to prevent. So: fail on any violation absent from the allowlist, and
+  separately require the allowlist to shrink or hold. The count is then a
+  progress number for humans, never the pass condition.
+- A violation's identity has to survive edits that are not violations. Key it on
+  `[namespace, required-namespace]` rather than on a line number or a hash of
+  surrounding code, or every unrelated edit churns the allowlist and the gate
+  becomes noise people silence.
 - Allowlist existing violations explicitly, with the file and reason, so the
   backlog is legible and shrinking is visible.
 - Reuse the existing checker style (`scripts/check-*.mjs`) rather than inventing
@@ -64,9 +73,15 @@ Practical shape:
 
 ## Known violations to seed the allowlist
 
-- `infra.routes.mcp` — ~160 raw interop expressions in 799 lines, against an
-  800-line lint error ceiling; two concerns (OAuth authorization server + MCP
-  transport) in one file.
+- `infra.routes.mcp` — ~160 raw interop expressions. Partly addressed: the
+  consent page and the transport are now their own namespaces and the file is
+  734 lines, but the raw interop density is untouched. Worth knowing which
+  ceiling is real here: clj-kondo enforces file error at 800 and **function
+  error at 60**, and it was the function rule that actually bit. A separate
+  `size-lint.config.mjs` documents warn 350 / error 500, but that config was
+  deleted by a fork-tax commit (`b3348eb1`), so `lint:size` cannot run at all —
+  recovering it reports **50 errors repo-wide**, which is itself an argument for
+  the ratchet rather than a cliff.
 - `domain.actor.credentials` requires `infra.auth.authz` and `infra.db.policy` —
   a domain namespace depending on infra.
 - Contract validation flows through `open-hax.contract-runtime`, not

--- a/kanban/tasks/knoxx-layer-enforcement-gate.md
+++ b/kanban/tasks/knoxx-layer-enforcement-gate.md
@@ -1,0 +1,81 @@
+---
+uuid: "knoxx-layer-enforcement-gate"
+title: "Make the four-category constitution enforceable in CI"
+status: incoming
+priority: P1
+labels: ["tasks", "5sp", "has-parent", "compliance", "architecture"]
+created_at: "2026-08-04T00:00:00Z"
+points: 5
+category: tasks
+---
+# Make the four-category constitution enforceable
+
+> Parent epic: `knoxx-decouple-into-katamorph-contracts`
+> This is the enabling card. Every other compliance card regresses without it.
+
+## Purpose
+
+AGENTS.md declares the layer split and the code violates it anyway. That is not
+a discipline problem, it is a feedback problem, and the upstream cutover epic
+already named it:
+
+> contract discipline is only load-bearing in muse (build fails without the data
+> pipeline); in sol/knoxx contracts are optional config, so agents defined
+> schemas in place. **Fix = cutover + make it enforceable, not more
+> documentation.**
+
+Muse complies because non-compliance breaks its build. Knoxx will comply for the
+same reason and no other.
+
+## What already exists to build on
+
+Knoxx has four gates in `backend/package.json`, so the mechanism is proven:
+
+| gate | checks |
+|---|---|
+| `lint` | clj-kondo, with `fn-length/too-long` and `file-length/too-long` as **errors** |
+| `boundary:check` | `scripts/check-js-boundary.mjs` — non-extern imports of the generic extern helpers |
+| `error-boundaries:check` | silent catch sites must log, return data, or rethrow |
+| `lint:size` | file size |
+
+None checks **layer dependencies**, which is the rule most often broken.
+
+## Scope
+
+Add a gate that fails on a layer violation. Rules, in dependency order
+(`law → shape → extern → domain → infra`):
+
+- `law.*` may require only `law.*` and malli/clojure.* — no I/O, no shape, no domain
+- `shape.*` may require only `law.*` + `shape.*` — pure, domain-agnostic
+- `extern.*` is the only place raw JS interop may be born or decoded
+- `domain.*` may require `law` + `shape` + `domain` — never `infra.*` or `extern.*`
+- `infra.*` may require anything below it
+
+Practical shape:
+
+- Start as a **ratchet, not a cliff.** Emit the current violation count, fail
+  only on an increase. A hard gate on day one fails the build immediately and
+  gets disabled; a ratchet gets adopted.
+- Allowlist existing violations explicitly, with the file and reason, so the
+  backlog is legible and shrinking is visible.
+- Reuse the existing checker style (`scripts/check-*.mjs`) rather than inventing
+  a new tool. `code-quality.yml`-style Python in the infra repo is the sibling
+  precedent.
+
+## Known violations to seed the allowlist
+
+- `infra.routes.mcp` — ~160 raw interop expressions in 799 lines, against an
+  800-line lint error ceiling; two concerns (OAuth authorization server + MCP
+  transport) in one file.
+- `domain.actor.credentials` requires `infra.auth.authz` and `infra.db.policy` —
+  a domain namespace depending on infra.
+- Contract validation flows through `open-hax.contract-runtime`, not
+  `katamorph.schema`; knoxx does not reference katamorph at all. Out of scope
+  here (see `knoxx-katamorph-cutover` upstream) but the gate should not pretend
+  otherwise.
+
+## Done when
+
+- A layer violation in new code fails CI.
+- The current violations are enumerated in an allowlist, with counts.
+- The count can only go down.

--- a/kanban/tasks/knoxx-mcp-actor-ascription.md
+++ b/kanban/tasks/knoxx-mcp-actor-ascription.md
@@ -20,7 +20,7 @@ just never carries the actor.
 
 ## Verified as of 2026-08-04
 
-```
+```text
 agent-context/set-context!    called ONLY from infra/agent/session.cljs
                               (wrap-custom-tools-with-agent-context!) — the
                               agent-spawn path
@@ -76,7 +76,7 @@ The `open_hax` actor now exists on the DigitalOcean deployment with credentials
 attached, so the diagnosis above is no longer only a reading of the source. What
 is provisioned and what still fails:
 
-```
+```text
 contract               contracts/knoxx/actors/open_hax.edn (services repo)
 membership             431df12e-…  actor_id=open_hax  user=9ae812b9-…
 roles                  open-hax, discord-user, bluesky-publisher

--- a/kanban/tasks/knoxx-mcp-actor-ascription.md
+++ b/kanban/tasks/knoxx-mcp-actor-ascription.md
@@ -69,3 +69,41 @@ consent page gets a tool that cannot work.
 - A Discord or Bluesky tool call over MCP resolves credentials for that actor.
 - Selecting an actor the membership may not act as is refused at authorize time.
 - A test covers the refusal, not only the success path.
+
+## Confirmed in production, 2026-08-05
+
+The `open_hax` actor now exists on the DigitalOcean deployment with credentials
+attached, so the diagnosis above is no longer only a reading of the source. What
+is provisioned and what still fails:
+
+```
+contract               contracts/knoxx/actors/open_hax.edn (services repo)
+membership             431df12e-…  actor_id=open_hax  user=9ae812b9-…
+roles                  open-hax, discord-user, bluesky-publisher
+role tool policies     38 allow (19 bluesky.*, 12 discord.*, 7 read/search)
+credentials            discord_bot  kind=bot-token   account=450177073990860801
+                       bluesky      kind=app-password account=open-hax.bsky.social
+reader query           get-actor-credential-by-actor-and-provider! finds the
+                       membership by actor_id and returns both rows
+```
+
+Tested over `POST /mcp` with a 15-minute diagnostic token bound to that
+membership (since revoked):
+
+| call | result |
+|---|---|
+| `initialize` | ok |
+| `tools/list` | bluesky_publish, bluesky_profile, bluesky_search, bluesky_timeline, bluesky_author_feed, bluesky_notifications, graph_query, websearch, memory_search, semantic_query |
+| `bluesky_profile {"actor": "open-hax.bsky.social"}` | **succeeds** — but proves nothing: a supplied `actor` skips `bluesky-create-session!`, so no credential is read |
+| `bluesky_profile {}` | `isError: true` — *"No current actor_id is available for bluesky credentials"* |
+| `bluesky_notifications {}` | same |
+
+So the credential half is done and the tools are advertised; every
+credential-reading call still fails on the missing actor. This card is the only
+thing between a provisioned actor and working Discord/Bluesky tools over MCP.
+
+Note for whoever picks this up: `tools/list` returns `Method not found` and
+`initialize` advertises `capabilities: {}` when the token's `tools` array is
+empty, because the route registers only the granted intersection. That is
+correct behaviour, but it reads exactly like a broken server — worth a clearer
+signal.

--- a/kanban/tasks/knoxx-mcp-actor-ascription.md
+++ b/kanban/tasks/knoxx-mcp-actor-ascription.md
@@ -1,0 +1,71 @@
+---
+uuid: "knoxx-mcp-actor-ascription"
+title: "Ascribe an actor to MCP tool calls, and choose it during authorization"
+status: incoming
+priority: P1
+labels: ["tasks", "5sp", "has-parent", "mcp", "actors"]
+created_at: "2026-08-04T00:00:00Z"
+points: 5
+category: tasks
+---
+# Ascribe an actor to MCP tool calls
+
+> Parent epic: `knoxx-decouple-into-katamorph-contracts`
+
+## Purpose
+
+Discord and Bluesky tools called over MCP have **no owning actor**, so their
+credential lookup fails. Actor-owned credentials are the design; the MCP surface
+just never carries the actor.
+
+## Verified as of 2026-08-04
+
+```
+agent-context/set-context!    called ONLY from infra/agent/session.cljs
+                              (wrap-custom-tools-with-agent-context!) — the
+                              agent-spawn path
+MCP route                     calls (.execute tool "mcp" params nil nil nil)
+                              directly; never wraps tools with an agent context
+credentials/current-actor-id  reads ONLY agent-context :agent-spec :actor-id
+                              ⇒ nil over MCP
+get-credential!               throws "No current actor_id is available for
+                              <provider> credentials…"
+```
+
+The actor is *knowable* and simply dropped: `knoxx_memberships` carries
+`actor_id`, and `authz/ctx-actor-id` already reads `[:membership :actor-id]`. But
+the MCP OAuth **code and token records store `membershipId`, `userEmail`,
+`orgSlug` and no `actorId`**, and `domain.actor.credentials` never consults the
+request context regardless.
+
+Consequence: those tool groups are non-functional remotely. It fails safe — no
+call runs as the wrong actor — but a user who selects `discord_send` on the
+consent page gets a tool that cannot work.
+
+## Scope
+
+- Add actor selection to the authorization consent page
+  (`mcp-authorize-client!` / `authorization-consent-html`), listing the actors
+  the membership may act as. Default to the membership's own `actor_id` when
+  there is exactly one.
+- Carry `actorId` through the OAuth code record and into the access token
+  (`mcp-authorize-confirm!` → `persist-access-token!`), alongside
+  `membershipId`.
+- Make credential resolution accept an actor from the request context, not only
+  from an agent spawn. Prefer widening `domain.actor.credentials` over faking an
+  agent context at the MCP boundary — the latter would couple the two paths.
+- Reject at authorize time, not call time, when a selected tool needs an actor
+  and none is available. A tool that cannot work should not be offered.
+
+## Contract obligations
+
+- The actor must be one the membership is permitted to act as. Do not trust an
+  `actorId` echoed back from the client.
+- Name the check in `law.*`; this is an authorization decision, not transport.
+
+## Done when
+
+- A token minted through the consent page carries an actor.
+- A Discord or Bluesky tool call over MCP resolves credentials for that actor.
+- Selecting an actor the membership may not act as is refused at authorize time.
+- A test covers the refusal, not only the success path.

--- a/kanban/tasks/knoxx-mcp-consent-permission-groups.md
+++ b/kanban/tasks/knoxx-mcp-consent-permission-groups.md
@@ -8,7 +8,7 @@ created_at: "2026-08-04T00:00:00Z"
 points: 3
 category: tasks
 ---
-# Group tool permissions on the MCP consent page
+# Hierarchical tool grants on the MCP consent page
 
 > Parent epic: `knoxx-decouple-into-katamorph-contracts`
 
@@ -19,14 +19,36 @@ checkboxes in one flat list (observed in the authorize/confirm query on
 2026-08-04), which makes granting or revoking a capability tedious and makes the
 page a poor description of what is being granted.
 
+## The model: a hierarchy, like GitHub permissions
+
+Tick one top-level box for `discord` and every discord tool is granted. Not a
+flat list with a select-all convenience — an actual hierarchy, where the parent
+is the thing granted and the children are its expansion.
+
+The shape for this already exists upstream and should be adopted rather than
+invented. `katamorph.schema/CapabilityContract`:
+
+```clojure
+{:cap/id keyword? :cap/tools [any] :cap/user-surfaces [UserSurface]}
+```
+
+`:cap/id` is a **keyword**, so namespacing gives the hierarchy for free:
+`:cap/id :discord` expands to `:discord/send`, `:discord/read`, … and an actor
+holds `:actor/capabilities [:discord :bluesky]`. Granting a parent means
+granting the namespace.
+
+That also means the grant page stops being a tool list and becomes a projection
+of capabilities — which is what makes it data rather than markup.
+
 ## Scope
 
-- Group tools into capability sets: Discord, Bluesky, translations, sandbox,
-  memory/graph, voice, web, files.
-- Group-level select/deselect, with per-tool override retained.
-- Derive the grouping from **data**, not a hand-maintained list in the HTML —
-  a Katamorph-style capability declaration is the target shape, so this card is
-  a natural first contract.
+- Namespace the tool ids under capability parents: discord, bluesky,
+  translations, sandbox, memory/graph, voice, web, files.
+- Grant at any level; a parent grant expands to its children at token-mint time,
+  not at render time, so a tool added later is covered by an existing grant.
+- Store the grant as the capability set, not the expanded tool list. Storing the
+  expansion is what makes a grant go stale.
+- Derive the grouping from **data**, not a hand-maintained list in the HTML.
 - Show each group's risk honestly using the annotations from
   `law.mcp-tool-annotations` (read-only vs destructive vs open-world) rather
   than presenting all tools as equivalent.

--- a/kanban/tasks/knoxx-mcp-consent-permission-groups.md
+++ b/kanban/tasks/knoxx-mcp-consent-permission-groups.md
@@ -51,3 +51,10 @@ page a poor description of what is being granted.
   Hardcoded Tool Authorization with Policy-DB Check*. Grouping should read the
   same policy source that card establishes, not a second list. Land or at least
   settle that one first, or the groups will be hardcoded twice.
+- **`capability-schema-reconciliation`** in *eta-mu* (status: **ready**) —
+  reconciles muse's capability shape with katamorph's `CapabilityContract`; its
+  blueprint holds that *"a capability is the primitive."* Tool groups **are**
+  capabilities, so grouping before that decision lands would define a third
+  competing capability shape — exactly the drift the upstream P0 cutover exists
+  to stop. **Blocked on it.**
+

--- a/kanban/tasks/knoxx-mcp-consent-permission-groups.md
+++ b/kanban/tasks/knoxx-mcp-consent-permission-groups.md
@@ -1,0 +1,53 @@
+---
+uuid: "knoxx-mcp-consent-permission-groups"
+title: "Group tool permissions on the MCP consent page"
+status: incoming
+priority: P2
+labels: ["tasks", "3sp", "has-parent", "mcp", "ux"]
+created_at: "2026-08-04T00:00:00Z"
+points: 3
+category: tasks
+---
+# Group tool permissions on the MCP consent page
+
+> Parent epic: `knoxx-decouple-into-katamorph-contracts`
+
+## Purpose
+
+The consent page lists every tool individually. A real authorization carried ~60
+checkboxes in one flat list (observed in the authorize/confirm query on
+2026-08-04), which makes granting or revoking a capability tedious and makes the
+page a poor description of what is being granted.
+
+## Scope
+
+- Group tools into capability sets: Discord, Bluesky, translations, sandbox,
+  memory/graph, voice, web, files.
+- Group-level select/deselect, with per-tool override retained.
+- Derive the grouping from **data**, not a hand-maintained list in the HTML —
+  a Katamorph-style capability declaration is the target shape, so this card is
+  a natural first contract.
+- Show each group's risk honestly using the annotations from
+  `law.mcp-tool-annotations` (read-only vs destructive vs open-world) rather
+  than presenting all tools as equivalent.
+
+## Notes
+
+- Related: `knoxx-mcp-actor-ascription` adds actor selection to the same page.
+  Sequence them so the page is restructured once.
+- Only 9 of ~60 tools currently have declared annotations; the rest fall back to
+  MCP's pessimistic defaults. Grouping will make that gap visible in the UI,
+  which is useful pressure to finish the table.
+
+## Done when
+
+- Granting "all Discord tools" is one action.
+- The grouping comes from a declaration, not markup.
+- Revoking a group revokes every tool in it, verified by a test.
+
+## Prior art on this board
+
+- **`knoxx-tenant-policy-backed-tool-authz`** (status: review) — *Replace
+  Hardcoded Tool Authorization with Policy-DB Check*. Grouping should read the
+  same policy source that card establishes, not a second list. Land or at least
+  settle that one first, or the groups will be hardcoded twice.

--- a/kanban/tasks/knoxx-mcp-consent-server-side-state.md
+++ b/kanban/tasks/knoxx-mcp-consent-server-side-state.md
@@ -1,0 +1,87 @@
+---
+uuid: "knoxx-mcp-consent-server-side-state"
+title: "Bind MCP authorization consent to server-side state, not to query parameters"
+status: incoming
+priority: P0
+labels: ["tasks", "5sp", "has-parent", "mcp", "security", "oauth"]
+created_at: "2026-08-05T00:00:00Z"
+points: 5
+category: tasks
+---
+# Bind MCP consent to server-side state
+
+> Parent epic: `knoxx-decouple-into-katamorph-contracts`
+> Found by Codex reviewing `knoxx#219`, while checking whether the actor field
+> added there actually binds anything. It does not, and the reason generalises.
+
+## The hole
+
+`GET /api/mcp/oauth/authorize/confirm` mints an authorization code using only:
+
+- the browser's session cookie, and
+- query parameters.
+
+There is **no server-side record of what the consent page displayed**. Every
+input that decides what the token can do arrives in the URL:
+
+```text
+client_id  redirect_uri  code_challenge  scope  tool (repeated)  actor_id
+```
+
+The consent page is therefore decorative from a security standpoint. A crafted
+link, opened by a user with a live Knoxx session, mints a code for a client the
+attacker registered — dynamic client registration is open — with whatever tool
+set the attacker chose, and the user sees only a redirect.
+
+`law/consent-actor-unchanged?` does not close this. Its own docstring now says
+so: it is a race guard for an admin reassigning the membership's actor while a
+page sits open. A hostile caller simply sends the matching `actor_id`.
+
+## Why it is P0 rather than P2
+
+- The code exchange needs PKCE, but the attacker generates the verifier, so PKCE
+  costs them nothing here. It protects the code in transit, not the consent.
+- `redirect_uri` must belong to a registered client — and registration is open
+  and unauthenticated, so the attacker registers their own.
+- The minted token is indistinguishable from a legitimate one, so nothing
+  downstream can detect it. With `knoxx#219` landed, that token can carry an
+  actor and spend real Discord and Bluesky credentials.
+
+## Scope
+
+- On `GET /api/mcp/oauth/authorize`, persist a **consent record** under an
+  unguessable single-use nonce, with a short TTL: client id, redirect uri, code
+  challenge, membership id, the actor displayed, and the tools *offered*.
+- The page carries the nonce. Nothing else it sends is trusted.
+- On confirm, look the nonce up, require that it belongs to the confirming
+  membership, and take client id, redirect uri, code challenge and actor **from
+  the record**. Only the tool selection comes from the form, and it must be a
+  subset of the tools the record offered.
+- Consume the nonce on use, atomically, the same way `consume-code!` claims a
+  code — so a replayed confirmation cannot mint a second code.
+- Reject a confirm with no nonce. Do not fall back to query parameters; a
+  fallback is the hole.
+
+## Contract obligations
+
+- The consent record shape belongs in `law.mcp-oauth`, beside the code and token
+  contracts, with membership id and nonce non-blank for the same reason
+  `RevocationRequest` requires them.
+- Name the subset rule in `law.*`: "the tools authorized are a subset of the
+  tools offered" is an authorization decision, not transport.
+
+## Watch out
+
+- A consent nonce and an authorization code must not be interchangeable. If they
+  share a collection, a nonce presented at `/token` must be refused — do not let
+  one record type satisfy the other's lookup.
+- `mcp-authorize-confirm!` is already at the 60-line function ceiling; this needs
+  the extraction done, not squeezed in.
+
+## Done when
+
+- A confirm without a valid nonce is refused.
+- A confirm whose tool set exceeds what the record offered is refused, with a
+  test for the refusal rather than only the success path.
+- A replayed confirm mints no second code.
+- No decision on the token's authority is read from a query parameter.

--- a/kanban/tasks/knoxx-tool-namespace-boundary-audit.md
+++ b/kanban/tasks/knoxx-tool-namespace-boundary-audit.md
@@ -1,0 +1,88 @@
+---
+uuid: "knoxx-tool-namespace-boundary-audit"
+title: "Audit the tool namespaces against the four-category split before extracting anything"
+status: incoming
+priority: P2
+labels: ["tasks", "8sp", "has-parent", "decouple", "architecture"]
+created_at: "2026-08-04T00:00:00Z"
+points: 8
+category: tasks
+---
+# Audit the tool namespaces against the four-category split
+
+> Parent epic: `knoxx-decouple-into-katamorph-contracts`
+> This is the enabling card. Extraction of any tool set should wait on its slice.
+
+## Purpose
+
+AGENTS.md declares a four-category split — `domain` (pure), `infra` (effectful),
+`shape` (structure-only), `law` (contracts) — plus `extern.*` as the only place
+raw JS interop may be born. The tool code mixes these. Nothing can be extracted
+into a Katamorph contract or an eta-mu package until each tool set's boundary is
+named, because a namespace that only has behaviour cannot be moved by anyone but
+its author.
+
+## Evidence that this is the live problem
+
+Getting the MCP endpoint working surfaced eight defects, and **five were the same
+shape**: a writer and a reader that only ever ran together against live
+infrastructure, so their contract drifted silently.
+
+- `set-client!` wrapped its payload in `:client_data`; `get-client!` returned the
+  envelope. Every registered client's `redirect_uri` was rejected.
+- The writers stored `:expiresAt`; the readers asked `:expires-at`. Every code
+  and token read as expired.
+- The consent page read a CLJS map with `aget`, so it 500'd.
+- `clj->js {:sessionIdGenerator js/undefined}` emits `null`, which selects the
+  SDK's *stateful* mode. Every request after `initialize` was rejected.
+- A nested tool-parameter object was handed to `registerTool` as a bare field
+  shape, so tool registration threw.
+
+Each was a boundary nobody had declared. The existing `law.*` and `shape.*`
+namespaces are broadly fine — the problem is what never reached them.
+
+## Scope
+
+Per tool set (discord, bluesky, sandbox, voice, translations, memory/graph, CMS):
+
+- List its namespaces and classify each as domain / infra / shape / law / extern.
+- Name the violations concretely — a pure decision living in `infra`, raw interop
+  outside `extern`, a contract implied but never written.
+- For each boundary the set crosses, say what the contract *would* be. Writing it
+  is a follow-up; naming it is this card.
+- Produce a per-set extraction order, cheapest first.
+
+## Known, already named
+
+- `infra.routes.mcp` holds ~160 raw interop expressions in 799 lines, against an
+  800-line lint **error** ceiling — comments have been trimmed three times to
+  fit. It is two concerns in one file (OAuth authorization server + MCP
+  transport) and wants splitting.
+- A URL adapter and a TypeBox→Zod extern were both raised in review and deferred
+  as out of scope for a hotfix. Both belong here.
+- `mcp-sessions*` is read by `GET /mcp` and `DELETE /mcp` and **written by
+  nothing** (`git log -S'swap! mcp-sessions*'` returns no commits). Those two
+  routes cannot work. Either implement stateful sessions or delete the routes —
+  leaving them is a trap.
+- `set-token!`/`get-token!` still pass JSON strings where the rest of the store
+  now speaks CLJS data.
+- The SDK is unpinned: `backend/Dockerfile` installs with
+  `--no-frozen-lockfile` against `^1.29.0`, so production ran **1.30.0** while
+  the lockfile pinned **1.29.0**. That is the mechanism for "it broke and nobody
+  changed anything" and should be closed regardless of this audit.
+
+## Done when
+
+- Every tool set has a written classification and a named list of violations.
+- Every boundary it crosses has a stated contract, written or explicitly deferred.
+- There is an extraction order, and the first slice is small enough to ship alone.
+
+## Prior art on this board
+
+- **`knoxx-runtime-decomposition-inventory`** (pending) — *Decomposition
+  Inventory: Manifest / Driver / Protocol / Library*. Substantial overlap. Read
+  it before starting; this card should extend that inventory with the tool sets
+  and the four-category classification rather than start a second one.
+- **`knoxx-contract-runtime-extraction`** (pending) — *Extract the Contract
+  Runtime Core as a Package*. That is the eta-mu packaging step this audit
+  unblocks; sequence after.

--- a/kanban/tasks/knoxx-tool-vocabulary-rename.md
+++ b/kanban/tasks/knoxx-tool-vocabulary-rename.md
@@ -1,0 +1,61 @@
+---
+uuid: "knoxx-tool-vocabulary-rename"
+title: "Fix the tool vocabulary — say what each tool searches, not that it is 'semantic'"
+status: incoming
+priority: P3
+labels: ["tasks", "3sp", "has-parent", "naming", "mcp"]
+created_at: "2026-08-04T00:00:00Z"
+points: 3
+category: tasks
+---
+# Fix the tool vocabulary
+
+> Parent epic: `knoxx-decouple-into-katamorph-contracts`
+
+## Purpose
+
+The tool names do not tell a caller — human or model — what they search.
+"semantic" is the worst offender: `semantic_query`, `semantic_read`,
+`semantic_compaction`, "semantic memory". It names an implementation technique
+(embeddings) rather than a subject, and three different tools use it for three
+different corpora.
+
+An MCP client sees only the name, description and schema. The name is doing real
+work here, and it is currently doing it badly.
+
+## What each actually is, today
+
+- `semantic_query` — vector search over the **active document corpus**
+- `memory_search` — search over **prior sessions and actions**
+- `memory_session` — retrieve **one conversation**
+- `graph_query` — entities and edges across **lakes** (workspace, web, bluesky,
+  knoxx-session)
+
+Three of the four are "search something"; the distinction is *which corpus*, and
+none of the names say so.
+
+## Scope
+
+- Choose names that name the subject. Sketch, not a decision:
+  `documents_search`, `sessions_search`, `session_read`, `graph_search`.
+- Decide the convention deliberately — `<subject>_<verb>` reads better in a tool
+  list than `<verb>_<subject>`, because clients sort alphabetically and grouping
+  by subject is what a user scans for.
+- Keep the old names working. `sanitize-custom-tool-name` already sets
+  `originalName`, so aliasing is cheap; an installed connector must not break on
+  a rename.
+- Fix the descriptions at the same time — they should say which corpus is
+  searched in the first clause.
+
+## Sequencing
+
+Do this **after** `knoxx-mcp-consent-permission-groups` and the annotation table
+is complete. Renaming across a boundary that has no declaration is how the
+`web.read` → `web_read` annotation lookup silently broke on #218; a rename wants
+the contract in place first.
+
+## Done when
+
+- Every advertised tool's name identifies its subject.
+- Old names still resolve, with a test.
+- No tool description begins by describing its algorithm.

--- a/kanban/tasks/knoxx-translation-pipeline-validation.md
+++ b/kanban/tasks/knoxx-translation-pipeline-validation.md
@@ -1,0 +1,54 @@
+---
+uuid: "knoxx-translation-pipeline-validation"
+title: "Validate the whole translation pipeline end to end"
+status: incoming
+priority: P2
+labels: ["tasks", "5sp", "has-parent", "translations", "validation"]
+created_at: "2026-08-04T00:00:00Z"
+points: 5
+category: tasks
+---
+# Validate the whole translation pipeline
+
+> Parent epic: `knoxx-decouple-into-katamorph-contracts`
+
+## Purpose
+
+The translation pipeline has never been validated end to end. It is on the
+production deploy's health gate, so a silent break there fails every deployment
+— and it has already been the subject of several emergency fixes (#210, #211,
+and the Mongo boundary migration).
+
+## Scope
+
+Walk the pipeline and assert each hop, from ingestion to a rendered translation:
+
+- document/segment ingestion
+- segment identity and tenant scoping
+- the translate call itself and its provider path
+- `assert-translated!` (currently rejects a translation byte-identical to its
+  source — confirm that is the rule we want)
+- persistence (see `knoxx-translations-event-sourced`)
+- read-back through `/api/translations/segments` and the Studio surface
+- the labelling/review states (`pending`, `in_review`, `approved`, `rejected`)
+
+## Approach
+
+- Prefer contract tests at each boundary over one long end-to-end script; the
+  recurring defect class in this codebase is a writer and a reader disagreeing,
+  which a boundary test catches and an integration test only sometimes does.
+- `law.openplanner-translation` already holds Malli contracts for this boundary
+  — extend rather than invent.
+
+## Done when
+
+- Each hop has a test that fails when that hop is broken, independently.
+- A deliberate break anywhere in the chain is attributable from the failure alone.
+
+## Prior art on this board
+
+- **`knowledge-ops-translation-mt-pipeline`** (done, LANDED) — the MT pipeline
+  itself. This card validates it rather than builds it.
+- **`knowledge-ops-translation-routes`**, **`knowledge-ops-translation-export`**,
+  **`knowledge-ops-translation-document-review-v2`** — check their state before
+  scoping; parts of the chain may already have coverage.

--- a/kanban/tasks/knoxx-translations-event-sourced.md
+++ b/kanban/tasks/knoxx-translations-event-sourced.md
@@ -1,0 +1,59 @@
+---
+uuid: "knoxx-translations-event-sourced"
+title: "Make translations append-only / event sourced instead of an overwriting upsert"
+status: incoming
+priority: P2
+labels: ["tasks", "5sp", "has-parent", "translations"]
+created_at: "2026-08-04T00:00:00Z"
+points: 5
+category: tasks
+---
+# Make translations append-only / event sourced
+
+> Parent epic: `knoxx-decouple-into-katamorph-contracts`
+
+## Purpose
+
+Translations should be event sourced. They are currently a destructive upsert, so
+a re-translation silently replaces the previous one and the history is gone.
+
+## Verified as of 2026-08-04
+
+`extern/openplanner_translation_mongo/segments.cljs` `upsert-segment!` is a
+`findOneAndUpdate` with `$set` and `:upsert true`, keyed on a tenant-scoped
+segment identity. `create-segment!` reads the existing row, computes
+`modified?`, and overwrites when the content differs.
+
+This is why `save_translation` is declared `destructiveHint: true` in
+`law.mcp-tool-annotations` — an accurate description of today's behaviour, and a
+hint that should become `false` when this card lands.
+
+## Scope
+
+- Append a translation **event** per save rather than mutating a segment row.
+- Derive the current segment state from its events — projection, not truth.
+- Keep reads fast: `/api/translations/segments` is on the deploy health gate, so
+  a projection/materialised view is likely required rather than folding events
+  per request.
+- Migrate existing segment rows into an initial event per segment, preserving
+  `created_at`/`updated_at` as best known.
+- Update `save_translation`'s annotation to non-destructive once it is true, and
+  drop the destructive justification from `law.mcp-tool-annotations`.
+
+## Contract obligations
+
+- The event shape belongs in `law.*` with a Malli schema, and the projection
+  should assert against it. This is a good candidate for the first genuinely
+  Katamorph-shaped store in Knoxx.
+
+## Watch out
+
+- The deploy health gate requires `/api/translations/segments?limit=1` to answer
+  200. Do not land a migration that leaves that endpoint erroring, or every
+  deployment fails — see the Knoxx verify.sh translation probe.
+
+## Done when
+
+- Saving the same segment twice preserves both versions.
+- The current-state read is unchanged from a caller's perspective.
+- `save_translation` is honestly non-destructive, with the annotation updated.

--- a/kanban/tasks/knoxx-translations-event-sourced.md
+++ b/kanban/tasks/knoxx-translations-event-sourced.md
@@ -46,6 +46,24 @@ hint that should become `false` when this card lands.
   should assert against it. This is a good candidate for the first genuinely
   Katamorph-shaped store in Knoxx.
 
+- **Settle event identity and ordering before any migration.** An append-only
+  log without these is not append-only in practice, and the damage is not
+  recoverable by a later fix — the history is already wrong. Name all four:
+
+  | obligation | why, concretely |
+  |---|---|
+  | immutable event id | a retried save must be recognised as the same event, not appended twice. `save_translation` is a tool an agent can and will call again after a timeout. |
+  | segment key | which segment a event belongs to, stable across renames — it is the projection's grouping key |
+  | sequence or ordering rule | two concurrent saves to one segment must fold to a defined end state. Wall-clock `updated_at` is not an ordering rule; ties and clock skew both break it. |
+  | retry behaviour | append-at-least-once plus a dedup on event id, or append-exactly-once. Pick one and say which, because the projection's correctness depends on it. |
+
+- **Say what happens when the append succeeds and the projection fails.** That
+  is the normal failure, not the exotic one, and the answer decides whether a
+  read can be stale: either the projection is rebuildable from the log on
+  demand (so a stale read self-heals) or the write is not acknowledged until
+  both land (so it cannot). Silence here means "stale forever, discovered by a
+  user".
+
 ## Watch out
 
 - The deploy health gate requires `/api/translations/segments?limit=1` to answer

--- a/kanban/tasks/knoxx-voice-tools-remote-transport.md
+++ b/kanban/tasks/knoxx-voice-tools-remote-transport.md
@@ -1,0 +1,48 @@
+---
+uuid: "knoxx-voice-tools-remote-transport"
+title: "Rework the voice MCP tools for a remote client instead of an owned realtime harness"
+status: incoming
+priority: P3
+labels: ["tasks", "8sp", "has-parent", "voice", "mcp"]
+created_at: "2026-08-04T00:00:00Z"
+points: 8
+category: tasks
+---
+# Rework the voice MCP tools for remote use
+
+> Parent epic: `knoxx-decouple-into-katamorph-contracts`
+
+## Purpose
+
+The voice tools were written against a harness we owned, where the caller could
+queue and steer a live session. An MCP client cannot do that: it makes discrete
+request/response calls, and Knoxx's MCP transport is stateless per request — each
+POST builds a fresh server, so there is no session to steer.
+
+## The actual constraint
+
+`mcp-handle-post!` constructs a new `McpServer` and transport per request with
+stateless options. `GET /mcp` and `DELETE /mcp` — the resumable-stream and
+session-teardown routes — read `mcp-sessions*`, which **nothing populates**, so
+they cannot work today (see the note in `knoxx-tool-namespace-boundary-audit`).
+Any design that assumes a steerable live session needs that fixed first, and it
+should be a deliberate choice rather than a side effect.
+
+## Scope
+
+- Decide the interaction model honestly:
+  - **fire-and-forget**: `voice_tts` returns an artifact reference; no steering.
+  - **job handle**: start returns an id; separate tools poll or cancel.
+  - **true session**: requires real MCP session support (stateful transport plus
+    populated `mcp-sessions*`), and only then can `GET /mcp` stream.
+- Re-shape `voice_tts`, `voice_tts_stream`, and the Discord voice tools to the
+  chosen model.
+- Remove or clearly mark the tools that cannot work remotely, rather than
+  advertising them and failing at call time.
+
+## Done when
+
+- Every advertised voice tool works from a remote MCP client, or is not
+  advertised.
+- Streaming, if kept, works through a mechanism that exists rather than one
+  assumed.


### PR DESCRIPTION
Discord and Bluesky tools called over MCP resolved **no actor at all**, so every credential read threw `No current actor_id is available`. This carries the actor from authorization through to the tool handler.

Closes the app-side half of `knoxx-mcp-actor-ascription`. The deployment half landed in `open-hax/services#41`, which provisioned the `open_hax` actor with both credentials — so the failure is confirmed against a fully provisioned actor, not inferred.

## Confirmed in production before this change

```
membership   431df12e-…  actor_id=open_hax  user=9ae812b9-…
roles        open-hax, discord-user, bluesky-publisher
policies     38 allow — 19 bluesky.*, 12 discord.*, 7 read/search
credentials  discord_bot bot-token · bluesky app-password, both active
reader       get-actor-credential-by-actor-and-provider! returns both rows
```

Over `POST /mcp` with a 15-minute diagnostic token (since revoked):

| call | before |
|---|---|
| `initialize`, `tools/list` | fine — 10 tools incl. all six bluesky |
| `bluesky_profile {"actor": "open-hax.bsky.social"}` | succeeds, and **proves nothing** — a supplied `actor` skips `bluesky-create-session!`, so no credential is read |
| `bluesky_profile {}` | `No current actor_id is available` |
| `bluesky_notifications {}` | same |

Everything was provisioned. Only the ascription was missing.

## The shortcut I did not take

The obvious fix is for the MCP route to set `agent-context`, the existing actor carrier. **That would be a cross-tenant credential leak.** `agent-context` is a single process-global atom — "best-effort, per-process" by its own docstring — and on a concurrent HTTP surface calls interleave at every await. Three concurrent calls, measured against each implementation:

```
global atom        -> ["chat_primary","chat_primary","chat_primary"]
AsyncLocalStorage  -> ["open_hax","discord_automation","chat_primary"]
```

Every caller reads the last-started caller's credentials. No single-request test finds it.

So `extern.async-local-storage` births the `node:async_hooks` interop and `infra.actor.scope` offers `run-as!`/`current-actor-id` over it — surface-neutral, per-unit-of-work, unreachable outside. `domain.actor.credentials` prefers the scope and keeps `agent-context` as the fallback, so the agent-spawn path is untouched and the narrower claim always beats the wider one.

## The flow

| stage | what carries the actor |
|---|---|
| `authorize/confirm` | `actorId` from the resolved context, admitted by `law/actor-grantable?`; absent rather than blank when there is none |
| token exchange | copied from the claimed code record |
| every `POST /mcp` | resolved from the membership *again*; the token's copy only used to refuse a mismatch |
| tool handler | runs inside `actor-scope/run-as!` |

Two rules in `law` rather than inline comparisons:

- **`actor-grantable?`** — a membership may name its own actor and no other. Identity today because nothing in the policy DB says which *other* actors a user may assume; naming the rule means widening it later is one edit with one place to test. The actor comes from the context and never from the query — the client is on the far side of a redirect it controls, so an echoed `actorId` would be the client choosing its own identity.
- **`token-actor-honourable?`** — a token's actor must still be its membership's. A token outlives an admin reassigning or clearing `actor_id`, and honouring its own copy would let a stale identity read the old actor's credentials until expiry. Refused with `403 actor_reassigned`. A token carrying *no* actor stays honourable, so tokens minted before this change keep working for every tool that needs no credential.

## Consent page

Now states which actor the token will act as, and warns when there is none that credential-backed tools will fail. That decides which Discord or Bluesky account gets posted from, which should not be implicit on a consent screen. **Shown rather than chosen** — a membership has exactly one actor, and a selector needs a grant that does not exist yet.

## Refactor, and why it is in this PR

`infra.routes.mcp` was 773 lines against a clj-kondo file ceiling of 800, and `mcp-handle-post!` was one edit from the 60-line function ceiling. Two namespaces come out on real seams: `mcp.consent` (the page, string building only) and `mcp.transport` (the wire — bearer extraction, session id, Accept normalization, the RFC 9728 challenge, and the stateless-mode options with its SDK note intact). `mcp-handle-post!` splits into `granted-tools`, `register-tools!`, `tool-config-js` and `serve-mcp-post!`, dropping it from 66 lines and giving the grant intersection a name — including why an empty grant makes `tools/list` answer `Method not found`, since that reads exactly like a broken server.

Net: 773 → 734 lines plus two focused namespaces.

One behaviour change beyond the actor work: the POST error path now honours a thrown `statusCode`/`code` instead of flattening everything to 500. Needed because this route hijacks the reply and writes the response itself.

## Verification

- `shadow-cljs compile server` — clean, 0 warnings. This is the build CI runs; `release` cannot run on this build (`:optimizations :none`), which `build-images.yml:162` already documents.
- `clj-kondo --lint src/cljs test/cljs` — **errors: 0**, down from 1 (`mcp-handle-post!` had crossed the function ceiling).
- 744 tests, 2208 assertions, 0 failures 0 errors. Also fixed `mcp_schema_test`'s reference to the moved `stateless-transport-options`, which was an undeclared-var warning masking a skipped assertion.
- JS boundary check and error-boundary check pass.
- The new tests were **mutated to confirm they can fail** — including both async ones, so `done` is genuinely awaited rather than the test passing vacuously.

## Not in scope

Hierarchical tool grants on the consent page (`knoxx-mcp-consent-permission-groups`) — blocked on `eta-mu:capability-schema-reconciliation`.

Also noticed and deliberately not fixed here: `get-actor-credential-by-actor-and-provider!` looks up the membership with `findOne {actor_id}` and **no org scope**, so an actor id reused across orgs resolves to an arbitrary membership. Harmless at one org, a cross-tenant credential leak if that stops being true. Wants its own card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP requests now maintain actor context across asynchronous operations.
  * OAuth tokens and consent flows preserve actor identity and reject mismatches.
  * MCP transport supports improved authorization challenges, session handling, content negotiation, and structured errors.
  * Consent pages provide clearer tool selection and actor information.
* **Bug Fixes**
  * Invalid MCP parameters and unauthorized tool selections now receive consistent validation errors.
  * Actorless or inconsistent authorization contexts are handled safely.
* **Documentation**
  * Added roadmap links and expanded project planning documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->