### PR TITLE
security(svg): guard Puppeteer document rendering

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -19,7 +19,7 @@
     "test:shadow": "shadow-cljs compile test",
     "test:e2e": "node --test tests/*.e2e.test.mjs",
     "lint": "clj-kondo --lint src/cljs test/cljs",
-    "lint:shared-markup": "clj-kondo --lint ../shared/src/cljs src/cljs/knoxx/backend/infra/routes/mcp/consent.cljs src/cljs/knoxx/backend/infra/svg_render.cljs test/cljs/knoxx/backend/uxx_html_renderer_test.cljs test/cljs/knoxx/backend/mcp_consent_rendering_test.cljs test/cljs/knoxx/backend/svg_render_test.cljs --fail-level error",
+    "lint:shared-markup": "clj-kondo --lint ../shared/src/cljs src/cljs/knoxx/backend/law/svg.cljs src/cljs/knoxx/backend/infra/routes/mcp/consent.cljs src/cljs/knoxx/backend/infra/svg_render.cljs test/cljs/knoxx/backend/law/svg_test.cljs test/cljs/knoxx/backend/uxx_html_renderer_test.cljs test/cljs/knoxx/backend/mcp_consent_rendering_test.cljs test/cljs/knoxx/backend/svg_render_test.cljs --fail-level error",
     "boundary:check": "node scripts/check-js-boundary.mjs --check",
     "boundary:inventory": "node scripts/check-js-boundary.mjs --markdown",
     "error-boundaries:check": "node scripts/check-error-boundaries.mjs --check",

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,7 +19,7 @@
     "test:shadow": "shadow-cljs compile test",
     "test:e2e": "node --test tests/*.e2e.test.mjs",
     "lint": "clj-kondo --lint src/cljs test/cljs",
-    "lint:shared-markup": "clj-kondo --lint ../shared/src/cljs src/cljs/knoxx/backend/infra/routes/mcp/consent.cljs test/cljs/knoxx/backend/uxx_html_renderer_test.cljs test/cljs/knoxx/backend/mcp_consent_rendering_test.cljs --fail-level error",
+    "lint:shared-markup": "clj-kondo --lint ../shared/src/cljs src/cljs/knoxx/backend/infra/routes/mcp/consent.cljs src/cljs/knoxx/backend/infra/svg_render.cljs test/cljs/knoxx/backend/uxx_html_renderer_test.cljs test/cljs/knoxx/backend/mcp_consent_rendering_test.cljs test/cljs/knoxx/backend/svg_render_test.cljs --fail-level error",
     "boundary:check": "node scripts/check-js-boundary.mjs --check",
     "boundary:inventory": "node scripts/check-js-boundary.mjs --markdown",
     "error-boundaries:check": "node scripts/check-error-boundaries.mjs --check",

--- a/backend/src/cljs/knoxx/backend/infra/svg_render.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/svg_render.cljs
@@ -182,7 +182,8 @@
   [svg-string]
   (str "<!doctype html>\n" (html/render (svg-document-node svg-string))))
 
-(defn- ^:async prepare-page!
+(defn ^:async prepare-page!
+  "Configure a fresh Puppeteer page as a code-free, network-denied SVG canvas."
   [page width height]
   (await (.setViewport page #js {:width width :height height}))
   (await (.setJavaScriptEnabled page false))

--- a/backend/src/cljs/knoxx/backend/infra/svg_render.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/svg_render.cljs
@@ -5,6 +5,7 @@
    cold-start cost. Uses puppeteer-core so deployments can provide Chromium via
    PUPPETEER_EXECUTABLE_PATH/KNOXX_CHROMIUM_PATH or a common system path."
   (:require [clojure.string :as str]
+            [knoxx.backend.law.svg :as svg-law]
             [open-hax.uxx.markup :as markup]
             [open-hax.uxx.render.html :as html]
             ["node:fs" :as fs]
@@ -19,19 +20,6 @@
    "/usr/bin/google-chrome-stable"
    "/usr/bin/google-chrome"
    "/snap/bin/chromium"])
-
-(def ^:private svg-root-pattern #"(?is)^\s*<svg\b")
-(def ^:private prohibited-declaration-pattern #"(?is)<\s*!(?:doctype|entity)\b")
-(def ^:private processing-instruction-pattern #"(?is)<\?")
-(def ^:private prohibited-element-pattern
-  #"(?is)<\s*(?:script|foreignobject|iframe|object|embed|link|img|audio|video|source|base|meta|html|body|form|input|button|textarea|select|option|animate(?:motion|transform)?|set|discard)\b")
-(def ^:private event-attribute-pattern #"(?is)\son[a-z0-9:_-]*\s*=")
-(def ^:private base-attribute-pattern #"(?is)\s(?:xml:base|base)\s*=")
-(def ^:private resource-attribute-pattern
-  #"(?is)\s(?:href|xlink:href|src)\s*=\s*(?:\"([^\"]*)\"|'([^']*)'|([^\s>]+))")
-(def ^:private css-url-pattern
-  #"(?is)url\(\s*(?:\"([^\"]*)\"|'([^']*)'|([^)]*))\s*\)")
-(def ^:private css-import-pattern #"(?is)@import\b")
 
 (defn- env-value
   [k]
@@ -96,80 +84,12 @@
       (reset! browser-promise-atom launch-promise)
       (await launch-promise))))
 
-(defn- svg-preview
-  [svg-string]
-  (let [value (str (or svg-string ""))]
-    (.slice value 0 (min 160 (count value)))))
-
-(defn- reject-svg!
-  [message type svg-string]
-  (throw (ex-info message
-                  {:type type
-                   :preview (svg-preview svg-string)})))
-
-(defn- captured-reference
-  [match]
-  (str/trim (str (or (nth match 1 nil)
-                         (nth match 2 nil)
-                         (nth match 3 nil)
-                         ""))))
-
-(defn- local-fragment-reference?
-  [value]
-  (str/starts-with? value "#"))
-
-(defn validate-svg!
-  "Validate SVG before it crosses the explicit raw-markup capability boundary.
-
-   Local fragment references remain valid for gradients, filters, masks, clips,
-   symbols, and other in-document resources. Any reference that could resolve
-   outside the document is rejected; Chromium request interception is still
-   enabled as a defense-in-depth network boundary."
-  [svg-string]
-  (when-not (string? svg-string)
-    (reject-svg! "SVG content must be a string" :svg/invalid-content svg-string))
-  (let [candidate (str/trim svg-string)]
-    (when (str/blank? candidate)
-      (reject-svg! "SVG content cannot be blank" :svg/blank-content svg-string))
-    (when-not (re-find svg-root-pattern candidate)
-      (reject-svg! "SVG content must begin with an <svg> root"
-                   :svg/missing-root svg-string))
-    (when (re-find prohibited-declaration-pattern candidate)
-      (reject-svg! "SVG declarations and entities are not allowed"
-                   :svg/prohibited-declaration svg-string))
-    (when (re-find processing-instruction-pattern candidate)
-      (reject-svg! "SVG processing instructions are not allowed"
-                   :svg/processing-instruction svg-string))
-    (when (re-find prohibited-element-pattern candidate)
-      (reject-svg! "SVG contains an active, mutating, or HTML-only element"
-                   :svg/prohibited-element svg-string))
-    (when (re-find event-attribute-pattern candidate)
-      (reject-svg! "SVG event attributes are not allowed"
-                   :svg/event-attribute svg-string))
-    (when (re-find base-attribute-pattern candidate)
-      (reject-svg! "SVG base URL attributes are not allowed"
-                   :svg/base-url svg-string))
-    (when (re-find css-import-pattern candidate)
-      (reject-svg! "SVG CSS imports are not allowed"
-                   :svg/css-import svg-string))
-    (doseq [match (re-seq resource-attribute-pattern candidate)]
-      (let [reference (captured-reference match)]
-        (when-not (local-fragment-reference? reference)
-          (reject-svg! "SVG resource attributes must use local fragments"
-                       :svg/external-resource svg-string))))
-    (doseq [match (re-seq css-url-pattern candidate)]
-      (let [reference (captured-reference match)]
-        (when-not (local-fragment-reference? reference)
-          (reject-svg! "SVG CSS URLs must use local fragments"
-                       :svg/external-css-resource svg-string))))
-    candidate))
-
 (defn- trusted-svg-markup
   [svg-string]
-  (markup/trusted-html (validate-svg! svg-string)))
+  (markup/trusted-html (svg-law/validate-svg! svg-string)))
 
 (defn svg-document-node
-  "Build the browser document around validated SVG using the shared AST."
+  "Build the browser document around law-validated SVG using the shared AST."
   [svg-string]
   [:html {}
    [:head {}

--- a/backend/src/cljs/knoxx/backend/infra/svg_render.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/svg_render.cljs
@@ -24,7 +24,7 @@
 (def ^:private prohibited-declaration-pattern #"(?is)<\s*!(?:doctype|entity)\b")
 (def ^:private processing-instruction-pattern #"(?is)<\?")
 (def ^:private prohibited-element-pattern
-  #"(?is)<\s*(?:script|foreignobject|iframe|object|embed|link|img|audio|video|source|base|meta|html|body|form|input|button|textarea|select|option)\b")
+  #"(?is)<\s*(?:script|foreignobject|iframe|object|embed|link|img|audio|video|source|base|meta|html|body|form|input|button|textarea|select|option|animate(?:motion|transform)?|set|discard)\b")
 (def ^:private event-attribute-pattern #"(?is)\son[a-z0-9:_-]*\s*=")
 (def ^:private base-attribute-pattern #"(?is)\s(?:xml:base|base)\s*=")
 (def ^:private resource-attribute-pattern
@@ -141,7 +141,7 @@
       (reject-svg! "SVG processing instructions are not allowed"
                    :svg/processing-instruction svg-string))
     (when (re-find prohibited-element-pattern candidate)
-      (reject-svg! "SVG contains an active or HTML-only element"
+      (reject-svg! "SVG contains an active, mutating, or HTML-only element"
                    :svg/prohibited-element svg-string))
     (when (re-find event-attribute-pattern candidate)
       (reject-svg! "SVG event attributes are not allowed"

--- a/backend/src/cljs/knoxx/backend/infra/svg_render.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/svg_render.cljs
@@ -5,6 +5,8 @@
    cold-start cost. Uses puppeteer-core so deployments can provide Chromium via
    PUPPETEER_EXECUTABLE_PATH/KNOXX_CHROMIUM_PATH or a common system path."
   (:require [clojure.string :as str]
+            [open-hax.uxx.markup :as markup]
+            [open-hax.uxx.render.html :as html]
             ["node:fs" :as fs]
             ["puppeteer-core" :as puppeteer-core]))
 
@@ -17,6 +19,19 @@
    "/usr/bin/google-chrome-stable"
    "/usr/bin/google-chrome"
    "/snap/bin/chromium"])
+
+(def ^:private svg-root-pattern #"(?is)^\s*<svg\b")
+(def ^:private prohibited-declaration-pattern #"(?is)<\s*!(?:doctype|entity)\b")
+(def ^:private processing-instruction-pattern #"(?is)<\?")
+(def ^:private prohibited-element-pattern
+  #"(?is)<\s*(?:script|foreignobject|iframe|object|embed|link|img|audio|video|source|base|meta|html|body|form|input|button|textarea|select|option)\b")
+(def ^:private event-attribute-pattern #"(?is)\son[a-z0-9:_-]*\s*=")
+(def ^:private base-attribute-pattern #"(?is)\s(?:xml:base|base)\s*=")
+(def ^:private resource-attribute-pattern
+  #"(?is)\s(?:href|xlink:href|src)\s*=\s*(?:\"([^\"]*)\"|'([^']*)'|([^\s>]+))")
+(def ^:private css-url-pattern
+  #"(?is)url\(\s*(?:\"([^\"]*)\"|'([^']*)'|([^)]*))\s*\)")
+(def ^:private css-import-pattern #"(?is)@import\b")
 
 (defn- env-value
   [k]
@@ -81,19 +96,107 @@
       (reset! browser-promise-atom launch-promise)
       (await launch-promise))))
 
-(defn- svg-document
+(defn- svg-preview
   [svg-string]
-  (str "<!doctype html>"
-       "<html><head><meta charset='utf-8'></head>"
-       "<body style='margin:0;padding:0;background:transparent'>"
-       svg-string
-       "</body></html>"))
+  (let [value (str (or svg-string ""))]
+    (.slice value 0 (min 160 (count value)))))
+
+(defn- reject-svg!
+  [message type svg-string]
+  (throw (ex-info message
+                  {:type type
+                   :preview (svg-preview svg-string)})))
+
+(defn- captured-reference
+  [match]
+  (str/trim (str (or (nth match 1 nil)
+                         (nth match 2 nil)
+                         (nth match 3 nil)
+                         ""))))
+
+(defn- local-fragment-reference?
+  [value]
+  (str/starts-with? value "#"))
+
+(defn validate-svg!
+  "Validate SVG before it crosses the explicit raw-markup capability boundary.
+
+   Local fragment references remain valid for gradients, filters, masks, clips,
+   symbols, and other in-document resources. Any reference that could resolve
+   outside the document is rejected; Chromium request interception is still
+   enabled as a defense-in-depth network boundary."
+  [svg-string]
+  (when-not (string? svg-string)
+    (reject-svg! "SVG content must be a string" :svg/invalid-content svg-string))
+  (let [candidate (str/trim svg-string)]
+    (when (str/blank? candidate)
+      (reject-svg! "SVG content cannot be blank" :svg/blank-content svg-string))
+    (when-not (re-find svg-root-pattern candidate)
+      (reject-svg! "SVG content must begin with an <svg> root"
+                   :svg/missing-root svg-string))
+    (when (re-find prohibited-declaration-pattern candidate)
+      (reject-svg! "SVG declarations and entities are not allowed"
+                   :svg/prohibited-declaration svg-string))
+    (when (re-find processing-instruction-pattern candidate)
+      (reject-svg! "SVG processing instructions are not allowed"
+                   :svg/processing-instruction svg-string))
+    (when (re-find prohibited-element-pattern candidate)
+      (reject-svg! "SVG contains an active or HTML-only element"
+                   :svg/prohibited-element svg-string))
+    (when (re-find event-attribute-pattern candidate)
+      (reject-svg! "SVG event attributes are not allowed"
+                   :svg/event-attribute svg-string))
+    (when (re-find base-attribute-pattern candidate)
+      (reject-svg! "SVG base URL attributes are not allowed"
+                   :svg/base-url svg-string))
+    (when (re-find css-import-pattern candidate)
+      (reject-svg! "SVG CSS imports are not allowed"
+                   :svg/css-import svg-string))
+    (doseq [match (re-seq resource-attribute-pattern candidate)]
+      (let [reference (captured-reference match)]
+        (when-not (local-fragment-reference? reference)
+          (reject-svg! "SVG resource attributes must use local fragments"
+                       :svg/external-resource svg-string))))
+    (doseq [match (re-seq css-url-pattern candidate)]
+      (let [reference (captured-reference match)]
+        (when-not (local-fragment-reference? reference)
+          (reject-svg! "SVG CSS URLs must use local fragments"
+                       :svg/external-css-resource svg-string))))
+    candidate))
+
+(defn- trusted-svg-markup
+  [svg-string]
+  (markup/trusted-html (validate-svg! svg-string)))
+
+(defn svg-document-node
+  "Build the browser document around validated SVG using the shared AST."
+  [svg-string]
+  [:html {}
+   [:head {}
+    [:meta {:charset "utf-8"}]]
+   [:body {:style "margin:0;padding:0;background:transparent"}
+    (markup/raw-html (trusted-svg-markup svg-string))]])
+
+(defn svg-document
+  "Render a complete, deterministic browser document around validated SVG."
+  [svg-string]
+  (str "<!doctype html>\n" (html/render (svg-document-node svg-string))))
+
+(defn- ^:async prepare-page!
+  [page width height]
+  (await (.setViewport page #js {:width width :height height}))
+  (await (.setJavaScriptEnabled page false))
+  (await (.setRequestInterception page true))
+  (.on page "request"
+       (fn [request]
+         (.abort request "blockedbyclient")))
+  page)
 
 (defn- ^:async render-svg!
   [page svg-string width height]
-  (let [_ (await (.setViewport page #js {:width width :height height}))
-        _ (await (.setJavaScriptEnabled page false))
-        _ (await (.setContent page (svg-document svg-string) #js {:waitUntil "networkidle0"}))
+  (let [_ (await (prepare-page! page width height))
+        _ (await (.setContent page (svg-document svg-string)
+                              #js {:waitUntil "networkidle0"}))
         element (await (.$ page "svg"))]
     (when-not element
       (throw (js/Error. "Cannot render SVG: no <svg> element found.")))
@@ -107,7 +210,7 @@
     (.finally render-promise (fn [] (.close page)))))
 
 (defn ^:async svg->png
-  "Renders an SVG string to a PNG Node Buffer via headless Chromium.
+  "Renders a validated SVG string to a PNG Node Buffer via headless Chromium.
    Returns a js/Promise<Buffer>."
   [svg-string {:keys [width height] :or {width 600 height 300}}]
   (let [browser (await (get-browser))

--- a/backend/src/cljs/knoxx/backend/law/svg.cljs
+++ b/backend/src/cljs/knoxx/backend/law/svg.cljs
@@ -16,25 +16,23 @@
 (def ^:private tag-name-pattern #"^[A-Za-z_][A-Za-z0-9_.:-]*")
 (def ^:private closing-tag-pattern #"^/\s*([A-Za-z_][A-Za-z0-9_.:-]*)\s*$")
 
-(defn- svg-preview
-  [svg-string]
-  (let [value (str (or svg-string ""))]
-    (.slice value 0 (min 160 (count value)))))
+(defn- preview
+  [value]
+  (let [text (str (or value ""))]
+    (.slice text 0 (min 160 (count text)))))
 
-(defn- reject-svg!
-  [message type svg-string]
-  (throw (ex-info message
-                  {:type type
-                   :preview (svg-preview svg-string)})))
+(defn- reject!
+  [message type value]
+  (throw (ex-info message {:type type :preview (preview value)})))
 
-(defn- captured-reference
+(defn- capture
   [match]
   (str/trim (str (or (nth match 1 nil)
                          (nth match 2 nil)
                          (nth match 3 nil)
                          ""))))
 
-(defn- local-fragment-reference?
+(defn- local-fragment?
   [value]
   (str/starts-with? value "#"))
 
@@ -46,7 +44,7 @@
   [candidate start token type]
   (let [index (.indexOf candidate token start)]
     (when (= -1 index)
-      (reject-svg! "SVG contains unterminated markup" type candidate))
+      (reject! "SVG contains unterminated markup" type candidate))
     (+ index (count token))))
 
 (defn- tag-end
@@ -54,8 +52,8 @@
   (loop [index (inc start)
          quote nil]
     (when (>= index (count candidate))
-      (reject-svg! "SVG contains an unterminated tag"
-                   :svg/unterminated-tag candidate))
+      (reject! "SVG contains an unterminated tag"
+               :svg/unterminated-tag candidate))
     (let [character (.charAt candidate index)]
       (cond
         quote
@@ -74,25 +72,89 @@
   [candidate start end]
   (let [token (str/trim (.slice candidate (inc start) end))]
     (when (or (str/blank? token) (str/includes? token "<"))
-      (reject-svg! "SVG contains a malformed tag" :svg/malformed-tag candidate))
+      (reject! "SVG contains a malformed tag" :svg/malformed-tag candidate))
     (if (str/starts-with? token "/")
       (if-let [[_ name] (re-matches closing-tag-pattern token)]
         {:kind :close :name (str/lower-case name)}
-        (reject-svg! "SVG contains a malformed closing tag"
-                     :svg/malformed-closing-tag candidate))
+        (reject! "SVG contains a malformed closing tag"
+                 :svg/malformed-closing-tag candidate))
       (let [self-closing? (boolean (re-find #"/\s*$" token))
             opening-token (if self-closing?
                             (str/trim (str/replace token #"/\s*$" ""))
                             token)
             name (re-find tag-name-pattern opening-token)]
         (when-not name
-          (reject-svg! "SVG contains a malformed opening tag"
-                       :svg/malformed-opening-tag candidate))
+          (reject! "SVG contains a malformed opening tag"
+                   :svg/malformed-opening-tag candidate))
         {:kind :open
          :name (str/lower-case name)
          :self-closing? self-closing?}))))
 
-(defn- require-single-svg-document!
+(defn- advance-special
+  [candidate index stack seen-root? root-closed?]
+  (cond
+    (starts-at? candidate index "<!--")
+    (do
+      (when (empty? stack)
+        (reject! "SVG comments must be inside the root element"
+                 :svg/outside-root-markup candidate))
+      [(sequence-end candidate (+ index 4) "-->" :svg/unterminated-comment)
+       stack seen-root? root-closed?])
+
+    (starts-at? candidate index "<![CDATA[")
+    (do
+      (when (empty? stack)
+        (reject! "SVG CDATA must be inside the root element"
+                 :svg/outside-root-markup candidate))
+      [(sequence-end candidate (+ index 9) "]]>" :svg/unterminated-cdata)
+       stack seen-root? root-closed?])
+
+    (starts-at? candidate index "<!")
+    (reject! "SVG declarations are not allowed"
+             :svg/prohibited-declaration candidate)
+
+    (starts-at? candidate index "<?")
+    (reject! "SVG processing instructions are not allowed"
+             :svg/processing-instruction candidate)
+
+    :else nil))
+
+(defn- advance-tag
+  [candidate index stack seen-root? root-closed?]
+  (let [end (tag-end candidate index)
+        {:keys [kind name self-closing?]} (parse-tag candidate index end)
+        next-index (inc end)]
+    (case kind
+      :open
+      (if (empty? stack)
+        (do
+          (when (or seen-root? root-closed?)
+            (reject! "SVG document contains trailing markup or another root"
+                     :svg/multiple-roots candidate))
+          (when-not (= "svg" name)
+            (reject! "SVG document root must be <svg>"
+                     :svg/missing-root candidate))
+          [next-index
+           (if self-closing? [] [name])
+           true
+           self-closing?])
+        [next-index
+         (if self-closing? stack (conj stack name))
+         seen-root?
+         root-closed?])
+
+      :close
+      (do
+        (when (empty? stack)
+          (reject! "SVG document contains an unexpected closing tag"
+                   :svg/unexpected-closing-tag candidate))
+        (when-not (= name (peek stack))
+          (reject! "SVG document contains mismatched tags"
+                   :svg/mismatched-tags candidate))
+        (let [next-stack (pop stack)]
+          [next-index next-stack seen-root? (empty? next-stack)])))))
+
+(defn- single-document!
   [candidate]
   (loop [index 0
          stack []
@@ -101,80 +163,24 @@
     (if (>= index (count candidate))
       (do
         (when (seq stack)
-          (reject-svg! "SVG document has unclosed elements"
-                       :svg/unclosed-elements candidate))
+          (reject! "SVG document has unclosed elements"
+                   :svg/unclosed-elements candidate))
         (when-not (and seen-root? root-closed?)
-          (reject-svg! "SVG content must contain exactly one SVG root"
-                       :svg/missing-root candidate))
+          (reject! "SVG content must contain exactly one SVG root"
+                   :svg/missing-root candidate))
         candidate)
-      (if-not (= "<" (.charAt candidate index))
+      (if (= "<" (.charAt candidate index))
+        (let [[next-index next-stack next-seen? next-closed?]
+              (or (advance-special candidate index stack seen-root? root-closed?)
+                  (advance-tag candidate index stack seen-root? root-closed?))]
+          (recur next-index next-stack next-seen? next-closed?))
         (let [next-tag (.indexOf candidate "<" index)
               end (if (= -1 next-tag) (count candidate) next-tag)
               text (.slice candidate index end)]
           (when (and (empty? stack) (not (str/blank? text)))
-            (reject-svg! "SVG document contains text outside the root element"
-                         :svg/trailing-content candidate))
-          (recur end stack seen-root? root-closed?))
-        (cond
-          (starts-at? candidate index "<!--")
-          (do
-            (when (empty? stack)
-              (reject-svg! "SVG comments must be inside the root element"
-                           :svg/outside-root-markup candidate))
-            (recur (sequence-end candidate (+ index 4) "-->"
-                                 :svg/unterminated-comment)
-                   stack seen-root? root-closed?))
-
-          (starts-at? candidate index "<![CDATA[")
-          (do
-            (when (empty? stack)
-              (reject-svg! "SVG CDATA must be inside the root element"
-                           :svg/outside-root-markup candidate))
-            (recur (sequence-end candidate (+ index 9) "]]>")
-                                 :svg/unterminated-cdata)
-                   stack seen-root? root-closed?))
-
-          (starts-at? candidate index "<!")
-          (reject-svg! "SVG declarations are not allowed"
-                       :svg/prohibited-declaration candidate)
-
-          (starts-at? candidate index "<?")
-          (reject-svg! "SVG processing instructions are not allowed"
-                       :svg/processing-instruction candidate)
-
-          :else
-          (let [end (tag-end candidate index)
-                {:keys [kind name self-closing?]} (parse-tag candidate index end)
-                next-index (inc end)]
-            (case kind
-              :open
-              (if (empty? stack)
-                (do
-                  (when (or seen-root? root-closed?)
-                    (reject-svg! "SVG document contains trailing markup or another root"
-                                 :svg/multiple-roots candidate))
-                  (when-not (= "svg" name)
-                    (reject-svg! "SVG document root must be <svg>"
-                                 :svg/missing-root candidate))
-                  (recur next-index
-                         (if self-closing? [] [name])
-                         true
-                         self-closing?))
-                (recur next-index
-                       (if self-closing? stack (conj stack name))
-                       seen-root?
-                       root-closed?))
-
-              :close
-              (do
-                (when (empty? stack)
-                  (reject-svg! "SVG document contains an unexpected closing tag"
-                               :svg/unexpected-closing-tag candidate))
-                (when-not (= name (peek stack))
-                  (reject-svg! "SVG document contains mismatched tags"
-                               :svg/mismatched-tags candidate))
-                (let [next-stack (pop stack)]
-                  (recur next-index next-stack seen-root? (empty? next-stack))))))))))))
+            (reject! "SVG document contains text outside the root element"
+                     :svg/trailing-content candidate))
+          (recur end stack seen-root? root-closed?))))))
 
 (defn validate-svg!
   "Return one static, resource-local SVG document or throw structured ex-info.
@@ -184,34 +190,34 @@
    filters, masks, clips, symbols, and other in-document resources."
   [svg-string]
   (when-not (string? svg-string)
-    (reject-svg! "SVG content must be a string" :svg/invalid-content svg-string))
+    (reject! "SVG content must be a string" :svg/invalid-content svg-string))
   (let [candidate (str/trim svg-string)]
     (when (str/blank? candidate)
-      (reject-svg! "SVG content cannot be blank" :svg/blank-content svg-string))
+      (reject! "SVG content cannot be blank" :svg/blank-content svg-string))
     (when (re-find prohibited-declaration-pattern candidate)
-      (reject-svg! "SVG declarations and entities are not allowed"
-                   :svg/prohibited-declaration svg-string))
+      (reject! "SVG declarations and entities are not allowed"
+               :svg/prohibited-declaration svg-string))
     (when (re-find processing-instruction-pattern candidate)
-      (reject-svg! "SVG processing instructions are not allowed"
-                   :svg/processing-instruction svg-string))
+      (reject! "SVG processing instructions are not allowed"
+               :svg/processing-instruction svg-string))
     (when (re-find prohibited-element-pattern candidate)
-      (reject-svg! "SVG contains an active, mutating, or HTML-only element"
-                   :svg/prohibited-element svg-string))
+      (reject! "SVG contains an active, mutating, or HTML-only element"
+               :svg/prohibited-element svg-string))
     (when (re-find event-attribute-pattern candidate)
-      (reject-svg! "SVG event attributes are not allowed"
-                   :svg/event-attribute svg-string))
+      (reject! "SVG event attributes are not allowed"
+               :svg/event-attribute svg-string))
     (when (re-find base-attribute-pattern candidate)
-      (reject-svg! "SVG base URL attributes are not allowed"
-                   :svg/base-url svg-string))
+      (reject! "SVG base URL attributes are not allowed"
+               :svg/base-url svg-string))
     (when (re-find css-import-pattern candidate)
-      (reject-svg! "SVG CSS imports are not allowed"
-                   :svg/css-import svg-string))
+      (reject! "SVG CSS imports are not allowed"
+               :svg/css-import svg-string))
     (doseq [match (re-seq resource-attribute-pattern candidate)]
-      (when-not (local-fragment-reference? (captured-reference match))
-        (reject-svg! "SVG resource attributes must use local fragments"
-                     :svg/external-resource svg-string)))
+      (when-not (local-fragment? (capture match))
+        (reject! "SVG resource attributes must use local fragments"
+                 :svg/external-resource svg-string)))
     (doseq [match (re-seq css-url-pattern candidate)]
-      (when-not (local-fragment-reference? (captured-reference match))
-        (reject-svg! "SVG CSS URLs must use local fragments"
-                     :svg/external-css-resource svg-string)))
-    (require-single-svg-document! candidate)))
+      (when-not (local-fragment? (capture match))
+        (reject! "SVG CSS URLs must use local fragments"
+                 :svg/external-css-resource svg-string)))
+    (single-document! candidate)))

--- a/backend/src/cljs/knoxx/backend/law/svg.cljs
+++ b/backend/src/cljs/knoxx/backend/law/svg.cljs
@@ -131,6 +131,7 @@
               (reject-svg! "SVG CDATA must be inside the root element"
                            :svg/outside-root-markup candidate))
             (recur (sequence-end candidate (+ index 9) "]]>")
+                                 :svg/unterminated-cdata)
                    stack seen-root? root-closed?))
 
           (starts-at? candidate index "<!")

--- a/backend/src/cljs/knoxx/backend/law/svg.cljs
+++ b/backend/src/cljs/knoxx/backend/law/svg.cljs
@@ -1,0 +1,216 @@
+(ns knoxx.backend.law.svg
+  "Pure validation law for SVG accepted by the headless browser renderer."
+  (:require [clojure.string :as str]))
+
+(def ^:private prohibited-declaration-pattern #"(?is)<\s*!(?:doctype|entity)\b")
+(def ^:private processing-instruction-pattern #"(?is)<\?")
+(def ^:private prohibited-element-pattern
+  #"(?is)<\s*(?:script|foreignobject|iframe|object|embed|link|img|audio|video|source|base|meta|html|body|form|input|button|textarea|select|option|animate(?:motion|transform)?|set|discard)\b")
+(def ^:private event-attribute-pattern #"(?is)\son[a-z0-9:_-]*\s*=")
+(def ^:private base-attribute-pattern #"(?is)\s(?:xml:base|base)\s*=")
+(def ^:private resource-attribute-pattern
+  #"(?is)\s(?:href|xlink:href|src)\s*=\s*(?:\"([^\"]*)\"|'([^']*)'|([^\s>]+))")
+(def ^:private css-url-pattern
+  #"(?is)url\(\s*(?:\"([^\"]*)\"|'([^']*)'|([^)]*))\s*\)")
+(def ^:private css-import-pattern #"(?is)@import\b")
+(def ^:private tag-name-pattern #"^[A-Za-z_][A-Za-z0-9_.:-]*")
+(def ^:private closing-tag-pattern #"^/\s*([A-Za-z_][A-Za-z0-9_.:-]*)\s*$")
+
+(defn- svg-preview
+  [svg-string]
+  (let [value (str (or svg-string ""))]
+    (.slice value 0 (min 160 (count value)))))
+
+(defn- reject-svg!
+  [message type svg-string]
+  (throw (ex-info message
+                  {:type type
+                   :preview (svg-preview svg-string)})))
+
+(defn- captured-reference
+  [match]
+  (str/trim (str (or (nth match 1 nil)
+                         (nth match 2 nil)
+                         (nth match 3 nil)
+                         ""))))
+
+(defn- local-fragment-reference?
+  [value]
+  (str/starts-with? value "#"))
+
+(defn- starts-at?
+  [value index token]
+  (= token (.slice value index (+ index (count token)))))
+
+(defn- sequence-end
+  [candidate start token type]
+  (let [index (.indexOf candidate token start)]
+    (when (= -1 index)
+      (reject-svg! "SVG contains unterminated markup" type candidate))
+    (+ index (count token))))
+
+(defn- tag-end
+  [candidate start]
+  (loop [index (inc start)
+         quote nil]
+    (when (>= index (count candidate))
+      (reject-svg! "SVG contains an unterminated tag"
+                   :svg/unterminated-tag candidate))
+    (let [character (.charAt candidate index)]
+      (cond
+        quote
+        (recur (inc index) (when-not (= character quote) quote))
+
+        (or (= character "\"") (= character "'"))
+        (recur (inc index) character)
+
+        (= character ">")
+        index
+
+        :else
+        (recur (inc index) nil)))))
+
+(defn- parse-tag
+  [candidate start end]
+  (let [token (str/trim (.slice candidate (inc start) end))]
+    (when (or (str/blank? token) (str/includes? token "<"))
+      (reject-svg! "SVG contains a malformed tag" :svg/malformed-tag candidate))
+    (if (str/starts-with? token "/")
+      (if-let [[_ name] (re-matches closing-tag-pattern token)]
+        {:kind :close :name (str/lower-case name)}
+        (reject-svg! "SVG contains a malformed closing tag"
+                     :svg/malformed-closing-tag candidate))
+      (let [self-closing? (boolean (re-find #"/\s*$" token))
+            opening-token (if self-closing?
+                            (str/trim (str/replace token #"/\s*$" ""))
+                            token)
+            name (re-find tag-name-pattern opening-token)]
+        (when-not name
+          (reject-svg! "SVG contains a malformed opening tag"
+                       :svg/malformed-opening-tag candidate))
+        {:kind :open
+         :name (str/lower-case name)
+         :self-closing? self-closing?}))))
+
+(defn- require-single-svg-document!
+  [candidate]
+  (loop [index 0
+         stack []
+         seen-root? false
+         root-closed? false]
+    (if (>= index (count candidate))
+      (do
+        (when (seq stack)
+          (reject-svg! "SVG document has unclosed elements"
+                       :svg/unclosed-elements candidate))
+        (when-not (and seen-root? root-closed?)
+          (reject-svg! "SVG content must contain exactly one SVG root"
+                       :svg/missing-root candidate))
+        candidate)
+      (if-not (= "<" (.charAt candidate index))
+        (let [next-tag (.indexOf candidate "<" index)
+              end (if (= -1 next-tag) (count candidate) next-tag)
+              text (.slice candidate index end)]
+          (when (and (empty? stack) (not (str/blank? text)))
+            (reject-svg! "SVG document contains text outside the root element"
+                         :svg/trailing-content candidate))
+          (recur end stack seen-root? root-closed?))
+        (cond
+          (starts-at? candidate index "<!--")
+          (do
+            (when (empty? stack)
+              (reject-svg! "SVG comments must be inside the root element"
+                           :svg/outside-root-markup candidate))
+            (recur (sequence-end candidate (+ index 4) "-->"
+                                 :svg/unterminated-comment)
+                   stack seen-root? root-closed?))
+
+          (starts-at? candidate index "<![CDATA[")
+          (do
+            (when (empty? stack)
+              (reject-svg! "SVG CDATA must be inside the root element"
+                           :svg/outside-root-markup candidate))
+            (recur (sequence-end candidate (+ index 9) "]]>")
+                   stack seen-root? root-closed?))
+
+          (starts-at? candidate index "<!")
+          (reject-svg! "SVG declarations are not allowed"
+                       :svg/prohibited-declaration candidate)
+
+          (starts-at? candidate index "<?")
+          (reject-svg! "SVG processing instructions are not allowed"
+                       :svg/processing-instruction candidate)
+
+          :else
+          (let [end (tag-end candidate index)
+                {:keys [kind name self-closing?]} (parse-tag candidate index end)
+                next-index (inc end)]
+            (case kind
+              :open
+              (if (empty? stack)
+                (do
+                  (when (or seen-root? root-closed?)
+                    (reject-svg! "SVG document contains trailing markup or another root"
+                                 :svg/multiple-roots candidate))
+                  (when-not (= "svg" name)
+                    (reject-svg! "SVG document root must be <svg>"
+                                 :svg/missing-root candidate))
+                  (recur next-index
+                         (if self-closing? [] [name])
+                         true
+                         self-closing?))
+                (recur next-index
+                       (if self-closing? stack (conj stack name))
+                       seen-root?
+                       root-closed?))
+
+              :close
+              (do
+                (when (empty? stack)
+                  (reject-svg! "SVG document contains an unexpected closing tag"
+                               :svg/unexpected-closing-tag candidate))
+                (when-not (= name (peek stack))
+                  (reject-svg! "SVG document contains mismatched tags"
+                               :svg/mismatched-tags candidate))
+                (let [next-stack (pop stack)]
+                  (recur next-index next-stack seen-root? (empty? next-stack))))))))))))
+
+(defn validate-svg!
+  "Return one static, resource-local SVG document or throw structured ex-info.
+
+   The accepted document has exactly one balanced `<svg>` root and no markup or
+   text outside it. Local fragment references remain available for gradients,
+   filters, masks, clips, symbols, and other in-document resources."
+  [svg-string]
+  (when-not (string? svg-string)
+    (reject-svg! "SVG content must be a string" :svg/invalid-content svg-string))
+  (let [candidate (str/trim svg-string)]
+    (when (str/blank? candidate)
+      (reject-svg! "SVG content cannot be blank" :svg/blank-content svg-string))
+    (when (re-find prohibited-declaration-pattern candidate)
+      (reject-svg! "SVG declarations and entities are not allowed"
+                   :svg/prohibited-declaration svg-string))
+    (when (re-find processing-instruction-pattern candidate)
+      (reject-svg! "SVG processing instructions are not allowed"
+                   :svg/processing-instruction svg-string))
+    (when (re-find prohibited-element-pattern candidate)
+      (reject-svg! "SVG contains an active, mutating, or HTML-only element"
+                   :svg/prohibited-element svg-string))
+    (when (re-find event-attribute-pattern candidate)
+      (reject-svg! "SVG event attributes are not allowed"
+                   :svg/event-attribute svg-string))
+    (when (re-find base-attribute-pattern candidate)
+      (reject-svg! "SVG base URL attributes are not allowed"
+                   :svg/base-url svg-string))
+    (when (re-find css-import-pattern candidate)
+      (reject-svg! "SVG CSS imports are not allowed"
+                   :svg/css-import svg-string))
+    (doseq [match (re-seq resource-attribute-pattern candidate)]
+      (when-not (local-fragment-reference? (captured-reference match))
+        (reject-svg! "SVG resource attributes must use local fragments"
+                     :svg/external-resource svg-string)))
+    (doseq [match (re-seq css-url-pattern candidate)]
+      (when-not (local-fragment-reference? (captured-reference match))
+        (reject-svg! "SVG CSS URLs must use local fragments"
+                     :svg/external-css-resource svg-string)))
+    (require-single-svg-document! candidate)))

--- a/backend/test/cljs/knoxx/backend/law/svg_test.cljs
+++ b/backend/test/cljs/knoxx/backend/law/svg_test.cljs
@@ -1,0 +1,69 @@
+(ns knoxx.backend.law.svg-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [knoxx.backend.law.svg :as svg]))
+
+(def browser-feature-svg
+  "<svg width='240' height='120' xmlns='http://www.w3.org/2000/svg'>
+     <defs>
+       <filter id='glow'><feGaussianBlur stdDeviation='3'/></filter>
+       <linearGradient id='g'><stop offset='0%' stop-color='#ff00aa'/></linearGradient>
+       <path id='shape' d='M0 0h10v10z'/>
+     </defs>
+     <rect width='10' height='10' fill='url(#g)' filter='url(#glow)'/>
+     <use href='#shape'/>
+   </svg>")
+
+(defn- rejection-data
+  [value]
+  (try
+    (svg/validate-svg! value)
+    nil
+    (catch :default error
+      (ex-data error))))
+
+(deftest accepts-one-static-resource-local-SVG-document
+  (is (= browser-feature-svg (svg/validate-svg! browser-feature-svg)))
+  (is (= "<svg/>" (svg/validate-svg! "  <svg/>  ")))
+  (is (= "<svg><svg><rect/></svg></svg>"
+         (svg/validate-svg! "<svg><svg><rect/></svg></svg>")))
+  (is (= "<svg><path data-label='a > b'/><!-- ok --><![CDATA[2 < 3]]></svg>"
+         (svg/validate-svg!
+          "<svg><path data-label='a > b'/><!-- ok --><![CDATA[2 < 3]]></svg>"))))
+
+(deftest rejects-active-content-and-resource-loading
+  (doseq [[label payload]
+          [["non-string" #js {}]
+           ["blank" "   "]
+           ["missing root" "<div>not svg</div>"]
+           ["doctype" "<svg><!DOCTYPE svg></svg>"]
+           ["processing instruction" "<svg><?xml-stylesheet href='https://evil.test/x.css'?></svg>"]
+           ["script" "<svg><script>alert(1)</script></svg>"]
+           ["foreignObject" "<svg><foreignObject><div>html</div></foreignObject></svg>"]
+           ["event attribute" "<svg onload='alert(1)'></svg>"]
+           ["base URL" "<svg xml:base='https://evil.test/'><use href='#shape'/></svg>"]
+           ["declarative mutation" "<svg><image id='target'/><set href='#target' attributeName='href' to='https://evil.test/image.png'/></svg>"]
+           ["external href" "<svg><image href='https://evil.test/image.png'/></svg>"]
+           ["protocol-relative href" "<svg><image href='//evil.test/image.png'/></svg>"]
+           ["data SVG" "<svg><image href='data:image/svg+xml,%3Csvg/%3E'/></svg>"]
+           ["external CSS URL" "<svg><style>rect{fill:url(https://evil.test/fill.svg)}</style></svg>"]
+           ["CSS data URL" "<svg><rect style='fill:url(data:image/png;base64,AAAA)'/></svg>"]
+           ["CSS import" "<svg><style>@import 'https://evil.test/x.css';</style></svg>"]]]
+    (testing label
+      (is (some? (rejection-data payload))))))
+
+(deftest requires-exactly-one-balanced-root-with-no-trailing-content
+  (doseq [[label payload expected-type]
+          [["trailing HTML" "<svg></svg><div>unexpected</div>" :svg/multiple-roots]
+           ["trailing SVG" "<svg></svg><svg></svg>" :svg/multiple-roots]
+           ["trailing text" "<svg></svg>unexpected" :svg/trailing-content]
+           ["leading comment" "<!-- outside --><svg/>" :svg/outside-root-markup]
+           ["trailing comment" "<svg/><!-- outside -->" :svg/outside-root-markup]
+           ["mismatched tags" "<svg><g></svg>" :svg/mismatched-tags]
+           ["unclosed root" "<svg><g/></svg" :svg/unterminated-tag]
+           ["unclosed child" "<svg><g></svg>" :svg/mismatched-tags]
+           ["unterminated comment" "<svg><!-- nope</svg>" :svg/unterminated-comment]
+           ["unterminated CDATA" "<svg><![CDATA[nope</svg>" :svg/unterminated-cdata]]]
+    (testing label
+      (let [data (rejection-data payload)]
+        (is (= expected-type (:type data)))
+        (is (string? (:preview data)))))))

--- a/backend/test/cljs/knoxx/backend/svg_render_test.cljs
+++ b/backend/test/cljs/knoxx/backend/svg_render_test.cljs
@@ -1,5 +1,5 @@
 (ns knoxx.backend.svg-render-test
-  (:require [cljs.test :refer [async deftest is testing]]
+  (:require [cljs.test :refer [deftest is testing]]
             [clojure.string :as str]
             [knoxx.backend.infra.svg-render :as svg-render]
             ["node:fs" :as fs]))
@@ -36,6 +36,88 @@
      <rect width='240' height='120' fill='#101020'/>
      <text x='20' y='70' font-family='Georgia, Arial' font-size='42' fill='url(#g)' filter='url(#glow)'>Knoxx</text>
    </svg>")
+
+(def fragment-reference-svg
+  "<svg xmlns='http://www.w3.org/2000/svg'>
+     <defs>
+       <linearGradient id='g'><stop offset='0%' stop-color='#fff'/></linearGradient>
+       <path id='shape' d='M0 0h10v10z'/>
+     </defs>
+     <rect width='10' height='10' fill='url(#g)'/>
+     <use href='#shape'/>
+   </svg>")
+
+(deftest svg-document-renders-through-the-shared-markup-shell
+  (let [svg "<svg xmlns='http://www.w3.org/2000/svg'><rect width='1' height='1'/></svg>"]
+    (is (= (str "<!doctype html>\n"
+                "<html><head><meta charset=\"utf-8\"></head>"
+                "<body style=\"margin:0;padding:0;background:transparent\">"
+                svg
+                "</body></html>")
+           (svg-render/svg-document svg)))))
+
+(deftest SVG-validation-preserves-local-browser-features
+  (is (= browser-feature-svg (svg-render/validate-svg! browser-feature-svg)))
+  (is (= fragment-reference-svg (svg-render/validate-svg! fragment-reference-svg))))
+
+(deftest SVG-validation-rejects-active-content-and-resource-loading
+  (doseq [[label payload]
+          [["non-string" #js {}]
+           ["blank" "   "]
+           ["missing root" "<div>not svg</div>"]
+           ["doctype" "<svg><!DOCTYPE svg></svg>"]
+           ["processing instruction" "<svg><?xml-stylesheet href='https://evil.test/x.css'?></svg>"]
+           ["script" "<svg><script>alert(1)</script></svg>"]
+           ["foreignObject" "<svg><foreignObject><div>html</div></foreignObject></svg>"]
+           ["HTML sibling" "<svg></svg><img src='https://evil.test/pixel'>"]
+           ["event attribute" "<svg onload='alert(1)'></svg>"]
+           ["base URL" "<svg xml:base='https://evil.test/'><use href='#shape'/></svg>"]
+           ["external href" "<svg><image href='https://evil.test/image.png'/></svg>"]
+           ["protocol-relative href" "<svg><image href='//evil.test/image.png'/></svg>"]
+           ["data SVG" "<svg><image href='data:image/svg+xml,%3Csvg/%3E'/></svg>"]
+           ["external CSS URL" "<svg><style>rect{fill:url(https://evil.test/fill.svg)}</style></svg>"]
+           ["CSS data URL" "<svg><rect style='fill:url(data:image/png;base64,AAAA)'/></svg>"]
+           ["CSS import" "<svg><style>@import 'https://evil.test/x.css';</style></svg>"]]]
+    (testing label
+      (is (thrown? js/Error (svg-render/validate-svg! payload))))))
+
+(deftest ^:async prepare-page-disables-code-and-denies-network
+  (let [calls (atom [])
+        request-handler (atom nil)
+        page #js {}]
+    (aset page "setViewport"
+          (fn [viewport]
+            (swap! calls conj [:viewport (js->clj viewport :keywordize-keys true)])
+            (js/Promise.resolve nil)))
+    (aset page "setJavaScriptEnabled"
+          (fn [enabled?]
+            (swap! calls conj [:javascript enabled?])
+            (js/Promise.resolve nil)))
+    (aset page "setRequestInterception"
+          (fn [enabled?]
+            (swap! calls conj [:interception enabled?])
+            (js/Promise.resolve nil)))
+    (aset page "on"
+          (fn [event-name handler]
+            (swap! calls conj [:listener event-name])
+            (reset! request-handler handler)
+            page))
+
+    (is (= page (await (svg-render/prepare-page! page 320 180))))
+    (is (= [[:viewport {:width 320 :height 180}]
+            [:javascript false]
+            [:interception true]
+            [:listener "request"]]
+           @calls))
+
+    (let [abort-calls (atom [])
+          request #js {}]
+      (aset request "abort"
+            (fn [reason]
+              (swap! abort-calls conj reason)
+              (js/Promise.resolve nil)))
+      (@request-handler request)
+      (is (= ["blockedbyclient"] @abort-calls)))))
 
 (deftest ^:async svg->png-renders-browser-svg-features
   (testing "Chromium produces a PNG buffer for filter, text font fallback, and text gradient SVGs"

--- a/backend/test/cljs/knoxx/backend/svg_render_test.cljs
+++ b/backend/test/cljs/knoxx/backend/svg_render_test.cljs
@@ -37,16 +37,6 @@
      <text x='20' y='70' font-family='Georgia, Arial' font-size='42' fill='url(#g)' filter='url(#glow)'>Knoxx</text>
    </svg>")
 
-(def fragment-reference-svg
-  "<svg xmlns='http://www.w3.org/2000/svg'>
-     <defs>
-       <linearGradient id='g'><stop offset='0%' stop-color='#fff'/></linearGradient>
-       <path id='shape' d='M0 0h10v10z'/>
-     </defs>
-     <rect width='10' height='10' fill='url(#g)'/>
-     <use href='#shape'/>
-   </svg>")
-
 (deftest svg-document-renders-through-the-shared-markup-shell
   (let [svg "<svg xmlns='http://www.w3.org/2000/svg'><rect width='1' height='1'/></svg>"]
     (is (= (str "<!doctype html>\n"
@@ -55,32 +45,6 @@
                 svg
                 "</body></html>")
            (svg-render/svg-document svg)))))
-
-(deftest SVG-validation-preserves-local-browser-features
-  (is (= browser-feature-svg (svg-render/validate-svg! browser-feature-svg)))
-  (is (= fragment-reference-svg (svg-render/validate-svg! fragment-reference-svg))))
-
-(deftest SVG-validation-rejects-active-content-and-resource-loading
-  (doseq [[label payload]
-          [["non-string" #js {}]
-           ["blank" "   "]
-           ["missing root" "<div>not svg</div>"]
-           ["doctype" "<svg><!DOCTYPE svg></svg>"]
-           ["processing instruction" "<svg><?xml-stylesheet href='https://evil.test/x.css'?></svg>"]
-           ["script" "<svg><script>alert(1)</script></svg>"]
-           ["foreignObject" "<svg><foreignObject><div>html</div></foreignObject></svg>"]
-           ["HTML sibling" "<svg></svg><img src='https://evil.test/pixel'>"]
-           ["event attribute" "<svg onload='alert(1)'></svg>"]
-           ["base URL" "<svg xml:base='https://evil.test/'><use href='#shape'/></svg>"]
-           ["declarative mutation" "<svg><image id='target'/><set href='#target' attributeName='href' to='https://evil.test/image.png'/></svg>"]
-           ["external href" "<svg><image href='https://evil.test/image.png'/></svg>"]
-           ["protocol-relative href" "<svg><image href='//evil.test/image.png'/></svg>"]
-           ["data SVG" "<svg><image href='data:image/svg+xml,%3Csvg/%3E'/></svg>"]
-           ["external CSS URL" "<svg><style>rect{fill:url(https://evil.test/fill.svg)}</style></svg>"]
-           ["CSS data URL" "<svg><rect style='fill:url(data:image/png;base64,AAAA)'/></svg>"]
-           ["CSS import" "<svg><style>@import 'https://evil.test/x.css';</style></svg>"]]]
-    (testing label
-      (is (thrown? js/Error (svg-render/validate-svg! payload))))))
 
 (deftest ^:async prepare-page-disables-code-and-denies-network
   (let [calls (atom [])

--- a/backend/test/cljs/knoxx/backend/svg_render_test.cljs
+++ b/backend/test/cljs/knoxx/backend/svg_render_test.cljs
@@ -72,6 +72,7 @@
            ["HTML sibling" "<svg></svg><img src='https://evil.test/pixel'>"]
            ["event attribute" "<svg onload='alert(1)'></svg>"]
            ["base URL" "<svg xml:base='https://evil.test/'><use href='#shape'/></svg>"]
+           ["declarative mutation" "<svg><image id='target'/><set href='#target' attributeName='href' to='https://evil.test/image.png'/></svg>"]
            ["external href" "<svg><image href='https://evil.test/image.png'/></svg>"]
            ["protocol-relative href" "<svg><image href='//evil.test/image.png'/></svg>"]
            ["data SVG" "<svg><image href='data:image/svg+xml,%3Csvg/%3E'/></svg>"]

--- a/docs/architecture/shared-markup-rendering.md
+++ b/docs/architecture/shared-markup-rendering.md
@@ -48,16 +48,19 @@ Dynamic SVG is not considered trusted merely because it is rendered with
 JavaScript disabled. SVG can still initiate browser requests through images,
 styles, fonts, filters, base URLs, and related resource references.
 
-A server renderer may wrap SVG in `:raw-html` only after a domain-specific
-validator has accepted it. The Knoxx Puppeteer renderer permits local fragment
-references such as `url(#glow)` and `href="#symbol"`, while rejecting active
-content, event attributes, declarations/entities, base URLs, CSS imports, and
-non-fragment resource references.
+Pure acceptance policy lives in `knoxx.backend.law.svg`; the
+`knoxx.backend.infra.svg-render` namespace contains only browser lifecycle and
+Puppeteer effects. The law requires exactly one balanced `<svg>` document root
+with no leading or trailing markup or text. It permits local fragment references
+such as `url(#glow)` and `href="#symbol"`, while rejecting active or mutating
+content, event attributes, declarations/entities, processing instructions,
+base URLs, CSS imports, and non-fragment resource references.
 
-Validation is not the only network boundary. The Puppeteer page also enables
-request interception and aborts every request before document content is set.
-This makes raw-markup validation the reviewed capability boundary and browser
-interception the defense-in-depth runtime boundary.
+Only after this law accepts the document may the infra adapter construct a UXX
+trusted raw-markup value. Validation is not the only network boundary: the
+Puppeteer page also enables request interception and aborts every request before
+document content is set. This makes the law the reviewed capability boundary
+and browser interception the defense-in-depth runtime boundary.
 
 ## First fixtures
 
@@ -67,16 +70,17 @@ copy while replacing local escaping and string concatenation with AST view
 functions plus the shared HTML renderer.
 
 The Puppeteer SVG document shell is the second fixture. Its outer HTML structure
-uses the same AST and deterministic renderer, while validated SVG crosses one
-explicit raw-markup boundary inside the body.
+uses the same AST and deterministic renderer, while law-validated SVG crosses
+one explicit raw-markup boundary inside the body.
 
 ## Consequences
 
 - Server and browser structure can be tested for normalized-DOM parity.
 - Security policy is centralized instead of repeated in templates.
 - React lifecycle, reconciliation, hooks, and context remain outside the AST.
-- Dynamic raw-markup domains must define their own validation capability before
+- Dynamic raw-markup domains must define pure law/guard validation before
   constructing a trusted value.
+- Effectful `infra.*` adapters invoke policy but do not own it.
 - Browser renderers must enforce network policy independently of string
   validation.
 - CSS-in-JS and a general template language are explicitly not introduced.

--- a/docs/architecture/shared-markup-rendering.md
+++ b/docs/architecture/shared-markup-rendering.md
@@ -42,16 +42,41 @@ by default. URL-bearing attributes use an allowlisted scheme policy. The HTML
 renderer remains React-free so OAuth, error, email, and static protocol pages do
 not require a browser runtime.
 
-## First fixture
+### Dynamic SVG
+
+Dynamic SVG is not considered trusted merely because it is rendered with
+JavaScript disabled. SVG can still initiate browser requests through images,
+styles, fonts, filters, base URLs, and related resource references.
+
+A server renderer may wrap SVG in `:raw-html` only after a domain-specific
+validator has accepted it. The Knoxx Puppeteer renderer permits local fragment
+references such as `url(#glow)` and `href="#symbol"`, while rejecting active
+content, event attributes, declarations/entities, base URLs, CSS imports, and
+non-fragment resource references.
+
+Validation is not the only network boundary. The Puppeteer page also enables
+request interception and aborts every request before document content is set.
+This makes raw-markup validation the reviewed capability boundary and browser
+interception the defense-in-depth runtime boundary.
+
+## First fixtures
 
 The MCP OAuth consent page is the first migrated document. It keeps its existing
 fields, actor warning, tool selections, hidden OAuth parameters, styling, and
 copy while replacing local escaping and string concatenation with AST view
 functions plus the shared HTML renderer.
 
+The Puppeteer SVG document shell is the second fixture. Its outer HTML structure
+uses the same AST and deterministic renderer, while validated SVG crosses one
+explicit raw-markup boundary inside the body.
+
 ## Consequences
 
 - Server and browser structure can be tested for normalized-DOM parity.
 - Security policy is centralized instead of repeated in templates.
 - React lifecycle, reconciliation, hooks, and context remain outside the AST.
+- Dynamic raw-markup domains must define their own validation capability before
+  constructing a trusted value.
+- Browser renderers must enforce network policy independently of string
+  validation.
 - CSS-in-JS and a general template language are explicitly not introduced.

--- a/kanban/tasks/uxx-svg-document-shell-network-guard.md
+++ b/kanban/tasks/uxx-svg-document-shell-network-guard.md
@@ -1,0 +1,45 @@
+---
+uuid: "uxx-svg-document-shell-network-guard"
+title: "Render SVG browser documents through UXX and block resource loading"
+status: in_progress
+priority: "P1"
+labels: ["tasks", "backend", "security", "svg", "puppeteer", "uxx", "5sp"]
+created_at: "2026-08-05T15:59:00Z"
+source: "uxx-shared-markup-html-helix-renderers"
+points: 5
+category: "tasks"
+---
+# Render SVG browser documents through UXX and block resource loading
+
+## Context
+
+The first UXX shared-markup slice migrated the MCP consent page, but
+`backend/src/cljs/knoxx/backend/infra/svg_render.cljs` still concatenates an
+HTML document around dynamic SVG before handing it to Chromium.
+
+That raw SVG originates from agent and attachment paths. JavaScript is disabled,
+but SVG can still request remote images, fonts, stylesheets, filter resources,
+or other URLs. A browser renderer therefore needs both an explicit raw-markup
+capability boundary and a network-deny boundary.
+
+## Work
+
+- Build the Puppeteer document shell through `open-hax.uxx.render.html`.
+- Validate SVG before converting it into a trusted raw-markup value.
+- Preserve local fragment references such as `url(#glow)` and `href="#id"`.
+- Reject active HTML/SVG elements, event attributes, doctypes/entities,
+  `xml:base`, external URL attributes, CSS imports, and non-fragment CSS URLs.
+- Enable Puppeteer request interception and abort every resource request before
+  setting page content.
+- Extend focused shared-markup lint and renderer tests.
+
+## Definition of Done
+
+- No document-shell string concatenation remains in `svg_render.cljs`.
+- Dynamic SVG crosses one reviewed validation function before `:raw-html`.
+- Browser JavaScript is disabled and network requests are aborted.
+- Existing gradients, filters, fonts, and fragment references still render.
+- Negative tests cover script/event injection and browser resource loading
+  spellings.
+- Focused lint, backend compilation/tests, frontend checks, and Rheos drift
+  validation pass.

--- a/kanban/tasks/uxx-svg-document-shell-network-guard.md
+++ b/kanban/tasks/uxx-svg-document-shell-network-guard.md
@@ -26,6 +26,9 @@ capability boundary and a network-deny boundary.
 ## Work
 
 - Build the Puppeteer document shell through `open-hax.uxx.render.html`.
+- Keep pure SVG acceptance policy in `knoxx.backend.law.svg` and browser effects
+  in `knoxx.backend.infra.svg-render`.
+- Require exactly one balanced SVG root with no leading or trailing content.
 - Validate SVG before converting it into a trusted raw-markup value.
 - Preserve local fragment references such as `url(#glow)` and `href="#id"`.
 - Reject active HTML/SVG elements, event attributes, doctypes/entities,
@@ -38,13 +41,17 @@ capability boundary and a network-deny boundary.
 ## Definition of Done
 
 - No document-shell string concatenation remains in `svg_render.cljs`.
-- Dynamic SVG crosses one reviewed validation function before `:raw-html`.
+- Pure SVG policy lives outside `infra.*`.
+- Dynamic SVG crosses one reviewed law function before `:raw-html`.
+- Exactly one balanced `<svg>` document is accepted; trailing HTML, text,
+  comments, or another root is rejected.
 - Browser JavaScript is disabled and network requests are aborted.
-- Existing gradients, filters, fonts, and fragment references still render.
-- Negative tests cover script/event injection, declarative mutation, and browser
-  resource-loading spellings.
-- Focused lint, backend compilation/tests, frontend checks, and Rheos drift
-  validation pass.
+- Existing gradients, filters, fonts, CDATA, comments, quoted delimiters, and
+  fragment references still render.
+- Negative tests cover script/event injection, declarative mutation, malformed
+  structure, and browser resource-loading spellings.
+- Focused lint, backend compilation/tests, frontend checks, review resolution,
+  and Rheos drift validation pass.
 
 ## Completion
 
@@ -52,7 +59,10 @@ Implemented in Knoxx PR #223.
 
 - Replaced the Puppeteer HTML shell concatenation with a shared UXX AST and
   deterministic HTML rendering.
-- Added `validate-svg!` as the sole capability crossing into trusted raw markup.
+- Added `knoxx.backend.law.svg/validate-svg!` as the sole capability crossing
+  into trusted raw markup.
+- Added an owned structural scanner for one balanced SVG root and no outside
+  content.
 - Preserved local fragment filters, gradients, masks, symbols, and `use`
   references.
 - Rejected scripts, `foreignObject`, event attributes, doctypes/entities,
@@ -61,22 +71,18 @@ Implemented in Knoxx PR #223.
   non-fragment CSS URLs.
 - Disabled JavaScript, enabled Puppeteer request interception, and aborted every
   request before document content is installed.
-- Added deterministic-shell, negative security, fake-page interception, and
-  Chromium PNG regression tests.
+- Added law-level parser and security tests, deterministic-shell tests,
+  fake-page interception tests, and the Chromium PNG regression test.
 - Extended the focused shared-markup lint gate and architecture decision.
+- Addressed and resolved both CodeRabbit major findings: the law/infra boundary
+  and exact single-document validation.
 
-Verification evidence:
-
-- Knoxx CI run `31023999070`: focused lint, backend typecheck/tests/coverage,
-  frontend TypeScript, frontend CLJS parity, and Vitest coverage all passed.
-- Rheos run `31024001928`: board snapshot generation, validation, and drift
-  ledger checks passed.
-- Review Resolution Gate run `31024000107` passed.
-- CodeRabbit status passed on implementation head
-  `7b42e34020e432225ab27834107234b25b3d47af`.
+Verification gates for the final PR head include focused clj-kondo lint, backend
+Shadow compilation and tests, frontend TypeScript/CLJS/Vitest checks, the
+Review Resolution Gate, and Rheos snapshot/drift validation.
 
 ---
-Triage 2026-08-05: Completed by PR #223. Dynamic SVG now crosses an explicit
+Triage 2026-08-05: Completed by PR #223. Dynamic SVG now crosses a pure law-owned
 validated raw-markup capability, while Chromium independently denies JavaScript
 and all resource requests. Verdict: done (P1, 5sp).
 ---

--- a/kanban/tasks/uxx-svg-document-shell-network-guard.md
+++ b/kanban/tasks/uxx-svg-document-shell-network-guard.md
@@ -1,10 +1,11 @@
 ---
 uuid: "uxx-svg-document-shell-network-guard"
 title: "Render SVG browser documents through UXX and block resource loading"
-status: in_progress
+status: done
 priority: "P1"
 labels: ["tasks", "backend", "security", "svg", "puppeteer", "uxx", "5sp"]
 created_at: "2026-08-05T15:59:00Z"
+completed_at: "2026-08-05T16:17:00Z"
 source: "uxx-shared-markup-html-helix-renderers"
 points: 5
 category: "tasks"
@@ -14,7 +15,7 @@ category: "tasks"
 ## Context
 
 The first UXX shared-markup slice migrated the MCP consent page, but
-`backend/src/cljs/knoxx/backend/infra/svg_render.cljs` still concatenates an
+`backend/src/cljs/knoxx/backend/infra/svg_render.cljs` still concatenated an
 HTML document around dynamic SVG before handing it to Chromium.
 
 That raw SVG originates from agent and attachment paths. JavaScript is disabled,
@@ -28,7 +29,8 @@ capability boundary and a network-deny boundary.
 - Validate SVG before converting it into a trusted raw-markup value.
 - Preserve local fragment references such as `url(#glow)` and `href="#id"`.
 - Reject active HTML/SVG elements, event attributes, doctypes/entities,
-  `xml:base`, external URL attributes, CSS imports, and non-fragment CSS URLs.
+  processing instructions, declarative mutation elements, `xml:base`, external
+  URL attributes, CSS imports, and non-fragment CSS URLs.
 - Enable Puppeteer request interception and abort every resource request before
   setting page content.
 - Extend focused shared-markup lint and renderer tests.
@@ -39,7 +41,42 @@ capability boundary and a network-deny boundary.
 - Dynamic SVG crosses one reviewed validation function before `:raw-html`.
 - Browser JavaScript is disabled and network requests are aborted.
 - Existing gradients, filters, fonts, and fragment references still render.
-- Negative tests cover script/event injection and browser resource loading
-  spellings.
+- Negative tests cover script/event injection, declarative mutation, and browser
+  resource-loading spellings.
 - Focused lint, backend compilation/tests, frontend checks, and Rheos drift
   validation pass.
+
+## Completion
+
+Implemented in Knoxx PR #223.
+
+- Replaced the Puppeteer HTML shell concatenation with a shared UXX AST and
+  deterministic HTML rendering.
+- Added `validate-svg!` as the sole capability crossing into trusted raw markup.
+- Preserved local fragment filters, gradients, masks, symbols, and `use`
+  references.
+- Rejected scripts, `foreignObject`, event attributes, doctypes/entities,
+  processing instructions, active HTML elements, SVG animation/mutation
+  elements, base URLs, external/data resource references, CSS imports, and
+  non-fragment CSS URLs.
+- Disabled JavaScript, enabled Puppeteer request interception, and aborted every
+  request before document content is installed.
+- Added deterministic-shell, negative security, fake-page interception, and
+  Chromium PNG regression tests.
+- Extended the focused shared-markup lint gate and architecture decision.
+
+Verification evidence:
+
+- Knoxx CI run `31023999070`: focused lint, backend typecheck/tests/coverage,
+  frontend TypeScript, frontend CLJS parity, and Vitest coverage all passed.
+- Rheos run `31024001928`: board snapshot generation, validation, and drift
+  ledger checks passed.
+- Review Resolution Gate run `31024000107` passed.
+- CodeRabbit status passed on implementation head
+  `7b42e34020e432225ab27834107234b25b3d47af`.
+
+---
+Triage 2026-08-05: Completed by PR #223. Dynamic SVG now crosses an explicit
+validated raw-markup capability, while Chromium independently denies JavaScript
+and all resource requests. Verdict: done (P1, 5sp).
+---


### PR DESCRIPTION
## Summary

Continues the shared-markup migration with the Puppeteer SVG renderer.

The browser document shell now renders through the UXX HTML renderer instead of concatenating a complete HTML string around dynamic SVG.

## Architecture

- pure SVG acceptance policy lives in `knoxx.backend.law.svg`;
- `knoxx.backend.infra.svg-render` remains the effectful Puppeteer adapter;
- validated SVG crosses one explicit UXX trusted-raw-markup boundary;
- an owned structural scanner requires exactly one balanced `<svg>` root with no leading/trailing markup or text.

## Security boundary

The SVG law:

- preserves local fragment references such as `url(#glow)` and `href="#symbol"`;
- rejects scripts, `foreignObject`, active HTML elements, event attributes, doctypes/entities, processing instructions, base URLs, and declarative mutation/animation elements;
- rejects external, data, and protocol-relative resource attributes;
- rejects CSS imports and non-fragment CSS URLs;
- rejects second roots, trailing HTML/text/comments, mismatched tags, and unterminated tags/comments/CDATA.

Puppeteer additionally:

- disables JavaScript;
- enables request interception;
- aborts every browser resource request before `setContent`.

## Tests

- law-level acceptance and rejection suites, including exact error metadata;
- deterministic UXX-rendered browser shell;
- gradients, filters, fonts, quoted `>` values, CDATA, comments, and local fragment references remain supported;
- fake-page proof that JavaScript is disabled, interception is enabled, and requests are aborted;
- existing Chromium PNG smoke test remains in place.

## Process

- extends the focused shared-markup clj-kondo gate;
- updates the shared rendering architecture decision;
- completes canonical Rheos card `uxx-svg-document-shell-network-guard`;
- addresses and resolves both CodeRabbit major findings.

## Review focus

Please scrutinize structural scanner edge cases, SVG validation bypasses, Puppeteer interception ordering, and whether any legitimate Knoxx SVG producer needs a non-fragment resource capability.