### PR TITLE
docs(kanban): contract-owned publication pipeline

### DIFF
--- a/kanban/epics/knoxx-contract-owned-publication-pipeline.md
+++ b/kanban/epics/knoxx-contract-owned-publication-pipeline.md
@@ -1,0 +1,110 @@
+---
+uuid: "knoxx-contract-owned-publication-pipeline"
+title: "Contract-owned document publication — remove OpenPlanner as publication authority"
+status: incoming
+priority: P1
+labels: ["epics", "cms", "publication", "translations", "decouple", "openplanner"]
+created_at: "2026-08-12T00:00:00Z"
+points: 0
+category: epics
+---
+# Contract-owned document publication — remove OpenPlanner as publication authority
+
+## Signal
+
+Knoxx must be able to describe **which documents exist and their intended publish state from resources alone**.
+
+OpenPlanner may remain a storage/projection integration, but it must no longer be the semantic authority for gardens, document publication state, translation policy, or translation pipeline configuration.
+
+The target invariant is:
+
+```text
+resource graph                = desired semantic state
+runtime receipts/projections  = observed execution state
+drift                         = desired - observed
+```
+
+A Knoxx process with no OpenPlanner REST service available must still be able to answer:
+
+- what documents exist;
+- where their canonical source lives;
+- which gardens they target;
+- which locale/revision is intended for each target;
+- whether publication is requested, withheld, or archived;
+- which translation/review policy gates each publication;
+- what remains blocked before the requested publication can materialize.
+
+It must **not** infer any of those facts from `garden_publications` metadata or from `/api/openplanner/...` reads.
+
+## Why this is the last decoupling seam
+
+Translation review already uses Knoxx-owned `/api/translations/...` routes and translation persistence has moved behind Knoxx boundaries. The remaining coupling is publication semantics and a small amount of translation pipeline configuration:
+
+- CMS discovers gardens through `/api/openplanner/v1/gardens`;
+- CMS reads `metadata.garden_publications` as publication truth;
+- translation pipeline config still reads/writes `/api/openplanner/v1/translations/config`;
+- the deploy gate still has a conditional OpenPlanner REST branch for CMS.
+
+The existing `knoxx-cms-contract-validation` card already identifies CMS as the last REST-only OpenPlanner dependency in the deployed stack. This epic is the concrete architectural answer to that card.
+
+## Ownership rule
+
+```text
+Knoxx resources      own desired state
+Knoxx law/domain     own admissibility and reconciliation decisions
+Knoxx receipts       own observed execution facts
+publication adapters perform effects
+OpenPlanner          owns only its own adapter/projection implementation
+```
+
+Publication is a relation, not a boolean on a document:
+
+```text
+document × garden × locale × revision -> publication intent
+```
+
+That permits one document to be public in English, awaiting review in Spanish, absent from another garden, and archived in a fourth without inventing contradictory document-level state.
+
+## Explicit non-goals
+
+- Do not replace OpenPlanner authority with a new mutable "Knoxx garden database" authority.
+- Do not store runtime facts such as `published_at`, worker run ids, translation job ids, or last deploy status in declarative resource data.
+- Do not encode workflow observations such as `:translating` or `:reviewing` as desired publication state.
+- Do not duplicate `knoxx-translations-event-sourced`; translation history remains that card's concern.
+- Do not require the publication adapter to be OpenPlanner-specific.
+
+## Children — all incoming
+
+1. `knoxx-publication-resource-contracts` — first-class document, garden, and publication resource laws.
+2. `knoxx-publication-intent-resolver` — pure resource graph -> desired publication projection.
+3. `knoxx-cms-resource-backed-publication-ui` — make CMS read/write resource intent instead of OpenPlanner publication metadata.
+4. `knoxx-translation-pipeline-config-resource` — remove the remaining OpenPlanner translation config authority.
+5. `knoxx-translation-publication-gate` — compute publication blockers from translation/review policy + receipts.
+6. `knoxx-publication-adapter-boundary` — define effect boundary and reconciliation plan; OpenPlanner becomes optional adapter.
+7. `knoxx-openplanner-publication-state-migration` — import existing gardens/publications into resources once, with conflict receipts.
+8. `knoxx-openplanner-rest-retirement` — delete the CMS/translation REST compatibility dependency and deploy flag.
+9. `knoxx-contract-publication-e2e` — prove the full publish/translate/review/materialize path with OpenPlanner REST absent.
+
+## Build order
+
+```text
+resource contracts
+      -> intent resolver
+      -> CMS + translation config cutover
+      -> translation/review gate
+      -> publication adapter boundary
+      -> migration
+      -> OpenPlanner REST retirement
+      -> no-OpenPlanner E2E gate
+```
+
+`knoxx-cms-contract-validation` should validate the surviving CMS contract surface against this model rather than deciding the dependency direction again.
+
+## Done when
+
+- Reading Knoxx resources alone is sufficient to reconstruct desired document/garden/locale/revision publication topology.
+- CMS publication actions mutate resource intent, not OpenPlanner metadata.
+- Translation/review state blocks or admits publication without becoming contract state itself.
+- OpenPlanner is optional at the semantic layer and can be replaced by another publication adapter without changing document/publication contracts.
+- Production deploy verification no longer conditionally skips CMS because OpenPlanner REST is absent.
+- An end-to-end test publishes a translated, reviewed document with the OpenPlanner REST service deliberately unavailable.

--- a/kanban/epics/knoxx-contract-owned-publication-pipeline.md
+++ b/kanban/epics/knoxx-contract-owned-publication-pipeline.md
@@ -16,36 +16,15 @@ Knoxx must be able to describe **which documents exist and their intended publis
 
 OpenPlanner may remain a storage/projection integration, but it must no longer be the semantic authority for gardens, document publication state, translation policy, or translation pipeline configuration.
 
-The target invariant is:
-
 ```text
 resource graph                = desired semantic state
 runtime receipts/projections  = observed execution state
 drift                         = desired - observed
 ```
 
-A Knoxx process with no OpenPlanner REST service available must still be able to answer:
+A Knoxx process with no OpenPlanner REST service available must still answer what documents exist, which gardens/locales/revisions they target, whether publication is requested/withheld/archived, which translation/review gates apply, and what remains blocked.
 
-- what documents exist;
-- where their canonical source lives;
-- which gardens they target;
-- which locale/revision is intended for each target;
-- whether publication is requested, withheld, or archived;
-- which translation/review policy gates each publication;
-- what remains blocked before the requested publication can materialize.
-
-It must **not** infer any of those facts from `garden_publications` metadata or from `/api/openplanner/...` reads.
-
-## Why this is the last decoupling seam
-
-Translation review already uses Knoxx-owned `/api/translations/...` routes and translation persistence has moved behind Knoxx boundaries. The remaining coupling is publication semantics and a small amount of translation pipeline configuration:
-
-- CMS discovers gardens through `/api/openplanner/v1/gardens`;
-- CMS reads `metadata.garden_publications` as publication truth;
-- translation pipeline config still reads/writes `/api/openplanner/v1/translations/config`;
-- the deploy gate still has a conditional OpenPlanner REST branch for CMS.
-
-The existing `knoxx-cms-contract-validation` card already identifies CMS as the last REST-only OpenPlanner dependency in the deployed stack. This epic is the concrete architectural answer to that card.
+It must not infer those facts from `garden_publications` metadata or `/api/openplanner/...` reads.
 
 ## Ownership rule
 
@@ -54,28 +33,18 @@ Knoxx resources      own desired state
 Knoxx law/domain     own admissibility and reconciliation decisions
 Knoxx receipts       own observed execution facts
 publication adapters perform effects
-OpenPlanner          owns only its own adapter/projection implementation
+OpenPlanner          owns only its adapter/projection implementation
 ```
 
-Publication is a relation, not a boolean on a document:
+Publication is a relation:
 
 ```text
 document × garden × locale × revision -> publication intent
 ```
 
-That permits one document to be public in English, awaiting review in Spanish, absent from another garden, and archived in a fourth without inventing contradictory document-level state.
-
-## Explicit non-goals
-
-- Do not replace OpenPlanner authority with a new mutable "Knoxx garden database" authority.
-- Do not store runtime facts such as `published_at`, worker run ids, translation job ids, or last deploy status in declarative resource data.
-- Do not encode workflow observations such as `:translating` or `:reviewing` as desired publication state.
-- Do not duplicate `knoxx-translations-event-sourced`; translation history remains that card's concern.
-- Do not require the publication adapter to be OpenPlanner-specific.
-
 ## Priority waves
 
-Priority is dependency urgency for this epic, not a statement that later verification is optional.
+Priority is dependency urgency, not optionality.
 
 ```text
 P0 — foundation + authority transfer
@@ -83,10 +52,13 @@ P0 — foundation + authority transfer
   intent resolver
   legacy publication migration
 
-P1 — runtime semantics + reconciliation
-  translation config authority
-  translation/review publication gate
-  publication adapter boundary
+P1 — runtime semantics + reconciliation — 18sp
+  translation config authority ............ 5
+  translation/review publication gate ..... 5
+  publication adapter boundary ............. 8
+      reconciliation plan laws ............. 3
+      adapter effects + idempotency ......... 3
+      receipts + fake-adapter proof ......... 2
 
 P2 — cutover + retirement + proof
   CMS resource-backed publication UI
@@ -96,19 +68,22 @@ P2 — cutover + retirement + proof
 
 ## Children
 
-1. **P0 / breakdown** `knoxx-publication-resource-contracts` — first-class document, garden, and publication resource laws.
-2. **P0 / accepted** `knoxx-publication-intent-resolver` — pure resource graph -> desired publication projection.
-3. **P0 / accepted** `knoxx-openplanner-publication-state-migration` — import existing gardens/publications into resources once, with conflict receipts, **before resource intent becomes CMS authority**.
-4. **P1 / accepted** `knoxx-translation-pipeline-config-resource` — remove the remaining OpenPlanner translation config authority.
-5. **P1 / accepted** `knoxx-translation-publication-gate` — compute publication blockers from translation/review policy + receipts.
-6. **P1 / accepted** `knoxx-publication-adapter-boundary` — define effect boundary and reconciliation plan; OpenPlanner becomes optional adapter.
-7. **P2 / accepted** `knoxx-cms-resource-backed-publication-ui` — make CMS read/write resource intent after migration has converged.
-8. **P2 / accepted** `knoxx-openplanner-rest-retirement` — delete the CMS/translation REST compatibility dependency and deploy flag.
-9. **P2 / accepted** `knoxx-contract-publication-e2e` — prove the full publish/translate/review/materialize path with OpenPlanner REST absent.
+1. **P0 / breakdown / 5sp** `knoxx-publication-resource-contracts` — first-class document, garden, and publication resource laws.
+2. **P0 / accepted / 5sp** `knoxx-publication-intent-resolver` — pure resource graph -> desired publication projection.
+3. **P0 / accepted / 5sp** `knoxx-openplanner-publication-state-migration` — import existing gardens/publications into resources once, with conflict receipts, before resource intent becomes CMS authority.
+4. **P1 / accepted / 5sp** `knoxx-translation-pipeline-config-resource` — remove OpenPlanner translation config authority across UI and ingestion worker.
+5. **P1 / accepted / 5sp** `knoxx-translation-publication-gate` — compute translation/review blockers and derivative replacement work from receipts.
+6. **P1 / breakdown / 0sp roll-up** `knoxx-publication-adapter-boundary` — coordination card for the original 8sp scope:
+   - **P1 / accepted / 3sp** `knoxx-publication-reconcile-plan-laws`
+   - **P1 / accepted / 3sp** `knoxx-publication-adapter-effects-idempotency`
+   - **P1 / accepted / 2sp** `knoxx-publication-receipts-fake-adapter-proof`
+7. **P2 / accepted / 5sp** `knoxx-cms-resource-backed-publication-ui` — make CMS read/write resource intent after migration has converged.
+8. **P2 / accepted / 3sp** `knoxx-openplanner-rest-retirement` — delete CMS/translation REST compatibility authority and deploy flag.
+9. **P2 / accepted / 5sp** `knoxx-contract-publication-e2e` — prove publish/translate/review/materialize with OpenPlanner REST absent.
 
 ## Build order
 
-The authority transfer must not expose an empty resource projection while legacy OpenPlanner state still contains the real publication topology. Migrate and resolve conflicts before the CMS cutover.
+Migration must converge before the CMS authority cutover. Within the adapter boundary, pure law precedes effects, and effects precede receipt/proof closure.
 
 ```text
 resource contracts
@@ -116,20 +91,29 @@ resource contracts
       -> OpenPlanner state migration + conflict resolution
       -> translation config resource
       -> translation/review gate
-      -> publication adapter boundary
+      -> reconciliation plan laws
+      -> adapter effects + idempotency
+      -> receipts + fake-adapter proof
       -> CMS resource-authority cutover
       -> OpenPlanner REST retirement
       -> no-OpenPlanner E2E gate
 ```
 
-`knoxx-cms-contract-validation` should validate the surviving CMS contract surface against this model rather than deciding the dependency direction again.
+## Explicit non-goals
+
+- Do not replace OpenPlanner authority with another mutable garden database authority.
+- Do not store runtime timestamps, job ids, worker phases, or deploy status in declarative resources.
+- Do not promote `:translating` or `:reviewing` into desired publication state.
+- Do not duplicate `knoxx-translations-event-sourced`; translation history remains that card's concern.
+- Do not require the publication adapter to be OpenPlanner-specific.
 
 ## Done when
 
-- Reading Knoxx resources alone is sufficient to reconstruct desired document/garden/locale/revision publication topology.
-- Existing OpenPlanner publication topology has been migrated and conflicts resolved before CMS resource authority is enabled.
-- CMS publication actions mutate resource intent, not OpenPlanner metadata.
-- Translation/review state blocks or admits publication without becoming contract state itself.
-- OpenPlanner is optional at the semantic layer and can be replaced by another publication adapter without changing document/publication contracts.
+- Resources alone reconstruct desired document/garden/locale/revision topology.
+- Existing OpenPlanner topology is migrated and conflicts resolved before CMS resource authority is enabled.
+- Translation/review evidence gates publication without becoming desired state.
+- The adapter boundary is proven as pure plan -> replaceable effects -> receipts, with the 3+3+2 children complete.
+- CMS actions mutate resource intent rather than OpenPlanner metadata.
+- OpenPlanner is optional at the semantic layer.
 - Production deploy verification no longer conditionally skips CMS because OpenPlanner REST is absent.
-- An end-to-end test publishes a translated, reviewed document with the OpenPlanner REST service deliberately unavailable.
+- The E2E publishes a translated, reviewed document with OpenPlanner REST deliberately unavailable.

--- a/kanban/epics/knoxx-contract-owned-publication-pipeline.md
+++ b/kanban/epics/knoxx-contract-owned-publication-pipeline.md
@@ -1,7 +1,7 @@
 ---
 uuid: "knoxx-contract-owned-publication-pipeline"
 title: "Contract-owned document publication — remove OpenPlanner as publication authority"
-status: accepted
+status: breakdown
 priority: P1
 labels: ["epics", "cms", "publication", "translations", "decouple", "openplanner"]
 created_at: "2026-08-12T00:00:00Z"
@@ -73,17 +73,38 @@ That permits one document to be public in English, awaiting review in Spanish, a
 - Do not duplicate `knoxx-translations-event-sourced`; translation history remains that card's concern.
 - Do not require the publication adapter to be OpenPlanner-specific.
 
-## Children — accepted
+## Priority waves
 
-1. `knoxx-publication-resource-contracts` — first-class document, garden, and publication resource laws.
-2. `knoxx-publication-intent-resolver` — pure resource graph -> desired publication projection.
-3. `knoxx-openplanner-publication-state-migration` — import existing gardens/publications into resources once, with conflict receipts, **before resource intent becomes CMS authority**.
-4. `knoxx-translation-pipeline-config-resource` — remove the remaining OpenPlanner translation config authority.
-5. `knoxx-translation-publication-gate` — compute publication blockers from translation/review policy + receipts.
-6. `knoxx-publication-adapter-boundary` — define effect boundary and reconciliation plan; OpenPlanner becomes optional adapter.
-7. `knoxx-cms-resource-backed-publication-ui` — make CMS read/write resource intent after migration has converged.
-8. `knoxx-openplanner-rest-retirement` — delete the CMS/translation REST compatibility dependency and deploy flag.
-9. `knoxx-contract-publication-e2e` — prove the full publish/translate/review/materialize path with OpenPlanner REST absent.
+Priority is dependency urgency for this epic, not a statement that later verification is optional.
+
+```text
+P0 — foundation + authority transfer
+  resource contracts
+  intent resolver
+  legacy publication migration
+
+P1 — runtime semantics + reconciliation
+  translation config authority
+  translation/review publication gate
+  publication adapter boundary
+
+P2 — cutover + retirement + proof
+  CMS resource-backed publication UI
+  OpenPlanner REST retirement
+  no-OpenPlanner E2E gate
+```
+
+## Children
+
+1. **P0 / breakdown** `knoxx-publication-resource-contracts` — first-class document, garden, and publication resource laws.
+2. **P0 / accepted** `knoxx-publication-intent-resolver` — pure resource graph -> desired publication projection.
+3. **P0 / accepted** `knoxx-openplanner-publication-state-migration` — import existing gardens/publications into resources once, with conflict receipts, **before resource intent becomes CMS authority**.
+4. **P1 / accepted** `knoxx-translation-pipeline-config-resource` — remove the remaining OpenPlanner translation config authority.
+5. **P1 / accepted** `knoxx-translation-publication-gate` — compute publication blockers from translation/review policy + receipts.
+6. **P1 / accepted** `knoxx-publication-adapter-boundary` — define effect boundary and reconciliation plan; OpenPlanner becomes optional adapter.
+7. **P2 / accepted** `knoxx-cms-resource-backed-publication-ui` — make CMS read/write resource intent after migration has converged.
+8. **P2 / accepted** `knoxx-openplanner-rest-retirement` — delete the CMS/translation REST compatibility dependency and deploy flag.
+9. **P2 / accepted** `knoxx-contract-publication-e2e` — prove the full publish/translate/review/materialize path with OpenPlanner REST absent.
 
 ## Build order
 

--- a/kanban/epics/knoxx-contract-owned-publication-pipeline.md
+++ b/kanban/epics/knoxx-contract-owned-publication-pipeline.md
@@ -1,7 +1,7 @@
 ---
 uuid: "knoxx-contract-owned-publication-pipeline"
 title: "Contract-owned document publication — remove OpenPlanner as publication authority"
-status: incoming
+status: accepted
 priority: P1
 labels: ["epics", "cms", "publication", "translations", "decouple", "openplanner"]
 created_at: "2026-08-12T00:00:00Z"
@@ -73,27 +73,30 @@ That permits one document to be public in English, awaiting review in Spanish, a
 - Do not duplicate `knoxx-translations-event-sourced`; translation history remains that card's concern.
 - Do not require the publication adapter to be OpenPlanner-specific.
 
-## Children — all incoming
+## Children — accepted
 
 1. `knoxx-publication-resource-contracts` — first-class document, garden, and publication resource laws.
 2. `knoxx-publication-intent-resolver` — pure resource graph -> desired publication projection.
-3. `knoxx-cms-resource-backed-publication-ui` — make CMS read/write resource intent instead of OpenPlanner publication metadata.
+3. `knoxx-openplanner-publication-state-migration` — import existing gardens/publications into resources once, with conflict receipts, **before resource intent becomes CMS authority**.
 4. `knoxx-translation-pipeline-config-resource` — remove the remaining OpenPlanner translation config authority.
 5. `knoxx-translation-publication-gate` — compute publication blockers from translation/review policy + receipts.
 6. `knoxx-publication-adapter-boundary` — define effect boundary and reconciliation plan; OpenPlanner becomes optional adapter.
-7. `knoxx-openplanner-publication-state-migration` — import existing gardens/publications into resources once, with conflict receipts.
+7. `knoxx-cms-resource-backed-publication-ui` — make CMS read/write resource intent after migration has converged.
 8. `knoxx-openplanner-rest-retirement` — delete the CMS/translation REST compatibility dependency and deploy flag.
 9. `knoxx-contract-publication-e2e` — prove the full publish/translate/review/materialize path with OpenPlanner REST absent.
 
 ## Build order
 
+The authority transfer must not expose an empty resource projection while legacy OpenPlanner state still contains the real publication topology. Migrate and resolve conflicts before the CMS cutover.
+
 ```text
 resource contracts
       -> intent resolver
-      -> CMS + translation config cutover
+      -> OpenPlanner state migration + conflict resolution
+      -> translation config resource
       -> translation/review gate
       -> publication adapter boundary
-      -> migration
+      -> CMS resource-authority cutover
       -> OpenPlanner REST retirement
       -> no-OpenPlanner E2E gate
 ```
@@ -103,6 +106,7 @@ resource contracts
 ## Done when
 
 - Reading Knoxx resources alone is sufficient to reconstruct desired document/garden/locale/revision publication topology.
+- Existing OpenPlanner publication topology has been migrated and conflicts resolved before CMS resource authority is enabled.
 - CMS publication actions mutate resource intent, not OpenPlanner metadata.
 - Translation/review state blocks or admits publication without becoming contract state itself.
 - OpenPlanner is optional at the semantic layer and can be replaced by another publication adapter without changing document/publication contracts.

--- a/kanban/tasks/knoxx-cms-resource-backed-publication-ui.md
+++ b/kanban/tasks/knoxx-cms-resource-backed-publication-ui.md
@@ -29,14 +29,16 @@ This cutover happens only after `knoxx-openplanner-publication-state-migration` 
 - Load document/garden/publication views from the Knoxx publication facade.
 - Define one normalized JSON wire contract for list and document responses; do not wrap `publication/document-view` under another `:document` key.
 - Treat JSON enum values as strings at the HTTP boundary and explicitly convert them to/from domain keywords. Keywordizing object keys is not sufficient.
+- Reuse the resource wire identity convention: keyword ids serialize as `namespace/name` with no EDN leading colon and decode back to the same qualified keyword.
 - Map resource `:publication/state` to wire-level `"desired"` string values in the backend facade and combine it with observed receipt status there.
 - Encode keyword-valued response fields symmetrically (locale, desired/observed state, blockers, resource IDs where applicable), then explicitly decode them into CLJS UI-domain values in the frontend helper.
 - Render desired publication state separately from observed adapter state.
 - Make publish/unpublish/archive edits update only the relevant publication **state** through the existing resource-write boundary (or the narrowest new resource-write facade required).
 - Treat publication identity dimensions — document, garden, locale, revision selector — as immutable for state edits. Any re-key must be an explicit operation with duplicate/conflict validation.
+- Keep Fastify/native request objects inside the HTTP adapter: decode once, then read route params and body from the decoded CLJS request map.
 - Do not make the frontend parse EDN itself; frontend consumes normalized JSON API data.
 - Keep dirty/save semantics explicit: editing body content and editing publication intent are separate mutations even when exposed in one CMS surface.
-- New asynchronous frontend CLJS uses native `^:async` + `await`, not `.then` chains.
+- New asynchronous frontend/adapter CLJS uses native `^:async` + `await`, not `.then` chains.
 
 ## CLJS pseudocode
 
@@ -66,11 +68,22 @@ JSON wire contracts use JSON-safe scalar values:
    [:gardens [:vector :map]]])
 ```
 
-Backend encoding is explicit rather than relying on incidental keyword serialization:
+Backend encoding is explicit rather than relying on incidental keyword serialization. Qualified keyword ids never include an EDN leading colon:
 
 ```clojure
-(defn encode-id [x] (str x))
-(defn encode-enum [x] (when x (name x)))
+(defn encode-keyword [x]
+  (when x
+    (if-let [ns (namespace x)]
+      (str ns "/" (name x))
+      (name x))))
+
+(defn encode-id [x]
+  (if (keyword? x)
+    (encode-keyword x)
+    (str x)))
+
+(defn decode-id [x]
+  (keyword x))
 
 (defn publication->wire [receipts intent]
   (law/assert!
@@ -78,15 +91,15 @@ Backend encoding is explicit rather than relying on incidental keyword serializa
    {:id (encode-id (:publication/id intent))
     :document (encode-id (:publication/document intent))
     :garden (encode-id (:publication/garden intent))
-    :locale (encode-enum (:publication/locale intent))
+    :locale (encode-keyword (:publication/locale intent))
     :revision (if (keyword? (:publication/revision intent))
-                (name (:publication/revision intent))
+                (encode-keyword (:publication/revision intent))
                 (:publication/revision intent))
     :path (:publication/path intent)
-    :desired (encode-enum (:publication/state intent))
+    :desired (encode-keyword (:publication/state intent))
     :observed (some-> (publication-status/observed-for receipts intent)
-                      encode-enum)
-    :blockers (mapv encode-enum
+                      encode-keyword)
+    :blockers (mapv encode-keyword
                     (publication-status/blockers-for receipts intent))}))
 
 (defn cms-document-view [resource-index receipts document-id]
@@ -134,13 +147,15 @@ State mutation has separate JSON and domain contracts:
   (resources/rekey! ctx publication-id new-identity))
 ```
 
-The Fastify/HTTP adapter validates and decodes the JSON value before domain validation:
+The Fastify/HTTP adapter decodes once and reads both body and route identity from the decoded CLJS map:
 
 ```clojure
-(defn patch-publication-state-route! [ctx req]
-  (let [wire   (:body (decode-request req))
-        domain (decode-publication-state-patch wire)]
-    (put-publication-state! ctx (:publication-id req) domain)))
+(defn ^:async patch-publication-state-route! [ctx req]
+  (let [request        (decode-request req)
+        wire           (:body request)
+        publication-id (decode-id (get-in request [:params :publication-id]))
+        domain         (decode-publication-state-patch wire)]
+    (await (put-publication-state! ctx publication-id domain))))
 ```
 
 Frontend wire decoding is symmetric:
@@ -148,9 +163,9 @@ Frontend wire decoding is symmetric:
 ```clojure
 (defn decode-publication-wire [wire]
   (-> wire
-      (update :id keyword)
-      (update :document keyword)
-      (update :garden keyword)
+      (update :id decode-id)
+      (update :document decode-id)
+      (update :garden decode-id)
       (update :locale keyword)
       (update :desired keyword)
       (update :observed #(when % (keyword %)))
@@ -165,7 +180,7 @@ Frontend wire decoding is symmetric:
                  %)))
 ```
 
-Frontend page flow consumes those exact keys using native async/await:
+Frontend page flow consumes those exact keys using native async/await and serializes ids through the same colon-free resource-id convention:
 
 ```clojure
 (defn ^:async load-cms! []
@@ -175,11 +190,13 @@ Frontend page flow consumes those exact keys using native async/await:
            :documents (:documents response)
            :gardens (:gardens response))))
 
-(defn request-publish! [{:keys [publication-id]}]
-  (api/request
-   (str "/api/publications/intents/" (js/encodeURIComponent publication-id))
-   {:method "PATCH"
-    :body {:publication/state "published"}}))
+(defn ^:async request-publish! [{:keys [publication-id]}]
+  (await
+   (api/request
+    (str "/api/publications/intents/"
+         (js/encodeURIComponent (encode-id publication-id)))
+    {:method "PATCH"
+     :body {:publication/state "published"}})))
 ```
 
 UI-domain state remains keyword-oriented after explicit frontend decoding:
@@ -193,6 +210,8 @@ UI-domain state remains keyword-oriented after explicit frontend decoding:
 ## Watch out
 
 - Do not preserve `publishedGardenIds` as a second client-side authority; derive selected/publication badges from `:desired` in the decoded publication projection.
+- Do not rely on `(str keyword)` for resource wire ids: `:docs/probe` must serialize as `"docs/probe"`, never `":docs/probe"`.
+- Do not read route params from the raw Fastify request after decoding; native request handles stay at the adapter edge.
 - Do not rely on JSON serialization to preserve Clojure keyword values. Wire enums are strings; domain enums are keywords; adapters convert explicitly in both directions.
 - Do not silently write runtime timestamps/job ids back into resources after publishing.
 - A failed adapter call must leave desired state unchanged and surface drift, not revert the user's requested contract state unless the user explicitly changes it.
@@ -203,6 +222,8 @@ UI-domain state remains keyword-oriented after explicit frontend decoding:
 - CMS can render document publication topology with OpenPlanner REST disabled.
 - List and document routes expose one consistent `{documents, gardens}` / `{document, publications}` vocabulary with JSON-safe publication `{desired, observed, blockers}` fields.
 - A state PATCH containing JSON `"published"` decodes to domain `:published` before Malli validates `PublicationStatePatch`.
+- Qualified resource ids round-trip exactly: domain `:docs/probe` -> JSON `"docs/probe"` -> domain `:docs/probe`, and PATCH URLs contain no spurious colon.
+- The PATCH adapter obtains `publication-id` from decoded request params, never by keyword lookup on the native Fastify object.
 - Response keyword-valued fields round-trip through explicit JSON encoding and frontend decoding without relying on implicit keyword serialization.
 - `load-cms!` uses `^:async`/`await` and contains no Promise `.then` chain.
 - Publishing from the CMS changes only the Knoxx publication resource's desired state and the UI reflects it from the normalized response.

--- a/kanban/tasks/knoxx-cms-resource-backed-publication-ui.md
+++ b/kanban/tasks/knoxx-cms-resource-backed-publication-ui.md
@@ -1,7 +1,7 @@
 ---
 uuid: "knoxx-cms-resource-backed-publication-ui"
 title: "Make CMS read and write publication intent through Knoxx resources"
-status: incoming
+status: accepted
 priority: P1
 labels: ["tasks", "5sp", "has-parent", "cms", "publication", "frontend"]
 created_at: "2026-08-12T00:00:00Z"
@@ -16,6 +16,8 @@ category: tasks
 
 Stop `CmsPage` from treating OpenPlanner garden rows and `metadata.garden_publications` as publication truth. The CMS should become an editor/view over Knoxx resource intent.
 
+This cutover happens only after `knoxx-openplanner-publication-state-migration` has imported the existing topology and conflicts have been resolved.
+
 ## Current coupling to remove
 
 - garden discovery through `/api/openplanner/v1/gardens`;
@@ -25,29 +27,88 @@ Stop `CmsPage` from treating OpenPlanner garden rows and `metadata.garden_public
 ## Scope
 
 - Load document/garden/publication views from the Knoxx publication facade.
+- Define one normalized wire contract for list and document responses; do not wrap `publication/document-view` under another `:document` key.
+- Map resource `:publication/state` to wire-level `:desired` in the backend facade and combine it with observed receipt status there.
 - Render desired publication state separately from observed adapter state.
-- Make publish/unpublish/archive edits update the relevant publication resource through the existing resource-write boundary (or the narrowest new resource-write facade required).
-- Preserve explicit locale/revision/policy dimensions when editing.
+- Make publish/unpublish/archive edits update only the relevant publication **state** through the existing resource-write boundary (or the narrowest new resource-write facade required).
+- Treat publication identity dimensions — document, garden, locale, revision selector — as immutable for state edits. Any re-key must be an explicit operation with duplicate/conflict validation.
 - Do not make the frontend parse EDN itself; frontend consumes normalized API data.
 - Keep dirty/save semantics explicit: editing body content and editing publication intent are separate mutations even when exposed in one CMS surface.
 
 ## CLJS pseudocode
 
-Backend facade shape:
+Normalized backend facade:
 
 ```clojure
-(defn cms-document-view [resource-index receipts document-id]
-  {:document (publication/document-view resource-index document-id)
-   :observed (publication-status/observed-for receipts document-id)})
+(def PublicationWire
+  [:map
+   [:id qualified-keyword?]
+   [:document qualified-keyword?]
+   [:garden qualified-keyword?]
+   [:locale :keyword]
+   [:revision [:or :string :keyword]]
+   [:path :string]
+   [:desired [:enum :published :withheld :archived]]
+   [:observed {:optional true} :keyword]
+   [:blockers [:vector :keyword]]])
 
-(defn put-publication-intent! [ctx publication-id patch]
-  (let [current (resources/resolve-one ctx publication-id)
-        next    (publication/apply-edit current patch)]
-    (law/assert! publication/PublicationIntent next)
-    (resources/write! ctx next)))
+(def CmsDocumentWire
+  [:map
+   [:document :map]
+   [:publications [:vector PublicationWire]]])
+
+(def CmsListWire
+  [:map
+   [:documents [:vector CmsDocumentWire]]
+   [:gardens [:vector :map]]])
+
+(defn publication->wire [receipts intent]
+  {:id (:publication/id intent)
+   :document (:publication/document intent)
+   :garden (:publication/garden intent)
+   :locale (:publication/locale intent)
+   :revision (:publication/revision intent)
+   :path (:publication/path intent)
+   :desired (:publication/state intent)
+   :observed (publication-status/observed-for receipts intent)
+   :blockers (publication-status/blockers-for receipts intent)})
+
+(defn cms-document-view [resource-index receipts document-id]
+  (let [{:keys [document publications]}
+        (publication/document-view resource-index document-id)]
+    {:document document
+     :publications (mapv #(publication->wire receipts %) publications)}))
+
+(defn cms-list-view [resource-index receipts]
+  (let [{:keys [documents gardens]}
+        (publication/list-document-views resource-index)]
+    {:documents (mapv #(cms-document-view resource-index receipts
+                                           (get-in % [:document :document/id]))
+                      documents)
+     :gardens gardens}))
 ```
 
-Frontend page flow:
+State-only mutation boundary:
+
+```clojure
+(def PublicationStatePatch
+  [:map [:publication/state [:enum :published :withheld :archived]]])
+
+(defn put-publication-state! [ctx publication-id patch]
+  (law/assert! PublicationStatePatch patch)
+  (let [current (resources/resolve-one ctx publication-id)
+        next    (assoc current :publication/state
+                               (:publication/state patch))]
+    ;; locale/revision/document/garden cannot move through this endpoint.
+    (law/assert! publication/PublicationIntentResource next)
+    (resources/write! ctx next)))
+
+(defn rekey-publication! [ctx publication-id new-identity]
+  (publication/assert-no-identity-conflict! ctx publication-id new-identity)
+  (resources/rekey! ctx publication-id new-identity))
+```
+
+Frontend page flow consumes those exact keys:
 
 ```clojure
 (defn load-cms! []
@@ -56,31 +117,32 @@ Frontend page flow:
                      :documents (:documents %)
                      :gardens (:gardens %)))))
 
-(defn request-publish! [{:keys [publication-id locale revision]}]
+(defn request-publish! [{:keys [publication-id]}]
   (api/request
    (str "/api/publications/intents/" (js/encodeURIComponent publication-id))
    {:method "PATCH"
-    :body {:publication/state :published
-           :publication/locale locale
-           :publication/revision revision}}))
+    :body {:publication/state :published}}))
 ```
 
-UI state must distinguish:
+Wire state is explicit and non-authoritative on the observed side:
 
 ```clojure
 {:desired :published
- :observed :pending     ; receipt/projection, not contract state
+ :observed :pending
  :blockers [:translation-review-required]}
 ```
 
 ## Watch out
 
-- Do not preserve `publishedGardenIds` as a second client-side authority; derive selected/publication badges from the returned desired-state projection.
+- Do not preserve `publishedGardenIds` as a second client-side authority; derive selected/publication badges from `:desired` in the returned publication projection.
 - Do not silently write runtime timestamps/job ids back into resources after publishing.
 - A failed adapter call must leave desired state unchanged and surface drift, not revert the user's requested contract state unless the user explicitly changes it.
+- State PATCHes cannot change locale, revision, document, or garden. Re-keying is explicit and conflict-checked.
 
 ## Done when
 
 - CMS can render document publication topology with OpenPlanner REST disabled.
-- Publishing from the CMS changes a Knoxx publication resource and the UI reflects desired state from that resource.
+- List and document routes expose one consistent `{documents, gardens}` / `{document, publications}` vocabulary with publication `{desired, observed, blockers}` fields.
+- Publishing from the CMS changes only the Knoxx publication resource's desired state and the UI reflects it from the normalized response.
+- Publication identity cannot silently move through publish/unpublish/archive edits.
 - No CMS code reads `garden_publications` to determine semantic publication state.

--- a/kanban/tasks/knoxx-cms-resource-backed-publication-ui.md
+++ b/kanban/tasks/knoxx-cms-resource-backed-publication-ui.md
@@ -1,0 +1,86 @@
+---
+uuid: "knoxx-cms-resource-backed-publication-ui"
+title: "Make CMS read and write publication intent through Knoxx resources"
+status: incoming
+priority: P1
+labels: ["tasks", "5sp", "has-parent", "cms", "publication", "frontend"]
+created_at: "2026-08-12T00:00:00Z"
+points: 5
+category: tasks
+---
+# Make CMS read and write publication intent through Knoxx resources
+
+> Parent epic: `knoxx-contract-owned-publication-pipeline`
+
+## Purpose
+
+Stop `CmsPage` from treating OpenPlanner garden rows and `metadata.garden_publications` as publication truth. The CMS should become an editor/view over Knoxx resource intent.
+
+## Current coupling to remove
+
+- garden discovery through `/api/openplanner/v1/gardens`;
+- `CmsDocMetadata.garden_publications` as the source for published garden ids;
+- publish/unpublish actions whose semantic result exists only in OpenPlanner metadata.
+
+## Scope
+
+- Load document/garden/publication views from the Knoxx publication facade.
+- Render desired publication state separately from observed adapter state.
+- Make publish/unpublish/archive edits update the relevant publication resource through the existing resource-write boundary (or the narrowest new resource-write facade required).
+- Preserve explicit locale/revision/policy dimensions when editing.
+- Do not make the frontend parse EDN itself; frontend consumes normalized API data.
+- Keep dirty/save semantics explicit: editing body content and editing publication intent are separate mutations even when exposed in one CMS surface.
+
+## CLJS pseudocode
+
+Backend facade shape:
+
+```clojure
+(defn cms-document-view [resource-index receipts document-id]
+  {:document (publication/document-view resource-index document-id)
+   :observed (publication-status/observed-for receipts document-id)})
+
+(defn put-publication-intent! [ctx publication-id patch]
+  (let [current (resources/resolve-one ctx publication-id)
+        next    (publication/apply-edit current patch)]
+    (law/assert! publication/PublicationIntent next)
+    (resources/write! ctx next)))
+```
+
+Frontend page flow:
+
+```clojure
+(defn load-cms! []
+  (-> (api/request "/api/publications/documents")
+      (.then #(swap! state assoc
+                     :documents (:documents %)
+                     :gardens (:gardens %)))))
+
+(defn request-publish! [{:keys [publication-id locale revision]}]
+  (api/request
+   (str "/api/publications/intents/" (js/encodeURIComponent publication-id))
+   {:method "PATCH"
+    :body {:publication/state :published
+           :publication/locale locale
+           :publication/revision revision}}))
+```
+
+UI state must distinguish:
+
+```clojure
+{:desired :published
+ :observed :pending     ; receipt/projection, not contract state
+ :blockers [:translation-review-required]}
+```
+
+## Watch out
+
+- Do not preserve `publishedGardenIds` as a second client-side authority; derive selected/publication badges from the returned desired-state projection.
+- Do not silently write runtime timestamps/job ids back into resources after publishing.
+- A failed adapter call must leave desired state unchanged and surface drift, not revert the user's requested contract state unless the user explicitly changes it.
+
+## Done when
+
+- CMS can render document publication topology with OpenPlanner REST disabled.
+- Publishing from the CMS changes a Knoxx publication resource and the UI reflects desired state from that resource.
+- No CMS code reads `garden_publications` to determine semantic publication state.

--- a/kanban/tasks/knoxx-cms-resource-backed-publication-ui.md
+++ b/kanban/tasks/knoxx-cms-resource-backed-publication-ui.md
@@ -30,8 +30,9 @@ This cutover happens only after `knoxx-openplanner-publication-state-migration` 
 - Define one normalized JSON wire contract for list and document responses; do not wrap `publication/document-view` under another `:document` key.
 - Treat JSON enum values as strings at the HTTP boundary and explicitly convert them to/from domain keywords. Keywordizing object keys is not sufficient.
 - Reuse the resource wire identity convention: keyword ids serialize as `namespace/name` with no EDN leading colon and decode back to the same qualified keyword.
+- Give document and garden rows explicit JSON wire contracts/codecs too; never return raw resource maps and rely on `clj->js` for identity or enum serialization.
 - Map resource `:publication/state` to wire-level `"desired"` string values in the backend facade and combine it with observed receipt status there.
-- Encode keyword-valued response fields symmetrically (locale, desired/observed state, blockers, resource IDs where applicable), then explicitly decode them into CLJS UI-domain values in the frontend helper.
+- Encode keyword-valued response fields symmetrically (document/garden/publication IDs, source/target locales, garden status, desired/observed state, blockers), then explicitly decode them into CLJS UI-domain values in the frontend helper.
 - Render desired publication state separately from observed adapter state.
 - Make publish/unpublish/archive edits update only the relevant publication **state** through the existing resource-write boundary (or the narrowest new resource-write facade required).
 - Treat publication identity dimensions — document, garden, locale, revision selector — as immutable for state edits. Any re-key must be an explicit operation with duplicate/conflict validation.
@@ -42,9 +43,22 @@ This cutover happens only after `knoxx-openplanner-publication-state-migration` 
 
 ## CLJS pseudocode
 
-JSON wire contracts use JSON-safe scalar values:
+JSON wire contracts use JSON-safe scalar values throughout:
 
 ```clojure
+(def DocumentWireJson
+  [:map
+   [:id :string]
+   [:title :string]
+   [:source-locale :string]
+   [:source [:map [:path :string]]]])
+
+(def GardenWireJson
+  [:map
+   [:id :string]
+   [:title :string]
+   [:status [:enum "active" "archived"]]])
+
 (def PublicationWireJson
   [:map
    [:id :string]
@@ -59,13 +73,13 @@ JSON wire contracts use JSON-safe scalar values:
 
 (def CmsDocumentWireJson
   [:map
-   [:document :map]
+   [:document DocumentWireJson]
    [:publications [:vector PublicationWireJson]]])
 
 (def CmsListWireJson
   [:map
    [:documents [:vector CmsDocumentWireJson]]
-   [:gardens [:vector :map]]])
+   [:gardens [:vector GardenWireJson]]])
 ```
 
 Backend encoding is explicit rather than relying on incidental keyword serialization. Qualified keyword ids never include an EDN leading colon:
@@ -84,6 +98,21 @@ Backend encoding is explicit rather than relying on incidental keyword serializa
 
 (defn decode-id [x]
   (keyword x))
+
+(defn document->wire [document]
+  (law/assert!
+   DocumentWireJson
+   {:id (encode-id (:document/id document))
+    :title (:document/title document)
+    :source-locale (encode-keyword (:document/source-locale document))
+    :source (:document/source document)}))
+
+(defn garden->wire [garden]
+  (law/assert!
+   GardenWireJson
+   {:id (encode-id (:garden/id garden))
+    :title (:garden/title garden)
+    :status (encode-keyword (:garden/status garden))}))
 
 (defn publication->wire [receipts intent]
   (law/assert!
@@ -105,16 +134,20 @@ Backend encoding is explicit rather than relying on incidental keyword serializa
 (defn cms-document-view [resource-index receipts document-id]
   (let [{:keys [document publications]}
         (publication/document-view resource-index document-id)]
-    {:document document
-     :publications (mapv #(publication->wire receipts %) publications)}))
+    (law/assert!
+     CmsDocumentWireJson
+     {:document (document->wire document)
+      :publications (mapv #(publication->wire receipts %) publications)})))
 
 (defn cms-list-view [resource-index receipts]
   (let [{:keys [documents gardens]}
         (publication/list-document-views resource-index)]
-    {:documents (mapv #(cms-document-view resource-index receipts
-                                           (get-in % [:document :document/id]))
-                      documents)
-     :gardens gardens}))
+    (law/assert!
+     CmsListWireJson
+     {:documents (mapv #(cms-document-view resource-index receipts
+                                            (get-in % [:document :document/id]))
+                       documents)
+      :gardens (mapv garden->wire gardens)})))
 ```
 
 State mutation has separate JSON and domain contracts:
@@ -158,9 +191,19 @@ The Fastify/HTTP adapter decodes once and reads both body and route identity fro
     (await (put-publication-state! ctx publication-id domain))))
 ```
 
-Frontend wire decoding is symmetric:
+Frontend wire decoding is symmetric across every resource row:
 
 ```clojure
+(defn decode-document-wire [wire]
+  (-> wire
+      (update :id decode-id)
+      (update :source-locale keyword)))
+
+(defn decode-garden-wire [wire]
+  (-> wire
+      (update :id decode-id)
+      (update :status keyword)))
+
 (defn decode-publication-wire [wire]
   (-> wire
       (update :id decode-id)
@@ -172,12 +215,16 @@ Frontend wire decoding is symmetric:
       (update :blockers #(mapv keyword %))))
 
 (defn decode-cms-list-wire [wire]
-  (update wire :documents
-          #(mapv (fn [doc]
-                   (update doc :publications
-                           (fn [publications]
-                             (mapv decode-publication-wire publications))))
-                 %)))
+  (-> wire
+      (update :documents
+              #(mapv (fn [doc]
+                       (-> doc
+                           (update :document decode-document-wire)
+                           (update :publications
+                                   (fn [publications]
+                                     (mapv decode-publication-wire publications)))))
+                     %))
+      (update :gardens #(mapv decode-garden-wire %))))
 ```
 
 Frontend page flow consumes those exact keys using native async/await and serializes ids through the same colon-free resource-id convention:
@@ -210,6 +257,7 @@ UI-domain state remains keyword-oriented after explicit frontend decoding:
 ## Watch out
 
 - Do not preserve `publishedGardenIds` as a second client-side authority; derive selected/publication badges from `:desired` in the decoded publication projection.
+- Do not return raw document/garden resource maps at the JSON boundary; their IDs/locales/statuses use the same explicit wire convention as publication rows.
 - Do not rely on `(str keyword)` for resource wire ids: `:docs/probe` must serialize as `"docs/probe"`, never `":docs/probe"`.
 - Do not read route params from the raw Fastify request after decoding; native request handles stay at the adapter edge.
 - Do not rely on JSON serialization to preserve Clojure keyword values. Wire enums are strings; domain enums are keywords; adapters convert explicitly in both directions.
@@ -220,9 +268,10 @@ UI-domain state remains keyword-oriented after explicit frontend decoding:
 ## Done when
 
 - CMS can render document publication topology with OpenPlanner REST disabled.
-- List and document routes expose one consistent `{documents, gardens}` / `{document, publications}` vocabulary with JSON-safe publication `{desired, observed, blockers}` fields.
+- List and document routes expose one consistent `{documents, gardens}` / `{document, publications}` vocabulary with explicit JSON-safe document, garden, and publication contracts.
 - A state PATCH containing JSON `"published"` decodes to domain `:published` before Malli validates `PublicationStatePatch`.
 - Qualified resource ids round-trip exactly: domain `:docs/probe` -> JSON `"docs/probe"` -> domain `:docs/probe`, and PATCH URLs contain no spurious colon.
+- Document source locale and garden status round-trip through explicit string encoding/keyword decoding, never incidental `clj->js` behavior.
 - The PATCH adapter obtains `publication-id` from decoded request params, never by keyword lookup on the native Fastify object.
 - Response keyword-valued fields round-trip through explicit JSON encoding and frontend decoding without relying on implicit keyword serialization.
 - `load-cms!` uses `^:async`/`await` and contains no Promise `.then` chain.

--- a/kanban/tasks/knoxx-cms-resource-backed-publication-ui.md
+++ b/kanban/tasks/knoxx-cms-resource-backed-publication-ui.md
@@ -2,7 +2,7 @@
 uuid: "knoxx-cms-resource-backed-publication-ui"
 title: "Make CMS read and write publication intent through Knoxx resources"
 status: accepted
-priority: P1
+priority: P2
 labels: ["tasks", "5sp", "has-parent", "cms", "publication", "frontend"]
 created_at: "2026-08-12T00:00:00Z"
 points: 5
@@ -27,51 +27,67 @@ This cutover happens only after `knoxx-openplanner-publication-state-migration` 
 ## Scope
 
 - Load document/garden/publication views from the Knoxx publication facade.
-- Define one normalized wire contract for list and document responses; do not wrap `publication/document-view` under another `:document` key.
-- Map resource `:publication/state` to wire-level `:desired` in the backend facade and combine it with observed receipt status there.
+- Define one normalized JSON wire contract for list and document responses; do not wrap `publication/document-view` under another `:document` key.
+- Treat JSON enum values as strings at the HTTP boundary and explicitly convert them to/from domain keywords. Keywordizing object keys is not sufficient.
+- Map resource `:publication/state` to wire-level `"desired"` string values in the backend facade and combine it with observed receipt status there.
+- Encode keyword-valued response fields symmetrically (locale, desired/observed state, blockers, resource IDs where applicable), then explicitly decode them into CLJS UI-domain values in the frontend helper.
 - Render desired publication state separately from observed adapter state.
 - Make publish/unpublish/archive edits update only the relevant publication **state** through the existing resource-write boundary (or the narrowest new resource-write facade required).
 - Treat publication identity dimensions — document, garden, locale, revision selector — as immutable for state edits. Any re-key must be an explicit operation with duplicate/conflict validation.
-- Do not make the frontend parse EDN itself; frontend consumes normalized API data.
+- Do not make the frontend parse EDN itself; frontend consumes normalized JSON API data.
 - Keep dirty/save semantics explicit: editing body content and editing publication intent are separate mutations even when exposed in one CMS surface.
+- New asynchronous frontend CLJS uses native `^:async` + `await`, not `.then` chains.
 
 ## CLJS pseudocode
 
-Normalized backend facade:
+JSON wire contracts use JSON-safe scalar values:
 
 ```clojure
-(def PublicationWire
+(def PublicationWireJson
   [:map
-   [:id qualified-keyword?]
-   [:document qualified-keyword?]
-   [:garden qualified-keyword?]
-   [:locale :keyword]
-   [:revision [:or :string :keyword]]
+   [:id :string]
+   [:document :string]
+   [:garden :string]
+   [:locale :string]
+   [:revision :string]
    [:path :string]
-   [:desired [:enum :published :withheld :archived]]
-   [:observed {:optional true} :keyword]
-   [:blockers [:vector :keyword]]])
+   [:desired [:enum "published" "withheld" "archived"]]
+   [:observed {:optional true} [:maybe :string]]
+   [:blockers [:vector :string]]])
 
-(def CmsDocumentWire
+(def CmsDocumentWireJson
   [:map
    [:document :map]
-   [:publications [:vector PublicationWire]]])
+   [:publications [:vector PublicationWireJson]]])
 
-(def CmsListWire
+(def CmsListWireJson
   [:map
-   [:documents [:vector CmsDocumentWire]]
+   [:documents [:vector CmsDocumentWireJson]]
    [:gardens [:vector :map]]])
+```
+
+Backend encoding is explicit rather than relying on incidental keyword serialization:
+
+```clojure
+(defn encode-id [x] (str x))
+(defn encode-enum [x] (when x (name x)))
 
 (defn publication->wire [receipts intent]
-  {:id (:publication/id intent)
-   :document (:publication/document intent)
-   :garden (:publication/garden intent)
-   :locale (:publication/locale intent)
-   :revision (:publication/revision intent)
-   :path (:publication/path intent)
-   :desired (:publication/state intent)
-   :observed (publication-status/observed-for receipts intent)
-   :blockers (publication-status/blockers-for receipts intent)})
+  (law/assert!
+   PublicationWireJson
+   {:id (encode-id (:publication/id intent))
+    :document (encode-id (:publication/document intent))
+    :garden (encode-id (:publication/garden intent))
+    :locale (encode-enum (:publication/locale intent))
+    :revision (if (keyword? (:publication/revision intent))
+                (name (:publication/revision intent))
+                (:publication/revision intent))
+    :path (:publication/path intent)
+    :desired (encode-enum (:publication/state intent))
+    :observed (some-> (publication-status/observed-for receipts intent)
+                      encode-enum)
+    :blockers (mapv encode-enum
+                    (publication-status/blockers-for receipts intent))}))
 
 (defn cms-document-view [resource-index receipts document-id]
   (let [{:keys [document publications]}
@@ -88,17 +104,27 @@ Normalized backend facade:
      :gardens gardens}))
 ```
 
-State-only mutation boundary:
+State mutation has separate JSON and domain contracts:
 
 ```clojure
+(def PublicationStatePatchJson
+  [:map [:publication/state [:enum "published" "withheld" "archived"]]])
+
 (def PublicationStatePatch
   [:map [:publication/state [:enum :published :withheld :archived]]])
 
-(defn put-publication-state! [ctx publication-id patch]
-  (law/assert! PublicationStatePatch patch)
+(defn decode-publication-state-patch [wire]
+  (law/assert! PublicationStatePatchJson wire)
+  (let [domain {:publication/state
+                (keyword (:publication/state wire))}]
+    (law/assert! PublicationStatePatch domain)
+    domain))
+
+(defn put-publication-state! [ctx publication-id domain-patch]
+  (law/assert! PublicationStatePatch domain-patch)
   (let [current (resources/resolve-one ctx publication-id)
         next    (assoc current :publication/state
-                               (:publication/state patch))]
+                               (:publication/state domain-patch))]
     ;; locale/revision/document/garden cannot move through this endpoint.
     (law/assert! publication/PublicationIntentResource next)
     (resources/write! ctx next)))
@@ -108,23 +134,55 @@ State-only mutation boundary:
   (resources/rekey! ctx publication-id new-identity))
 ```
 
-Frontend page flow consumes those exact keys:
+The Fastify/HTTP adapter validates and decodes the JSON value before domain validation:
 
 ```clojure
-(defn load-cms! []
-  (-> (api/request "/api/publications/documents")
-      (.then #(swap! state assoc
-                     :documents (:documents %)
-                     :gardens (:gardens %)))))
+(defn patch-publication-state-route! [ctx req]
+  (let [wire   (:body (decode-request req))
+        domain (decode-publication-state-patch wire)]
+    (put-publication-state! ctx (:publication-id req) domain)))
+```
+
+Frontend wire decoding is symmetric:
+
+```clojure
+(defn decode-publication-wire [wire]
+  (-> wire
+      (update :id keyword)
+      (update :document keyword)
+      (update :garden keyword)
+      (update :locale keyword)
+      (update :desired keyword)
+      (update :observed #(when % (keyword %)))
+      (update :blockers #(mapv keyword %))))
+
+(defn decode-cms-list-wire [wire]
+  (update wire :documents
+          #(mapv (fn [doc]
+                   (update doc :publications
+                           (fn [publications]
+                             (mapv decode-publication-wire publications))))
+                 %)))
+```
+
+Frontend page flow consumes those exact keys using native async/await:
+
+```clojure
+(defn ^:async load-cms! []
+  (let [wire     (await (api/request "/api/publications/documents"))
+        response (decode-cms-list-wire wire)]
+    (swap! state assoc
+           :documents (:documents response)
+           :gardens (:gardens response))))
 
 (defn request-publish! [{:keys [publication-id]}]
   (api/request
    (str "/api/publications/intents/" (js/encodeURIComponent publication-id))
    {:method "PATCH"
-    :body {:publication/state :published}}))
+    :body {:publication/state "published"}}))
 ```
 
-Wire state is explicit and non-authoritative on the observed side:
+UI-domain state remains keyword-oriented after explicit frontend decoding:
 
 ```clojure
 {:desired :published
@@ -134,7 +192,8 @@ Wire state is explicit and non-authoritative on the observed side:
 
 ## Watch out
 
-- Do not preserve `publishedGardenIds` as a second client-side authority; derive selected/publication badges from `:desired` in the returned publication projection.
+- Do not preserve `publishedGardenIds` as a second client-side authority; derive selected/publication badges from `:desired` in the decoded publication projection.
+- Do not rely on JSON serialization to preserve Clojure keyword values. Wire enums are strings; domain enums are keywords; adapters convert explicitly in both directions.
 - Do not silently write runtime timestamps/job ids back into resources after publishing.
 - A failed adapter call must leave desired state unchanged and surface drift, not revert the user's requested contract state unless the user explicitly changes it.
 - State PATCHes cannot change locale, revision, document, or garden. Re-keying is explicit and conflict-checked.
@@ -142,7 +201,10 @@ Wire state is explicit and non-authoritative on the observed side:
 ## Done when
 
 - CMS can render document publication topology with OpenPlanner REST disabled.
-- List and document routes expose one consistent `{documents, gardens}` / `{document, publications}` vocabulary with publication `{desired, observed, blockers}` fields.
+- List and document routes expose one consistent `{documents, gardens}` / `{document, publications}` vocabulary with JSON-safe publication `{desired, observed, blockers}` fields.
+- A state PATCH containing JSON `"published"` decodes to domain `:published` before Malli validates `PublicationStatePatch`.
+- Response keyword-valued fields round-trip through explicit JSON encoding and frontend decoding without relying on implicit keyword serialization.
+- `load-cms!` uses `^:async`/`await` and contains no Promise `.then` chain.
 - Publishing from the CMS changes only the Knoxx publication resource's desired state and the UI reflects it from the normalized response.
 - Publication identity cannot silently move through publish/unpublish/archive edits.
 - No CMS code reads `garden_publications` to determine semantic publication state.

--- a/kanban/tasks/knoxx-contract-publication-e2e.md
+++ b/kanban/tasks/knoxx-contract-publication-e2e.md
@@ -2,7 +2,7 @@
 uuid: "knoxx-contract-publication-e2e"
 title: "Prove contract-owned publish -> translate -> review -> materialize with OpenPlanner REST absent"
 status: accepted
-priority: P1
+priority: P2
 labels: ["tasks", "5sp", "has-parent", "cms", "translations", "publication", "e2e", "deploy"]
 created_at: "2026-08-12T00:00:00Z"
 points: 5

--- a/kanban/tasks/knoxx-contract-publication-e2e.md
+++ b/kanban/tasks/knoxx-contract-publication-e2e.md
@@ -107,7 +107,7 @@ Do not maintain a second partial route list in this card. Import the exact surfa
 (require '[knoxx.backend.law.required-surfaces
            :refer [required-publication-surfaces]])
 
-(defn verify-contract-publication! [client auth-harness]
+(defn ^:async verify-contract-publication! [client auth-harness]
   (doseq [{:keys [method path auth]} required-publication-surfaces]
     (let [authorized (await (client/request! method path
                                              (auth-harness/headers-for auth)))]
@@ -147,4 +147,5 @@ The test should fail if:
 - Initial translation/review blockers match the gate's independent blocker semantics.
 - The final receipt asserts exact document, target, locale, and concrete revision and the public read returns the translated artifact.
 - Deploy verification and E2E use the same complete required-surface contract unconditionally.
+- The shared verifier itself uses native `^:async`/`await`; no helper contains `await` inside an ordinary `defn`.
 - One receipt chain is sufficient to explain how a resource intent converged to a public translated artifact.

--- a/kanban/tasks/knoxx-contract-publication-e2e.md
+++ b/kanban/tasks/knoxx-contract-publication-e2e.md
@@ -1,0 +1,108 @@
+---
+uuid: "knoxx-contract-publication-e2e"
+title: "Prove contract-owned publish -> translate -> review -> materialize with OpenPlanner REST absent"
+status: incoming
+priority: P1
+labels: ["tasks", "5sp", "has-parent", "cms", "translations", "publication", "e2e", "deploy"]
+created_at: "2026-08-12T00:00:00Z"
+points: 5
+category: tasks
+---
+# Prove contract-owned publish -> translate -> review -> materialize with OpenPlanner REST absent
+
+> Parent epic: `knoxx-contract-owned-publication-pipeline`
+
+## Purpose
+
+Turn the architectural claim into a deploy gate. The system only counts as decoupled when one complete publication journey succeeds while the OpenPlanner REST service is deliberately unavailable.
+
+## Scenario
+
+Use one disposable document, one garden, one source locale, and one translated target locale requiring review.
+
+The test must prove:
+
+```text
+resource document/publication intent
+  -> publication projection visible in CMS
+  -> translation requested from unmet intent
+  -> translated segments persisted through Knoxx translation boundary
+  -> reviewer approval recorded
+  -> publication gate clears
+  -> publication adapter materializes exact requested locale/revision
+  -> receipt reports convergence
+  -> public/read surface serves the materialized translation
+```
+
+OpenPlanner REST must not be started or stubbed. A hidden call to `/api/openplanner/...` should fail the test, not be accidentally satisfied.
+
+## CLJS pseudocode
+
+```clojure
+(deftest contract-owned-publication-without-openplanner-rest
+  (async done
+    (let [fixture (fixtures/publication-system
+                   {:openplanner-rest :disabled
+                    :adapter :fake-publication-target})]
+      (-> (fixtures/write-resources!
+           fixture
+           [{:document/id :docs/probe
+             :document/title "Probe"
+             :document/source {:path "fixtures/probe.md"}}
+            {:publication/id :docs/probe-es
+             :publication/document :docs/probe
+             :publication/garden :gardens/probe
+             :publication/locale :es
+             :publication/revision :source/current
+             :publication/state :published
+             :translation/review :required}])
+
+          (.then #(cms/load-document! fixture :docs/probe))
+          (.then (fn [view]
+                   (is (= :published
+                          (get-in view [:publications 0 :desired])))))
+
+          (.then #(reconciler/tick! fixture))
+          (.then #(is (= [:translation-missing]
+                          (publication/current-blockers fixture :docs/probe-es))))
+
+          (.then #(translation/complete-probe! fixture :docs/probe-es))
+          (.then #(review/approve-probe! fixture :docs/probe-es))
+          (.then #(reconciler/tick! fixture))
+
+          (.then (fn [_]
+                   (is (empty?
+                        (publication/current-blockers fixture :docs/probe-es)))
+                   (is (= "probe-revision"
+                          (:materialized/revision
+                           (receipts/latest fixture :docs/probe-es))))
+                   (is (= 0 (openplanner-rest/call-count fixture)))
+                   (done)))))))
+```
+
+Deploy-smoke shape:
+
+```clojure
+(defn verify-contract-publication! [client]
+  (-> (client/get! "/api/publications/health")
+      (.then #(assert (= 200 (:status %))))
+      (.then #(client/get! "/api/translations/documents?limit=1"))
+      (.then #(assert (= 200 (:status %))))))
+```
+
+## Failure assertions
+
+The test should fail if:
+
+- CMS falls back to `garden_publications` metadata;
+- translation config reaches `/api/openplanner/v1/translations/config`;
+- garden discovery reaches `/api/openplanner/v1/gardens`;
+- review-required publication materializes before approval;
+- adapter materializes the wrong locale or source revision;
+- desired state is rewritten to match a failed adapter observation instead of reporting drift.
+
+## Done when
+
+- The E2E passes with OpenPlanner REST absent and fails when any legacy authority path is restored.
+- The deploy verification path includes the new publication/CMS surfaces unconditionally.
+- One receipt chain is sufficient to explain how a resource intent converged to a public translated artifact.

--- a/kanban/tasks/knoxx-contract-publication-e2e.md
+++ b/kanban/tasks/knoxx-contract-publication-e2e.md
@@ -1,7 +1,7 @@
 ---
 uuid: "knoxx-contract-publication-e2e"
 title: "Prove contract-owned publish -> translate -> review -> materialize with OpenPlanner REST absent"
-status: incoming
+status: accepted
 priority: P1
 labels: ["tasks", "5sp", "has-parent", "cms", "translations", "publication", "e2e", "deploy"]
 created_at: "2026-08-12T00:00:00Z"
@@ -18,7 +18,7 @@ Turn the architectural claim into a deploy gate. The system only counts as decou
 
 ## Scenario
 
-Use one disposable document, one garden, one source locale, and one translated target locale requiring review.
+Use one disposable document, one active garden, one source locale, and one translated target locale requiring review.
 
 The test must prove:
 
@@ -38,71 +38,113 @@ OpenPlanner REST must not be started or stubbed. A hidden call to `/api/openplan
 
 ## CLJS pseudocode
 
+Use Knoxx's native async test shape: `deftest ^:async` plus `await`, not legacy `cljs.test/async` callbacks or Promise chains.
+
 ```clojure
-(deftest contract-owned-publication-without-openplanner-rest
-  (async done
-    (let [fixture (fixtures/publication-system
-                   {:openplanner-rest :disabled
-                    :adapter :fake-publication-target})]
-      (-> (fixtures/write-resources!
-           fixture
-           [{:document/id :docs/probe
-             :document/title "Probe"
-             :document/source {:path "fixtures/probe.md"}}
-            {:publication/id :docs/probe-es
-             :publication/document :docs/probe
-             :publication/garden :gardens/probe
-             :publication/locale :es
-             :publication/revision :source/current
-             :publication/state :published
-             :translation/review :required}])
+(deftest ^:async contract-owned-publication-without-openplanner-rest
+  (let [fixture (await (fixtures/publication-system
+                        {:openplanner-rest :disabled
+                         :adapter :fake-publication-target}))]
+    (await
+     (fixtures/write-resources!
+      fixture
+      [{:garden/id :gardens/probe
+        :garden/title "Probe Garden"
+        :garden/status :active}
 
-          (.then #(cms/load-document! fixture :docs/probe))
-          (.then (fn [view]
-                   (is (= :published
-                          (get-in view [:publications 0 :desired])))))
+       {:document/id :docs/probe
+        :document/title "Probe"
+        :document/source-locale :en
+        :document/source {:path "fixtures/probe.md"}}
 
-          (.then #(reconciler/tick! fixture))
-          (.then #(is (= [:translation-missing]
-                          (publication/current-blockers fixture :docs/probe-es))))
+       {:publication/id :docs/probe-es
+        :publication/document :docs/probe
+        :publication/garden :gardens/probe
+        :publication/locale :es
+        :publication/revision :source/current
+        :publication/state :published
+        :publication/path "/probe"
+        :translation/review :required}]))
 
-          (.then #(translation/complete-probe! fixture :docs/probe-es))
-          (.then #(review/approve-probe! fixture :docs/probe-es))
-          (.then #(reconciler/tick! fixture))
+    (let [view (await (cms/load-document! fixture :docs/probe))]
+      (is (= :published
+             (get-in view [:publications 0 :desired]))))
 
-          (.then (fn [_]
-                   (is (empty?
-                        (publication/current-blockers fixture :docs/probe-es)))
-                   (is (= "probe-revision"
-                          (:materialized/revision
-                           (receipts/latest fixture :docs/probe-es))))
-                   (is (= 0 (openplanner-rest/call-count fixture)))
-                   (done)))))))
+    (await (reconciler/tick! fixture))
+    ;; Blockers are independent facts: translation is absent and therefore no
+    ;; revision-specific approval exists yet.
+    (is (= #{:translation-missing :translation-review-required}
+           (set (publication/current-blockers fixture :docs/probe-es))))
+
+    (await (translation/complete-probe! fixture :docs/probe-es))
+    (await (review/approve-probe! fixture :docs/probe-es))
+    (await (reconciler/tick! fixture))
+
+    (is (empty? (publication/current-blockers fixture :docs/probe-es)))
+
+    (let [receipt (receipts/latest fixture :docs/probe-es)
+          public  (await (public/read! fixture
+                                       {:garden :gardens/probe
+                                        :path "/probe"
+                                        :locale :es}))]
+      (is (= :docs/probe (:document/id receipt)))
+      (is (= :gardens/probe (:target receipt)))
+      (is (= :es (:locale receipt)))
+      (is (= "probe-revision" (:revision receipt)))
+      (is (= "Probe traducido" (:content public)))
+      (is (= :es (:locale public)))
+      (is (= "probe-revision" (:revision public)))
+      (is (= 0 (openplanner-rest/call-count fixture))))))
 ```
 
-Deploy-smoke shape:
+The fixture must establish the concrete current source revision as `"probe-revision"`, so `:source/current` resolves deterministically before materialization.
+
+## Shared deploy-smoke contract
+
+Do not maintain a second partial route list in this card. Import the exact surface contract owned by `knoxx-openplanner-rest-retirement`:
 
 ```clojure
-(defn verify-contract-publication! [client]
-  (-> (client/get! "/api/publications/health")
-      (.then #(assert (= 200 (:status %))))
-      (.then #(client/get! "/api/translations/documents?limit=1"))
-      (.then #(assert (= 200 (:status %))))))
+(require '[knoxx.backend.law.required-surfaces
+           :refer [required-publication-surfaces]])
+
+(defn verify-contract-publication! [client auth-harness]
+  (doseq [{:keys [method path auth]} required-publication-surfaces]
+    (let [authorized (await (client/request! method path
+                                             (auth-harness/headers-for auth)))]
+      (is (= 200 (:status authorized)))
+      (when-not (= :public auth)
+        (is (contains? #{401 403}
+                       (:status (await (client/request! method path {})))))))))
+```
+
+The shared list includes all five required surfaces:
+
+```text
+GET /api/publications/health
+GET /api/publications/documents?limit=1
+GET /api/publications/gardens
+GET /api/translations/documents?limit=1
+GET /api/translations/config
 ```
 
 ## Failure assertions
 
 The test should fail if:
 
+- the garden resource is missing/archived or publication path validation fails;
 - CMS falls back to `garden_publications` metadata;
 - translation config reaches `/api/openplanner/v1/translations/config`;
 - garden discovery reaches `/api/openplanner/v1/gardens`;
 - review-required publication materializes before approval;
-- adapter materializes the wrong locale or source revision;
-- desired state is rewritten to match a failed adapter observation instead of reporting drift.
+- adapter materializes the wrong document, target, locale, or concrete source revision;
+- the public/read surface does not serve the translated artifact that the receipt says was materialized;
+- desired state is rewritten to match a failed adapter observation instead of reporting drift;
+- any shared required surface has the wrong method/authorization behavior or becomes optional when OpenPlanner REST is absent.
 
 ## Done when
 
 - The E2E passes with OpenPlanner REST absent and fails when any legacy authority path is restored.
-- The deploy verification path includes the new publication/CMS surfaces unconditionally.
+- Initial translation/review blockers match the gate's independent blocker semantics.
+- The final receipt asserts exact document, target, locale, and concrete revision and the public read returns the translated artifact.
+- Deploy verification and E2E use the same complete required-surface contract unconditionally.
 - One receipt chain is sufficient to explain how a resource intent converged to a public translated artifact.

--- a/kanban/tasks/knoxx-openplanner-publication-state-migration.md
+++ b/kanban/tasks/knoxx-openplanner-publication-state-migration.md
@@ -2,7 +2,7 @@
 uuid: "knoxx-openplanner-publication-state-migration"
 title: "Migrate existing OpenPlanner garden/publication intent into Knoxx resources"
 status: accepted
-priority: P1
+priority: P0
 labels: ["tasks", "5sp", "has-parent", "publication", "migration", "openplanner"]
 created_at: "2026-08-12T00:00:00Z"
 points: 5

--- a/kanban/tasks/knoxx-openplanner-publication-state-migration.md
+++ b/kanban/tasks/knoxx-openplanner-publication-state-migration.md
@@ -1,0 +1,92 @@
+---
+uuid: "knoxx-openplanner-publication-state-migration"
+title: "Migrate existing OpenPlanner garden/publication intent into Knoxx resources"
+status: incoming
+priority: P1
+labels: ["tasks", "5sp", "has-parent", "publication", "migration", "openplanner"]
+created_at: "2026-08-12T00:00:00Z"
+points: 5
+category: tasks
+---
+# Migrate existing OpenPlanner garden/publication intent into Knoxx resources
+
+> Parent epic: `knoxx-contract-owned-publication-pipeline`
+
+## Purpose
+
+Perform the one-time authority transfer from existing OpenPlanner garden/publication metadata to Knoxx resources without silently losing or inventing desired state.
+
+This is not an ongoing synchronization system. After cutover, resources are authoritative and OpenPlanner is an adapter/projection only.
+
+## Scope
+
+- Inventory current garden rows and document `garden_publications` metadata used by CMS.
+- Convert semantic fields into `garden`, `document`, and `publication` resources.
+- Separate operational observations (`published_at`, job/run ids, adapter timestamps) into migration receipts rather than resource data.
+- Detect ambiguous/conflicting source rows and emit a report requiring explicit resolution; do not apply "last write wins".
+- Make migration idempotent and restart-safe.
+- Preserve stable content/document identity when source paths or titles have changed.
+- After successful migration, disable any compatibility path that can write OpenPlanner publication metadata as a competing authority.
+
+## CLJS pseudocode
+
+```clojure
+(ns knoxx.backend.domain.publication-migration)
+
+(defn garden->resource [row]
+  {:garden/id (canonical-garden-id row)
+   :garden/title (:title row)
+   :garden/status (if (= "archived" (:status row)) :archived :active)})
+
+(defn publication->resource [document row]
+  {:publication/id (canonical-publication-id document row)
+   :publication/document (:document/id document)
+   :publication/garden (canonical-garden-id row)
+   :publication/locale (keyword (or (:locale row) "en"))
+   :publication/revision (or (:revision row) :source/current)
+   :publication/state (if (:published row) :published :withheld)
+   :publication/path (:path row)
+   :translation/review (if (:review-required row) :required :none)})
+
+(defn migrate-record [resource-index source-record]
+  (let [candidate (publication->resource
+                   (resolve-document source-record)
+                   source-record)]
+    (cond
+      (publication/conflicts? resource-index candidate)
+      {:migration/status :conflict
+       :candidate candidate
+       :source source-record}
+
+      (publication/equivalent? resource-index candidate)
+      {:migration/status :noop
+       :resource/id (:publication/id candidate)}
+
+      :else
+      {:migration/status :write
+       :resource candidate})))
+```
+
+Migration runner sketch:
+
+```clojure
+(doseq [record (legacy/read-publication-records! ctx)]
+  (let [decision (migration/migrate-record resource-index record)]
+    (case (:migration/status decision)
+      :write    (resources/write! ctx (:resource decision))
+      :conflict (receipts/append! ctx decision)
+      :noop     nil)))
+```
+
+## Laws
+
+- Re-running migration over unchanged legacy data produces no new semantic resources.
+- Unknown/ambiguous locale, path, garden, or document identity becomes a conflict receipt, not guessed contract data.
+- Removing legacy operational timestamps from input cannot change generated desired-state resources.
+- Once cut over, migration is retired; no bidirectional sync remains.
+
+## Done when
+
+- Existing publish topology can be reconstructed as validated Knoxx resources.
+- Conflicts are enumerated explicitly with source evidence.
+- The same migration run twice yields identical resource state and no duplicate publications.

--- a/kanban/tasks/knoxx-openplanner-publication-state-migration.md
+++ b/kanban/tasks/knoxx-openplanner-publication-state-migration.md
@@ -24,7 +24,8 @@ This migration and explicit conflict resolution land **before** the CMS resource
 
 - Inventory current garden rows and document `garden_publications` metadata used by CMS.
 - Convert semantic fields into `garden`, `document`, and `publication` resources.
-- Validate legacy garden status, source/target locale, path, garden identity, document identity, and revision information before constructing resources; missing or unrecognized semantic values become conflicts rather than defaults.
+- Validate every legacy semantic field before constructing resources: garden status, source/target locale, path, garden identity, document identity, revision selector/value, requested publication state, and review policy. Missing, malformed, or unrecognized values become conflicts rather than defaults.
+- In particular, do **not** infer `:source/current` from a missing revision and do **not** coerce missing/truthy/falsy legacy `:published` values into publication state. Both must decode explicitly.
 - Separate operational observations (`published_at`, job/run ids, adapter timestamps) into migration receipts rather than resource data.
 - Detect ambiguous/conflicting source rows and emit a report requiring explicit resolution; do not apply "last write wins".
 - Make migration idempotent and restart-safe both for resource writes and conflict receipts.
@@ -37,45 +38,75 @@ This migration and explicit conflict resolution land **before** the CMS resource
 ```clojure
 (ns knoxx.backend.domain.publication-migration)
 
+(defn conflict [reason field value row]
+  {:migration/status :conflict
+   :reason reason
+   :field field
+   :value value
+   :source row})
+
 (defn decode-garden-status [row]
   (case (:status row)
     "active"   {:ok :active}
     "archived" {:ok :archived}
-    {:conflict :unknown-garden-status
-     :value (:status row)}))
+    (conflict :unknown-garden-status :status (:status row) row)))
 
 (defn decode-locale [field row]
   (let [value (get row field)
         locale (when (and (string? value) (seq value)) (keyword value))]
     (if (and locale (law/valid? publication/Locale locale))
       {:ok locale}
-      {:conflict :unknown-locale
-       :field field
-       :value value})))
+      (conflict :unknown-locale field value row))))
+
+(defn decode-revision [row]
+  (let [value (:revision row)]
+    (cond
+      (= :source/current value)
+      {:ok :source/current}
+
+      (and (string? value) (seq value))
+      {:ok value}
+
+      :else
+      (conflict :invalid-publication-revision :revision value row))))
+
+(defn decode-publication-state [row]
+  (if (and (contains? row :published)
+           (boolean? (:published row)))
+    {:ok (if (:published row) :published :withheld)}
+    (conflict :invalid-published-state :published (:published row) row)))
+
+(defn decode-review-policy [row]
+  (if (and (contains? row :review-required)
+           (boolean? (:review-required row)))
+    {:ok (if (:review-required row) :required :none)}
+    (conflict :invalid-review-policy
+              :review-required
+              (:review-required row)
+              row)))
 
 (defn garden->decision [row]
   (let [status (decode-garden-status row)]
-    (if-let [reason (:conflict status)]
-      {:migration/status :conflict
-       :reason reason
-       :source row}
+    (if (:migration/status status)
+      status
       {:migration/status :candidate
        :resource {:garden/id (canonical-garden-id row)
                   :garden/title (:title row)
                   :garden/status (:ok status)}})))
 
 (defn publication->decision [document row]
-  (let [locale (decode-locale :locale row)]
+  (let [locale   (decode-locale :locale row)
+        revision (decode-revision row)
+        state    (decode-publication-state row)
+        review   (decode-review-policy row)
+        invalid  (some #(when (:migration/status %) %)
+                       [locale revision state review])]
     (cond
-      (:conflict locale)
-      {:migration/status :conflict
-       :reason (:conflict locale)
-       :source row}
+      invalid
+      invalid
 
       (not (valid-publication-path? (:path row)))
-      {:migration/status :conflict
-       :reason :invalid-publication-path
-       :source row}
+      (conflict :invalid-publication-path :path (:path row) row)
 
       :else
       {:migration/status :candidate
@@ -84,11 +115,10 @@ This migration and explicit conflict resolution land **before** the CMS resource
         :publication/document (:document/id document)
         :publication/garden (canonical-garden-id row)
         :publication/locale (:ok locale)
-        :publication/revision (or (validated-revision row)
-                                  :source/current)
-        :publication/state (if (:published row) :published :withheld)
+        :publication/revision (:ok revision)
+        :publication/state (:ok state)
         :publication/path (:path row)
-        :translation/review (if (:review-required row) :required :none)}})))
+        :translation/review (:ok review)}})))
 
 (defn migrate-record [resource-index source-record]
   (let [candidate-decision
@@ -144,7 +174,9 @@ Garden migration uses the same decision/receipt discipline. Document migration m
 ## Laws
 
 - Re-running migration over unchanged legacy data produces no new semantic resources.
-- Unknown/ambiguous source locale, target locale, status, path, garden, or document identity becomes a conflict receipt, not guessed contract data.
+- Unknown/ambiguous source locale, target locale, status, path, garden, document identity, revision, publication state, or review policy becomes a conflict receipt, not guessed contract data.
+- Missing revision never means `:source/current` unless that selector was explicitly represented by the legacy source.
+- Only an actual legacy boolean may become `:published` or `:withheld`; truthiness/falsiness is not a decoder.
 - Conflict receipts have stable source-record keys; reruns do not duplicate them.
 - Successful writes immediately enter the migration index before the next source record is classified.
 - Removing legacy operational timestamps from input cannot change generated desired-state resources.
@@ -154,5 +186,6 @@ Garden migration uses the same decision/receipt discipline. Document migration m
 
 - Existing publish topology can be reconstructed as validated Knoxx resources before the CMS authority cutover.
 - Conflicts are enumerated explicitly with source evidence and no defaulted semantic values.
+- Fixtures prove missing/invalid revision and non-boolean/missing publish state produce conflicts rather than resources.
 - Two source rows mapping to the same publication are reconciled against the updated in-run index rather than both being blindly written.
 - The same migration run twice yields identical resource state and no duplicate publications or conflict receipts.

--- a/kanban/tasks/knoxx-openplanner-publication-state-migration.md
+++ b/kanban/tasks/knoxx-openplanner-publication-state-migration.md
@@ -25,6 +25,7 @@ This migration and explicit conflict resolution land **before** the CMS resource
 - Inventory current garden rows and document `garden_publications` metadata used by CMS.
 - Convert semantic fields into `garden`, `document`, and `publication` resources.
 - Validate every legacy semantic field before constructing resources: garden status, source/target locale, path, garden identity, document identity, revision selector/value, requested publication state, and review policy. Missing, malformed, or unrecognized values become conflicts rather than defaults.
+- Reuse `knoxx.backend.law.publication/valid-publication-path?` for path validation so migrated data and directly authored resource data obey the exact same route law.
 - In particular, do **not** infer `:source/current` from a missing revision and do **not** coerce missing/truthy/falsy legacy `:published` values into publication state. Both must decode explicitly.
 - Separate operational observations (`published_at`, job/run ids, adapter timestamps) into migration receipts rather than resource data.
 - Detect ambiguous/conflicting source rows and emit a report requiring explicit resolution; do not apply "last write wins".
@@ -105,7 +106,7 @@ This migration and explicit conflict resolution land **before** the CMS resource
       invalid
       invalid
 
-      (not (valid-publication-path? (:path row)))
+      (not (publication/valid-publication-path? (:path row)))
       (conflict :invalid-publication-path :path (:path row) row)
 
       :else
@@ -175,6 +176,7 @@ Garden migration uses the same decision/receipt discipline. Document migration m
 
 - Re-running migration over unchanged legacy data produces no new semantic resources.
 - Unknown/ambiguous source locale, target locale, status, path, garden, document identity, revision, publication state, or review policy becomes a conflict receipt, not guessed contract data.
+- Migration path validation is exactly the authoritative `publication/valid-publication-path?` law used for directly authored publication resources.
 - Missing revision never means `:source/current` unless that selector was explicitly represented by the legacy source.
 - Only an actual legacy boolean may become `:published` or `:withheld`; truthiness/falsiness is not a decoder.
 - Conflict receipts have stable source-record keys; reruns do not duplicate them.
@@ -187,5 +189,6 @@ Garden migration uses the same decision/receipt discipline. Document migration m
 - Existing publish topology can be reconstructed as validated Knoxx resources before the CMS authority cutover.
 - Conflicts are enumerated explicitly with source evidence and no defaulted semantic values.
 - Fixtures prove missing/invalid revision and non-boolean/missing publish state produce conflicts rather than resources.
+- Direct-resource and migration fixtures reject the same malformed publication paths through the same shared predicate.
 - Two source rows mapping to the same publication are reconciled against the updated in-run index rather than both being blindly written.
 - The same migration run twice yields identical resource state and no duplicate publications or conflict receipts.

--- a/kanban/tasks/knoxx-openplanner-publication-state-migration.md
+++ b/kanban/tasks/knoxx-openplanner-publication-state-migration.md
@@ -1,7 +1,7 @@
 ---
 uuid: "knoxx-openplanner-publication-state-migration"
 title: "Migrate existing OpenPlanner garden/publication intent into Knoxx resources"
-status: incoming
+status: accepted
 priority: P1
 labels: ["tasks", "5sp", "has-parent", "publication", "migration", "openplanner"]
 created_at: "2026-08-12T00:00:00Z"
@@ -18,13 +18,17 @@ Perform the one-time authority transfer from existing OpenPlanner garden/publica
 
 This is not an ongoing synchronization system. After cutover, resources are authoritative and OpenPlanner is an adapter/projection only.
 
+This migration and explicit conflict resolution land **before** the CMS resource-authority cutover.
+
 ## Scope
 
 - Inventory current garden rows and document `garden_publications` metadata used by CMS.
 - Convert semantic fields into `garden`, `document`, and `publication` resources.
+- Validate legacy garden status, source/target locale, path, garden identity, document identity, and revision information before constructing resources; missing or unrecognized semantic values become conflicts rather than defaults.
 - Separate operational observations (`published_at`, job/run ids, adapter timestamps) into migration receipts rather than resource data.
 - Detect ambiguous/conflicting source rows and emit a report requiring explicit resolution; do not apply "last write wins".
-- Make migration idempotent and restart-safe.
+- Make migration idempotent and restart-safe both for resource writes and conflict receipts.
+- Update the in-memory migration index after each successful write so later legacy rows are checked against state produced earlier in the same run.
 - Preserve stable content/document identity when source paths or titles have changed.
 - After successful migration, disable any compatibility path that can write OpenPlanner publication metadata as a competing authority.
 
@@ -33,60 +37,122 @@ This is not an ongoing synchronization system. After cutover, resources are auth
 ```clojure
 (ns knoxx.backend.domain.publication-migration)
 
-(defn garden->resource [row]
-  {:garden/id (canonical-garden-id row)
-   :garden/title (:title row)
-   :garden/status (if (= "archived" (:status row)) :archived :active)})
+(defn decode-garden-status [row]
+  (case (:status row)
+    "active"   {:ok :active}
+    "archived" {:ok :archived}
+    {:conflict :unknown-garden-status
+     :value (:status row)}))
 
-(defn publication->resource [document row]
-  {:publication/id (canonical-publication-id document row)
-   :publication/document (:document/id document)
-   :publication/garden (canonical-garden-id row)
-   :publication/locale (keyword (or (:locale row) "en"))
-   :publication/revision (or (:revision row) :source/current)
-   :publication/state (if (:published row) :published :withheld)
-   :publication/path (:path row)
-   :translation/review (if (:review-required row) :required :none)})
+(defn decode-locale [field row]
+  (let [value (get row field)
+        locale (when (and (string? value) (seq value)) (keyword value))]
+    (if (and locale (law/valid? publication/Locale locale))
+      {:ok locale}
+      {:conflict :unknown-locale
+       :field field
+       :value value})))
 
-(defn migrate-record [resource-index source-record]
-  (let [candidate (publication->resource
-                   (resolve-document source-record)
-                   source-record)]
-    (cond
-      (publication/conflicts? resource-index candidate)
+(defn garden->decision [row]
+  (let [status (decode-garden-status row)]
+    (if-let [reason (:conflict status)]
       {:migration/status :conflict
-       :candidate candidate
-       :source source-record}
+       :reason reason
+       :source row}
+      {:migration/status :candidate
+       :resource {:garden/id (canonical-garden-id row)
+                  :garden/title (:title row)
+                  :garden/status (:ok status)}})))
 
-      (publication/equivalent? resource-index candidate)
-      {:migration/status :noop
-       :resource/id (:publication/id candidate)}
+(defn publication->decision [document row]
+  (let [locale (decode-locale :locale row)]
+    (cond
+      (:conflict locale)
+      {:migration/status :conflict
+       :reason (:conflict locale)
+       :source row}
+
+      (not (valid-publication-path? (:path row)))
+      {:migration/status :conflict
+       :reason :invalid-publication-path
+       :source row}
 
       :else
-      {:migration/status :write
-       :resource candidate})))
+      {:migration/status :candidate
+       :resource
+       {:publication/id (canonical-publication-id document row)
+        :publication/document (:document/id document)
+        :publication/garden (canonical-garden-id row)
+        :publication/locale (:ok locale)
+        :publication/revision (or (validated-revision row)
+                                  :source/current)
+        :publication/state (if (:published row) :published :withheld)
+        :publication/path (:path row)
+        :translation/review (if (:review-required row) :required :none)}})))
+
+(defn migrate-record [resource-index source-record]
+  (let [candidate-decision
+        (publication->decision (resolve-document source-record) source-record)]
+    (if (= :conflict (:migration/status candidate-decision))
+      candidate-decision
+      (let [candidate (:resource candidate-decision)]
+        (cond
+          (publication/conflicts? resource-index candidate)
+          {:migration/status :conflict
+           :reason :publication-conflict
+           :candidate candidate
+           :source source-record}
+
+          (publication/equivalent? resource-index candidate)
+          {:migration/status :noop
+           :resource/id (:publication/id candidate)}
+
+          :else
+          {:migration/status :write
+           :resource candidate})))))
 ```
 
-Migration runner sketch:
+Stable receipt identity and stateful migration fold:
 
 ```clojure
-(doseq [record (legacy/read-publication-records! ctx)]
-  (let [decision (migration/migrate-record resource-index record)]
-    (case (:migration/status decision)
-      :write    (resources/write! ctx (:resource decision))
-      :conflict (receipts/append! ctx decision)
-      :noop     nil)))
+(defn migration-receipt-key [source-record]
+  [:openplanner/publication-migration
+   (:source/collection source-record)
+   (:source/id source-record)])
+
+(loop [idx resource-index
+       records (legacy/read-publication-records! ctx)]
+  (when-let [record (first records)]
+    (let [decision (migration/migrate-record idx record)]
+      (case (:migration/status decision)
+        :write
+        (let [written (resources/write! ctx (:resource decision))]
+          (recur (publication/index-resource idx written) (rest records)))
+
+        :conflict
+        (do (receipts/append-once! ctx
+                                   (migration-receipt-key record)
+                                   decision)
+            (recur idx (rest records)))
+
+        :noop
+        (recur idx (rest records))))))
 ```
+
+Garden migration uses the same decision/receipt discipline. Document migration must likewise refuse to invent required `:document/source-locale`; missing/ambiguous source locale is a conflict that must be resolved before CMS cutover.
 
 ## Laws
 
 - Re-running migration over unchanged legacy data produces no new semantic resources.
-- Unknown/ambiguous locale, path, garden, or document identity becomes a conflict receipt, not guessed contract data.
+- Unknown/ambiguous source locale, target locale, status, path, garden, or document identity becomes a conflict receipt, not guessed contract data.
+- Conflict receipts have stable source-record keys; reruns do not duplicate them.
+- Successful writes immediately enter the migration index before the next source record is classified.
 - Removing legacy operational timestamps from input cannot change generated desired-state resources.
 - Once cut over, migration is retired; no bidirectional sync remains.
 
 ## Done when
 
-- Existing publish topology can be reconstructed as validated Knoxx resources.
-- Conflicts are enumerated explicitly with source evidence.
-- The same migration run twice yields identical resource state and no duplicate publications.
+- Existing publish topology can be reconstructed as validated Knoxx resources before the CMS authority cutover.
+- Conflicts are enumerated explicitly with source evidence and no defaulted semantic values.
+- Two source rows mapping to the same publication are reconciled against the updated in-run index rather than both being blindly written.
+- The same migration run twice yields identical resource state and no duplicate publications or conflict receipts.

--- a/kanban/tasks/knoxx-openplanner-rest-retirement.md
+++ b/kanban/tasks/knoxx-openplanner-rest-retirement.md
@@ -26,7 +26,7 @@ Delete the compatibility dependency after the resource-owned publication path is
 - Keep OpenPlanner-backed adapters only behind `IPublicationTarget` or other explicit extern/infra boundaries.
 - Ensure no frontend module, backend route, ingestion worker, or other shipped service imports/calls an OpenPlanner config/publication authority path after cutover.
 - Define one shared required-surface contract and reuse it in deploy verification and `knoxx-contract-publication-e2e`, including route method and authorization expectations.
-- Replacement CLJS routes/functions use native `^:async`/`await` where asynchronous behavior is required.
+- Replacement CLJS routes/functions and smoke verifiers use native `^:async`/`await` where asynchronous behavior is required.
 
 ## CLJS pseudocode
 
@@ -80,15 +80,19 @@ One shared pure surface specification, imported by both the deploy verifier and 
 The symbolic auth expectations above map to the real Knoxx authorization guards/capabilities in the verifier. The same test data must assert both an authorized success and the intended anonymous/unauthorized denial for non-public routes.
 
 ```clojure
-(defn verify-required-surfaces! [http auth-harness]
+(defn ^:async verify-required-surfaces! [http auth-harness]
   (doseq [{:keys [method path auth]} required-publication-surfaces]
-    (let [authorized (http/request! method path
-                                    (auth-harness/headers-for auth))]
+    (let [authorized (await
+                      (http/request! method path
+                                     (auth-harness/headers-for auth)))]
       (assert (= 200 (:status authorized)))
       (when-not (= :public auth)
-        (assert (contains? #{401 403}
-                           (:status (http/request! method path {}))))))))
+        (let [unauthorized (await (http/request! method path {}))]
+          (assert (contains? #{401 403}
+                             (:status unauthorized))))))))
 ```
+
+No verifier performs keyword lookup on a Promise. Every asynchronous request is awaited before response status is inspected.
 
 Repository-wide retirement check is broader than frontend routes:
 
@@ -129,6 +133,7 @@ Do not delete the compatibility path before:
 - `ingestion/src/kms_ingestion/translation/worker.clj` resolves the same Knoxx resource-selected model reported by `/api/translations/config`.
 - Production deploy verification and the contract-publication E2E import the same complete required-surface list.
 - All five replacement surfaces are checked for method and intended authorization behavior.
+- The shared verifier is `^:async` and awaits both authorized and unauthorized HTTP requests before reading status.
 - Replacement asynchronous CLJS surfaces follow the repository's `^:async`/`await` convention.
 - Production deploy verification requires CMS/publication surfaces unconditionally.
 - `KNOXX_EXPECT_OPENPLANNER_REST` is gone.

--- a/kanban/tasks/knoxx-openplanner-rest-retirement.md
+++ b/kanban/tasks/knoxx-openplanner-rest-retirement.md
@@ -1,7 +1,7 @@
 ---
 uuid: "knoxx-openplanner-rest-retirement"
 title: "Retire OpenPlanner REST as a Knoxx CMS/translation dependency"
-status: incoming
+status: accepted
 priority: P1
 labels: ["tasks", "3sp", "has-parent", "cms", "translations", "openplanner", "deploy"]
 created_at: "2026-08-12T00:00:00Z"
@@ -24,6 +24,7 @@ Delete the compatibility dependency after the resource-owned publication path is
 - Remove `KNOXX_EXPECT_OPENPLANNER_REST` and the conditional CMS skip from deploy verification once the replacement surface is unconditional.
 - Keep OpenPlanner-backed adapters only behind `IPublicationTarget` or other explicit extern/infra boundaries.
 - Ensure no frontend module imports an `openplanner` API wrapper for publication semantics after cutover.
+- Define one shared required-surface contract and reuse it in deploy verification and `knoxx-contract-publication-e2e`, including route method and authorization expectations.
 
 ## CLJS pseudocode
 
@@ -52,17 +53,40 @@ After:
   (api/request "/api/publications/health"))
 ```
 
-Deploy probe intent:
+One shared pure surface specification, imported by both the deploy verifier and E2E test:
 
 ```clojure
-(def required-surfaces
-  ["/api/publications/health"
-   "/api/publications/documents?limit=1"
-   "/api/translations/documents?limit=1"])
+(ns knoxx.backend.law.required-surfaces)
 
-(defn verify-required-surfaces! [http]
-  (doseq [path required-surfaces]
-    (assert (= 200 (:status (http/get! path))))))
+(def required-publication-surfaces
+  [{:method :get
+    :path "/api/publications/health"
+    :auth :public}
+   {:method :get
+    :path "/api/publications/documents?limit=1"
+    :auth :publication-read}
+   {:method :get
+    :path "/api/publications/gardens"
+    :auth :publication-read}
+   {:method :get
+    :path "/api/translations/documents?limit=1"
+    :auth :translation-read}
+   {:method :get
+    :path "/api/translations/config"
+    :auth :translation-read}])
+```
+
+The symbolic auth expectations above map to the real Knoxx authorization guards/capabilities in the verifier. The same test data must assert both an authorized success and the intended anonymous/unauthorized denial for non-public routes.
+
+```clojure
+(defn verify-required-surfaces! [http auth-harness]
+  (doseq [{:keys [method path auth]} required-publication-surfaces]
+    (let [authorized (http/request! method path
+                                    (auth-harness/headers-for auth))]
+      (assert (= 200 (:status authorized)))
+      (when-not (= :public auth)
+        (assert (contains? #{401 403}
+                           (:status (http/request! method path {}))))))))
 ```
 
 There should be no equivalent of:
@@ -77,14 +101,17 @@ There should be no equivalent of:
 Do not delete the compatibility path before:
 
 - publication resources and resolver are live;
-- CMS reads/writes the resource projection;
+- the one-time OpenPlanner publication migration has converged and conflicts are resolved;
 - translation pipeline config is resource-owned;
-- existing publication state has been migrated or explicitly abandoned;
-- at least one publication adapter can materialize requested state.
+- translation/review gating and at least one publication adapter exist;
+- CMS reads/writes the resource projection;
+- the shared required-surface verification passes without OpenPlanner REST.
 
 ## Done when
 
 - Grepping shipped frontend/backend code for the two OpenPlanner authority routes returns no callers.
+- Production deploy verification and the contract-publication E2E import the same complete required-surface list.
+- All five replacement surfaces are checked for method and intended authorization behavior.
 - Production deploy verification requires CMS/publication surfaces unconditionally.
 - `KNOXX_EXPECT_OPENPLANNER_REST` is gone.
 - OpenPlanner may be absent without degrading Knoxx's ability to describe or edit desired publication state.

--- a/kanban/tasks/knoxx-openplanner-rest-retirement.md
+++ b/kanban/tasks/knoxx-openplanner-rest-retirement.md
@@ -2,7 +2,7 @@
 uuid: "knoxx-openplanner-rest-retirement"
 title: "Retire OpenPlanner REST as a Knoxx CMS/translation dependency"
 status: accepted
-priority: P1
+priority: P2
 labels: ["tasks", "3sp", "has-parent", "cms", "translations", "openplanner", "deploy"]
 created_at: "2026-08-12T00:00:00Z"
 points: 3

--- a/kanban/tasks/knoxx-openplanner-rest-retirement.md
+++ b/kanban/tasks/knoxx-openplanner-rest-retirement.md
@@ -26,32 +26,32 @@ Delete the compatibility dependency after the resource-owned publication path is
 - Keep OpenPlanner-backed adapters only behind `IPublicationTarget` or other explicit extern/infra boundaries.
 - Ensure no frontend module, backend route, ingestion worker, or other shipped service imports/calls an OpenPlanner config/publication authority path after cutover.
 - Define one shared required-surface contract and reuse it in deploy verification and `knoxx-contract-publication-e2e`, including route method and authorization expectations.
+- Replacement CLJS routes/functions use native `^:async`/`await` where asynchronous behavior is required.
 
 ## CLJS pseudocode
 
-Before:
+Legacy shapes being removed:
 
 ```clojure
-(defn load-gardens! []
+(defn load-gardens-legacy! []
   (api/request "/api/openplanner/v1/gardens"))
 
-(defn pipeline-config []
-  (-> (api/request "/api/openplanner/v1/translations/config")
-      (.then :config)))
+(defn pipeline-config-legacy! []
+  (api/request "/api/openplanner/v1/translations/config"))
 ```
 
-After:
+Replacement shapes:
 
 ```clojure
-(defn load-gardens! []
-  (-> (api/request "/api/publications/gardens")
-      (.then :gardens)))
+(defn ^:async load-gardens! []
+  (let [response (await (api/request "/api/publications/gardens"))]
+    (:gardens response)))
 
-(defn pipeline-config []
-  (api/request "/api/translations/config"))
+(defn ^:async pipeline-config! []
+  (await (api/request "/api/translations/config")))
 
-(defn publication-health! []
-  (api/request "/api/publications/health"))
+(defn ^:async publication-health! []
+  (await (api/request "/api/publications/health")))
 ```
 
 One shared pure surface specification, imported by both the deploy verifier and E2E test:
@@ -129,6 +129,7 @@ Do not delete the compatibility path before:
 - `ingestion/src/kms_ingestion/translation/worker.clj` resolves the same Knoxx resource-selected model reported by `/api/translations/config`.
 - Production deploy verification and the contract-publication E2E import the same complete required-surface list.
 - All five replacement surfaces are checked for method and intended authorization behavior.
+- Replacement asynchronous CLJS surfaces follow the repository's `^:async`/`await` convention.
 - Production deploy verification requires CMS/publication surfaces unconditionally.
 - `KNOXX_EXPECT_OPENPLANNER_REST` is gone.
 - OpenPlanner may be absent without degrading Knoxx's ability to describe or edit desired publication state or changing the worker's selected translation model.

--- a/kanban/tasks/knoxx-openplanner-rest-retirement.md
+++ b/kanban/tasks/knoxx-openplanner-rest-retirement.md
@@ -1,0 +1,90 @@
+---
+uuid: "knoxx-openplanner-rest-retirement"
+title: "Retire OpenPlanner REST as a Knoxx CMS/translation dependency"
+status: incoming
+priority: P1
+labels: ["tasks", "3sp", "has-parent", "cms", "translations", "openplanner", "deploy"]
+created_at: "2026-08-12T00:00:00Z"
+points: 3
+category: tasks
+---
+# Retire OpenPlanner REST as a Knoxx CMS/translation dependency
+
+> Parent epic: `knoxx-contract-owned-publication-pipeline`
+
+## Purpose
+
+Delete the compatibility dependency after the resource-owned publication path is live. Production Knoxx must no longer need a host OpenPlanner REST service for CMS gardens/publication state or translation pipeline config.
+
+## Scope
+
+- Remove CMS reads of `/api/openplanner/v1/gardens` and any legacy CMS publication routes that remain authoritative only because OpenPlanner owns the state.
+- Remove translation config reads/writes of `/api/openplanner/v1/translations/config`.
+- Remove or narrow proxy routes that exist only to preserve those authority paths.
+- Remove `KNOXX_EXPECT_OPENPLANNER_REST` and the conditional CMS skip from deploy verification once the replacement surface is unconditional.
+- Keep OpenPlanner-backed adapters only behind `IPublicationTarget` or other explicit extern/infra boundaries.
+- Ensure no frontend module imports an `openplanner` API wrapper for publication semantics after cutover.
+
+## CLJS pseudocode
+
+Before:
+
+```clojure
+(defn load-gardens! []
+  (api/request "/api/openplanner/v1/gardens"))
+
+(defn pipeline-config []
+  (-> (api/request "/api/openplanner/v1/translations/config")
+      (.then :config)))
+```
+
+After:
+
+```clojure
+(defn load-gardens! []
+  (-> (api/request "/api/publications/gardens")
+      (.then :gardens)))
+
+(defn pipeline-config []
+  (api/request "/api/translations/config"))
+
+(defn publication-health! []
+  (api/request "/api/publications/health"))
+```
+
+Deploy probe intent:
+
+```clojure
+(def required-surfaces
+  ["/api/publications/health"
+   "/api/publications/documents?limit=1"
+   "/api/translations/documents?limit=1"])
+
+(defn verify-required-surfaces! [http]
+  (doseq [path required-surfaces]
+    (assert (= 200 (:status (http/get! path))))))
+```
+
+There should be no equivalent of:
+
+```clojure
+(when expect-openplanner-rest?
+  (verify-cms!))
+```
+
+## Removal gate
+
+Do not delete the compatibility path before:
+
+- publication resources and resolver are live;
+- CMS reads/writes the resource projection;
+- translation pipeline config is resource-owned;
+- existing publication state has been migrated or explicitly abandoned;
+- at least one publication adapter can materialize requested state.
+
+## Done when
+
+- Grepping shipped frontend/backend code for the two OpenPlanner authority routes returns no callers.
+- Production deploy verification requires CMS/publication surfaces unconditionally.
+- `KNOXX_EXPECT_OPENPLANNER_REST` is gone.
+- OpenPlanner may be absent without degrading Knoxx's ability to describe or edit desired publication state.

--- a/kanban/tasks/knoxx-openplanner-rest-retirement.md
+++ b/kanban/tasks/knoxx-openplanner-rest-retirement.md
@@ -20,10 +20,11 @@ Delete the compatibility dependency after the resource-owned publication path is
 
 - Remove CMS reads of `/api/openplanner/v1/gardens` and any legacy CMS publication routes that remain authoritative only because OpenPlanner owns the state.
 - Remove translation config reads/writes of `/api/openplanner/v1/translations/config`.
+- Remove the ingestion worker's direct OpenPlanner `/v1/translations/config` lookup; production worker model selection must resolve through the Knoxx-owned translation-config boundary before retirement.
 - Remove or narrow proxy routes that exist only to preserve those authority paths.
 - Remove `KNOXX_EXPECT_OPENPLANNER_REST` and the conditional CMS skip from deploy verification once the replacement surface is unconditional.
 - Keep OpenPlanner-backed adapters only behind `IPublicationTarget` or other explicit extern/infra boundaries.
-- Ensure no frontend module imports an `openplanner` API wrapper for publication semantics after cutover.
+- Ensure no frontend module, backend route, ingestion worker, or other shipped service imports/calls an OpenPlanner config/publication authority path after cutover.
 - Define one shared required-surface contract and reuse it in deploy verification and `knoxx-contract-publication-e2e`, including route method and authorization expectations.
 
 ## CLJS pseudocode
@@ -89,6 +90,19 @@ The symbolic auth expectations above map to the real Knoxx authorization guards/
                            (:status (http/request! method path {}))))))))
 ```
 
+Repository-wide retirement check is broader than frontend routes:
+
+```clojure
+(def forbidden-authority-patterns
+  ["/api/openplanner/v1/gardens"
+   "/api/openplanner/v1/translations/config"
+   "/v1/translations/config"])
+
+(defn assert-no-openplanner-authority-callers! [source-index]
+  (doseq [pattern forbidden-authority-patterns]
+    (assert (empty? (source-index/shipped-callers pattern)))))
+```
+
 There should be no equivalent of:
 
 ```clojure
@@ -103,15 +117,18 @@ Do not delete the compatibility path before:
 - publication resources and resolver are live;
 - the one-time OpenPlanner publication migration has converged and conflicts are resolved;
 - translation pipeline config is resource-owned;
+- the ingestion translation worker consumes that same Knoxx-owned config and no longer reads OpenPlanner config directly;
 - translation/review gating and at least one publication adapter exist;
 - CMS reads/writes the resource projection;
+- repo-wide shipped-code search shows no remaining OpenPlanner authority callers;
 - the shared required-surface verification passes without OpenPlanner REST.
 
 ## Done when
 
-- Grepping shipped frontend/backend code for the two OpenPlanner authority routes returns no callers.
+- Grepping shipped frontend/backend/ingestion code for OpenPlanner garden and translation-config authority routes returns no callers.
+- `ingestion/src/kms_ingestion/translation/worker.clj` resolves the same Knoxx resource-selected model reported by `/api/translations/config`.
 - Production deploy verification and the contract-publication E2E import the same complete required-surface list.
 - All five replacement surfaces are checked for method and intended authorization behavior.
 - Production deploy verification requires CMS/publication surfaces unconditionally.
 - `KNOXX_EXPECT_OPENPLANNER_REST` is gone.
-- OpenPlanner may be absent without degrading Knoxx's ability to describe or edit desired publication state.
+- OpenPlanner may be absent without degrading Knoxx's ability to describe or edit desired publication state or changing the worker's selected translation model.

--- a/kanban/tasks/knoxx-publication-adapter-boundary.md
+++ b/kanban/tasks/knoxx-publication-adapter-boundary.md
@@ -1,7 +1,7 @@
 ---
 uuid: "knoxx-publication-adapter-boundary"
 title: "Define publication reconciliation and adapter boundary"
-status: incoming
+status: accepted
 priority: P1
 labels: ["tasks", "5sp", "has-parent", "publication", "adapters", "decouple"]
 created_at: "2026-08-12T00:00:00Z"
@@ -20,7 +20,9 @@ Make publication effects replaceable. The domain computes the desired materializ
 
 - Define a narrow publication target protocol/interface at the effect boundary.
 - Keep planning pure: compare desired publication intent with observed receipts/projections and emit actions.
-- Require adapters to return receipts describing what they actually materialized, including target, document, locale, revision, and adapter identity.
+- Handle non-publication states (`:withheld`, `:archived`) before translation/review blockers so removal can never be prevented by missing/stale translation evidence.
+- Resolve revision selectors such as `:source/current` to a concrete revision before comparing desired and observed materialization.
+- Require adapters to return receipts describing what they actually materialized, including target, document, locale, concrete revision, adapter identity, and idempotency key.
 - Make retry/idempotency semantics explicit before the first adapter implementation.
 - Provide an OpenPlanner adapter only as transitional compatibility if still needed; do not expose OpenPlanner ids above the adapter.
 - Permit future static-filesystem/Git/object-store publication adapters without changing document/publication laws.
@@ -30,35 +32,71 @@ Make publication effects replaceable. The domain computes the desired materializ
 ```clojure
 (ns knoxx.backend.domain.publication-reconcile)
 
+(defn concrete-revision [intent facts]
+  (case (:publication/revision intent)
+    :source/current (facts/current-source-revision
+                     facts
+                     (:publication/document intent))
+    (:publication/revision intent)))
+
+(defn non-public-plan [intent observed]
+  (if observed
+    {:op :remove :intent intent}
+    {:op :noop :intent intent}))
+
 (defn reconcile-plan [intent facts]
-  (let [blockers (gate/publication-blockers intent facts)
+  (let [state    (:publication/state intent)
         observed (facts/materialized-publication facts intent)]
-    (cond
-      (seq blockers)
-      {:op :blocked :blockers blockers}
+    (if (contains? #{:withheld :archived} state)
+      (non-public-plan intent observed)
+      (let [revision (concrete-revision intent facts)
+            blockers (gate/publication-blockers intent facts)]
+        (cond
+          (seq blockers)
+          {:op :blocked :blockers blockers :intent intent}
 
-      (= :archived (:publication/state intent))
-      {:op :remove :intent intent}
+          (not= revision (:materialized/revision observed))
+          {:op :publish
+           :intent intent
+           :concrete-revision revision}
 
-      (not= (:publication/revision intent)
-            (:materialized/revision observed))
-      {:op :publish :intent intent}
+          :else
+          {:op :noop
+           :intent intent
+           :concrete-revision revision})))))
+```
 
-      :else
-      {:op :noop :intent intent})))
+Stable publish operation identity:
+
+```clojure
+(defn publish-idempotency-key [adapter-id intent concrete-revision]
+  (stable/hash
+   [(:publication/id intent)
+    adapter-id
+    (:publication/garden intent)
+    (:publication/locale intent)
+    concrete-revision]))
 ```
 
 Effect boundary:
 
 ```clojure
 (defprotocol IPublicationTarget
-  (publish! [target ctx intent artifact])
+  (publish! [target ctx intent artifact idempotency-key])
   (remove! [target ctx intent])
   (observe! [target ctx intent]))
 
 (defn execute-plan! [adapter ctx plan artifact]
   (case (:op plan)
-    :publish (publish! adapter ctx (:intent plan) artifact)
+    :publish
+    (let [key (publish-idempotency-key
+               (adapter/id adapter)
+               (:intent plan)
+               (:concrete-revision plan))]
+      ;; Adapter must return the prior successful receipt when this key has
+      ;; already materialized the same operation; retries do not duplicate.
+      (publish! adapter ctx (:intent plan) artifact key))
+
     :remove  (remove! adapter ctx (:intent plan))
     :noop    {:receipt/type :publication/noop}
     :blocked {:receipt/type :publication/blocked
@@ -71,6 +109,7 @@ Receipt shape sketch:
 {:receipt/type :publication/materialized
  :publication/id :knoxx.docs/translation-pipeline-es
  :adapter/id :publication/static-garden
+ :idempotency/key "...stable..."
  :document/id :knoxx.docs/translation-pipeline
  :locale :es
  :revision "abc123"
@@ -79,13 +118,19 @@ Receipt shape sketch:
 
 ## Contract obligations
 
-- Repeating the same `:publish` plan with the same revision must converge without duplicate public artifacts.
+- `:withheld` and `:archived` can only remove or no-op; they can never enter the publish branch.
+- Removal is not gated by translation/review blockers. An archive request can always remove a stale public artifact.
+- Revision selectors are normalized before desired/observed comparison; unchanged `:source/current` publications do not republish every tick.
+- Repeating the same `:publish` operation with the same idempotency key returns the existing materialization receipt or equivalent converged result; it cannot create duplicate public artifacts.
 - Adapter-specific identifiers never become part of publication resource identity.
 - Adapter failure records failure/drift; it does not mutate desired state back to the old observed state.
 - `observe!` may report reality but cannot redefine what should be published.
 
 ## Done when
 
+- Fake-adapter tests prove `:withheld` and `:archived` never publish and remove existing materializations even when translation facts are blocked/stale.
+- `:source/current` resolves once to a concrete revision and no-ops when the receipt already names that revision.
+- Retrying a publish after an ambiguous external response with the same stable idempotency key does not duplicate materialization.
 - A fake adapter can drive the complete reconciler tests with no OpenPlanner dependency.
 - OpenPlanner can be unplugged/replaced without changing domain publication code or resource contracts.
 - Every successful materialization produces a receipt suitable for drift calculation and deploy verification.

--- a/kanban/tasks/knoxx-publication-adapter-boundary.md
+++ b/kanban/tasks/knoxx-publication-adapter-boundary.md
@@ -23,6 +23,7 @@ Make publication effects replaceable. The domain computes the desired materializ
 - Handle non-publication states (`:withheld`, `:archived`) before translation/review blockers so removal can never be prevented by missing/stale translation evidence.
 - Apply garden admissibility before publication blockers: a publication targeting an archived garden must remove any existing materialization even if the publication intent itself still says `:published`.
 - Resolve revision selectors such as `:source/current` to a concrete revision before comparing desired and observed materialization.
+- Treat an unresolved revision selector as a publication blocker. A publish operation, idempotency key, or materialization receipt may never carry a nil/unknown concrete revision.
 - Treat publication path as part of materialized topology. Path-only changes must produce drift and reconciliation rather than `:noop`.
 - Require adapters to return receipts describing what they actually materialized, including target, document, locale, concrete revision, publication path, adapter identity, and idempotency key.
 - Make retry/idempotency semantics explicit before the first adapter implementation. The stable publish operation key includes every effect-relevant materialization dimension, including path.
@@ -78,32 +79,31 @@ Make publication effects replaceable. The domain computes the desired materializ
 
       :else
       (let [revision (concrete-revision intent facts)
-            desired  (desired-materialization intent revision)
-            blockers (gate/publication-blockers intent facts)]
-        (cond
-          (seq blockers)
+            blockers (cond-> (vec (gate/publication-blockers intent facts))
+                       (nil? revision)
+                       (conj :publication-revision-unresolved))]
+        (if (seq blockers)
           {:op :blocked
            :blockers blockers
            :intent intent}
-
-          (not= desired (observed-materialization observed))
-          {:op :publish
-           :intent intent
-           :desired desired
-           :previous observed
-           :concrete-revision revision}
-
-          :else
-          {:op :noop
-           :intent intent
-           :desired desired
-           :concrete-revision revision})))))
+          (let [desired (desired-materialization intent revision)]
+            (if (not= desired (observed-materialization observed))
+              {:op :publish
+               :intent intent
+               :desired desired
+               :previous observed
+               :concrete-revision revision}
+              {:op :noop
+               :intent intent
+               :desired desired
+               :concrete-revision revision})))))))
 ```
 
 Stable publish operation identity:
 
 ```clojure
 (defn publish-idempotency-key [adapter-id intent concrete-revision]
+  (assert (some? concrete-revision))
   (stable/hash
    [(:publication/id intent)
     adapter-id
@@ -168,6 +168,7 @@ Receipt shape sketch:
 - A `:published` intent targeting an archived garden also can only remove or no-op until the garden is active again.
 - Removal is not gated by translation/review blockers. An archive request or garden archive can always remove a stale public artifact.
 - Revision selectors are normalized before desired/observed comparison; unchanged `:source/current` publications do not republish every tick.
+- If a selector cannot resolve to a concrete revision, reconciliation returns `:blocked` with `:publication-revision-unresolved`; adapters never receive a nil revision.
 - Desired/observed convergence compares concrete revision **and publication path**. A path-only edit is drift.
 - Path participates in publish idempotency identity. Retrying the same publication/revision/path converges; changing the path creates a distinct operation that replaces/removes the prior route rather than leaving both public.
 - Repeating the same `:publish` operation with the same idempotency key returns the existing materialization receipt or equivalent converged result; it cannot create duplicate public artifacts.
@@ -180,6 +181,7 @@ Receipt shape sketch:
 - Fake-adapter tests prove `:withheld` and `:archived` never publish and remove existing materializations even when translation facts are blocked/stale.
 - Fake-adapter tests prove archiving a target garden removes an already-public artifact even while its publication intent remains `:published`.
 - `:source/current` resolves once to a concrete revision and no-ops when the receipt already names that revision and path.
+- A fixture with no current source revision blocks with `:publication-revision-unresolved`, produces no publish action, and never computes a publish idempotency key.
 - Changing only `:publication/path` emits a publish/move plan, records the new path, and leaves the old path unavailable.
 - Retrying a path-aware publish after an ambiguous external response with the same stable idempotency key does not duplicate materialization.
 - A fake adapter can drive the complete reconciler tests with no OpenPlanner dependency.

--- a/kanban/tasks/knoxx-publication-adapter-boundary.md
+++ b/kanban/tasks/knoxx-publication-adapter-boundary.md
@@ -1,0 +1,91 @@
+---
+uuid: "knoxx-publication-adapter-boundary"
+title: "Define publication reconciliation and adapter boundary"
+status: incoming
+priority: P1
+labels: ["tasks", "5sp", "has-parent", "publication", "adapters", "decouple"]
+created_at: "2026-08-12T00:00:00Z"
+points: 5
+category: tasks
+---
+# Define publication reconciliation and adapter boundary
+
+> Parent epic: `knoxx-contract-owned-publication-pipeline`
+
+## Purpose
+
+Make publication effects replaceable. The domain computes the desired materialization and a reconciliation plan; an adapter performs the effect and records a receipt. OpenPlanner, if retained, becomes one implementation of this boundary rather than the owner of publication semantics.
+
+## Scope
+
+- Define a narrow publication target protocol/interface at the effect boundary.
+- Keep planning pure: compare desired publication intent with observed receipts/projections and emit actions.
+- Require adapters to return receipts describing what they actually materialized, including target, document, locale, revision, and adapter identity.
+- Make retry/idempotency semantics explicit before the first adapter implementation.
+- Provide an OpenPlanner adapter only as transitional compatibility if still needed; do not expose OpenPlanner ids above the adapter.
+- Permit future static-filesystem/Git/object-store publication adapters without changing document/publication laws.
+
+## CLJS pseudocode
+
+```clojure
+(ns knoxx.backend.domain.publication-reconcile)
+
+(defn reconcile-plan [intent facts]
+  (let [blockers (gate/publication-blockers intent facts)
+        observed (facts/materialized-publication facts intent)]
+    (cond
+      (seq blockers)
+      {:op :blocked :blockers blockers}
+
+      (= :archived (:publication/state intent))
+      {:op :remove :intent intent}
+
+      (not= (:publication/revision intent)
+            (:materialized/revision observed))
+      {:op :publish :intent intent}
+
+      :else
+      {:op :noop :intent intent})))
+```
+
+Effect boundary:
+
+```clojure
+(defprotocol IPublicationTarget
+  (publish! [target ctx intent artifact])
+  (remove! [target ctx intent])
+  (observe! [target ctx intent]))
+
+(defn execute-plan! [adapter ctx plan artifact]
+  (case (:op plan)
+    :publish (publish! adapter ctx (:intent plan) artifact)
+    :remove  (remove! adapter ctx (:intent plan))
+    :noop    {:receipt/type :publication/noop}
+    :blocked {:receipt/type :publication/blocked
+              :blockers (:blockers plan)}))
+```
+
+Receipt shape sketch:
+
+```clojure
+{:receipt/type :publication/materialized
+ :publication/id :knoxx.docs/translation-pipeline-es
+ :adapter/id :publication/static-garden
+ :document/id :knoxx.docs/translation-pipeline
+ :locale :es
+ :revision "abc123"
+ :target :gardens/promethean}
+```
+
+## Contract obligations
+
+- Repeating the same `:publish` plan with the same revision must converge without duplicate public artifacts.
+- Adapter-specific identifiers never become part of publication resource identity.
+- Adapter failure records failure/drift; it does not mutate desired state back to the old observed state.
+- `observe!` may report reality but cannot redefine what should be published.
+
+## Done when
+
+- A fake adapter can drive the complete reconciler tests with no OpenPlanner dependency.
+- OpenPlanner can be unplugged/replaced without changing domain publication code or resource contracts.
+- Every successful materialization produces a receipt suitable for drift calculation and deploy verification.

--- a/kanban/tasks/knoxx-publication-adapter-boundary.md
+++ b/kanban/tasks/knoxx-publication-adapter-boundary.md
@@ -1,11 +1,11 @@
 ---
 uuid: "knoxx-publication-adapter-boundary"
 title: "Define publication reconciliation and adapter boundary"
-status: accepted
+status: breakdown
 priority: P1
-labels: ["tasks", "8sp", "has-parent", "publication", "adapters", "decouple"]
+labels: ["tasks", "has-parent", "publication", "adapters", "decouple"]
 created_at: "2026-08-12T00:00:00Z"
-points: 8
+points: 0
 category: tasks
 ---
 # Define publication reconciliation and adapter boundary
@@ -14,176 +14,47 @@ category: tasks
 
 ## Purpose
 
-Make publication effects replaceable. The domain computes the desired materialization and a reconciliation plan; an adapter performs the effect and records a receipt. OpenPlanner, if retained, becomes one implementation of this boundary rather than the owner of publication semantics.
+Coordinate the replaceable publication effect boundary without mixing pure reconciliation law, external side effects, and observation/proof in one 8-point implementation card.
 
-## Scope
+The original 8sp scope is preserved exactly as three executable children totaling 8 points.
 
-- Define a narrow publication target protocol/interface at the effect boundary.
-- Keep planning pure: compare desired publication intent with resource admissibility and observed receipts/projections, then emit actions.
-- Handle non-publication states (`:withheld`, `:archived`) before translation/review blockers so removal can never be prevented by missing/stale translation evidence.
-- Apply garden admissibility before publication blockers: a publication targeting an archived garden must remove any existing materialization even if the publication intent itself still says `:published`.
-- Resolve revision selectors such as `:source/current` to a concrete revision before comparing desired and observed materialization.
-- Treat an unresolved revision selector as a publication blocker. A publish operation, idempotency key, or materialization receipt may never carry a nil/unknown concrete revision.
-- Treat publication path as part of materialized topology. Path-only changes must produce drift and reconciliation rather than `:noop`.
-- Require adapters to return receipts describing what they actually materialized, including target, document, locale, concrete revision, publication path, adapter identity, and idempotency key.
-- Make retry/idempotency semantics explicit before the first adapter implementation. The stable publish operation key includes every effect-relevant materialization dimension, including path.
-- Provide an OpenPlanner adapter only as transitional compatibility if still needed; do not expose OpenPlanner ids above the adapter.
-- Permit future static-filesystem/Git/object-store publication adapters without changing document/publication laws.
+## Child breakdown
 
-## CLJS pseudocode
+1. **P1 / accepted / 3sp** `knoxx-publication-reconcile-plan-laws` — pure reconciliation decisions: non-public removal, garden admissibility, concrete revision resolution, blockers, and path-aware drift.
+2. **P1 / accepted / 3sp** `knoxx-publication-adapter-effects-idempotency` — `IPublicationTarget`, publish/remove/observe effects, path replacement, and stable retry/idempotency semantics.
+3. **P1 / accepted / 2sp** `knoxx-publication-receipts-fake-adapter-proof` — receipt/projection shape plus fake-adapter tests proving convergence with no OpenPlanner dependency.
 
-```clojure
-(ns knoxx.backend.domain.publication-reconcile)
-
-(defn concrete-revision [intent facts]
-  (case (:publication/revision intent)
-    :source/current (facts/current-source-revision
-                     facts
-                     (:publication/document intent))
-    (:publication/revision intent)))
-
-(defn garden-active? [resource-index intent]
-  (= :active
-     (:garden/status
-      (get-in resource-index
-              [:gardens (:publication/garden intent)]))))
-
-(defn non-public-plan [intent observed reason]
-  (if observed
-    {:op :remove
-     :intent intent
-     :reason reason
-     :observed observed}
-    {:op :noop
-     :intent intent
-     :reason reason}))
-
-(defn desired-materialization [intent revision]
-  {:materialized/revision revision
-   :materialized/path (:publication/path intent)})
-
-(defn observed-materialization [observed]
-  (select-keys observed
-               [:materialized/revision
-                :materialized/path]))
-
-(defn reconcile-plan [resource-index intent facts]
-  (let [state    (:publication/state intent)
-        observed (facts/materialized-publication facts intent)]
-    (cond
-      (contains? #{:withheld :archived} state)
-      (non-public-plan intent observed :publication-not-public)
-
-      (not (garden-active? resource-index intent))
-      (non-public-plan intent observed :garden-not-active)
-
-      :else
-      (let [revision (concrete-revision intent facts)
-            blockers (cond-> (vec (gate/publication-blockers intent facts))
-                       (nil? revision)
-                       (conj :publication-revision-unresolved))]
-        (if (seq blockers)
-          {:op :blocked
-           :blockers blockers
-           :intent intent}
-          (let [desired (desired-materialization intent revision)]
-            (if (not= desired (observed-materialization observed))
-              {:op :publish
-               :intent intent
-               :desired desired
-               :previous observed
-               :concrete-revision revision}
-              {:op :noop
-               :intent intent
-               :desired desired
-               :concrete-revision revision})))))))
+```text
+reconciliation law (3)
+        ↓
+adapter effects + idempotency (3)
+        ↓
+receipts + fake-adapter proof (2)
 ```
 
-Stable publish operation identity:
+## Boundary invariant
 
 ```clojure
-(defn publish-idempotency-key [adapter-id intent concrete-revision]
-  (assert (some? concrete-revision))
-  (stable/hash
-   [(:publication/id intent)
-    adapter-id
-    (:publication/garden intent)
-    (:publication/locale intent)
-    (:publication/path intent)
-    concrete-revision]))
+(defn reconcile! [resource-index intent facts adapter ctx artifact]
+  (let [plan (publication-plan/reconcile-plan resource-index intent facts)]
+    ;; The law decides. The adapter only performs the requested effect.
+    (publication-effects/execute-plan! adapter ctx plan artifact)))
 ```
 
-Effect boundary:
+Desired state remains in resources, decision law remains pure, adapters perform effects, and receipts describe what actually happened.
 
-```clojure
-(defprotocol IPublicationTarget
-  (publish! [target ctx intent artifact previous idempotency-key])
-  (remove! [target ctx intent observed])
-  (observe! [target ctx intent]))
+## Coordination rules
 
-(defn execute-plan! [adapter ctx plan artifact]
-  (case (:op plan)
-    :publish
-    (let [key (publish-idempotency-key
-               (adapter/id adapter)
-               (:intent plan)
-               (:concrete-revision plan))]
-      ;; Adapter treats publication identity as one logical materialization.
-      ;; If :publication/path moved, the prior path is removed/replaced as part
-      ;; of this convergent operation; the old route cannot remain public.
-      ;; Replaying the same key returns the existing converged receipt.
-      (publish! adapter
-                ctx
-                (:intent plan)
-                artifact
-                (:previous plan)
-                key))
-
-    :remove  (remove! adapter ctx (:intent plan) (:observed plan))
-    :noop    {:receipt/type :publication/noop
-              :reason (:reason plan)}
-    :blocked {:receipt/type :publication/blocked
-              :blockers (:blockers plan)}))
-```
-
-Receipt shape sketch:
-
-```clojure
-{:receipt/type :publication/materialized
- :publication/id :knoxx.docs/translation-pipeline-es
- :adapter/id :publication/static-garden
- :idempotency/key "...stable..."
- :document/id :knoxx.docs/translation-pipeline
- :locale :es
- :revision "abc123"
- :path "/translation-pipeline"
- :target :gardens/promethean
- :materialized/revision "abc123"
- :materialized/path "/translation-pipeline"}
-```
-
-## Contract obligations
-
-- `:withheld` and `:archived` can only remove or no-op; they can never enter the publish branch.
-- A `:published` intent targeting an archived garden also can only remove or no-op until the garden is active again.
-- Removal is not gated by translation/review blockers. An archive request or garden archive can always remove a stale public artifact.
-- Revision selectors are normalized before desired/observed comparison; unchanged `:source/current` publications do not republish every tick.
-- If a selector cannot resolve to a concrete revision, reconciliation returns `:blocked` with `:publication-revision-unresolved`; adapters never receive a nil revision.
-- Desired/observed convergence compares concrete revision **and publication path**. A path-only edit is drift.
-- Path participates in publish idempotency identity. Retrying the same publication/revision/path converges; changing the path creates a distinct operation that replaces/removes the prior route rather than leaving both public.
-- Repeating the same `:publish` operation with the same idempotency key returns the existing materialization receipt or equivalent converged result; it cannot create duplicate public artifacts.
-- Adapter-specific identifiers never become part of publication resource identity.
-- Adapter failure records failure/drift; it does not mutate desired state back to the old observed state.
-- `observe!` may report reality but cannot redefine what should be published.
+- `:withheld`, `:archived`, or an archived garden must never reach publish effects.
+- Translation/review blockers govern publication, never removal.
+- `:source/current` resolves to a concrete revision before effect planning.
+- Publication path participates in drift and publish operation identity.
+- Retry safety belongs to the adapter-effect contract, not the pure planner.
+- Runtime receipts are evidence and may not rewrite desired resource state.
+- OpenPlanner-specific identifiers stay below the adapter boundary.
 
 ## Done when
 
-- Fake-adapter tests prove `:withheld` and `:archived` never publish and remove existing materializations even when translation facts are blocked/stale.
-- Fake-adapter tests prove archiving a target garden removes an already-public artifact even while its publication intent remains `:published`.
-- `:source/current` resolves once to a concrete revision and no-ops when the receipt already names that revision and path.
-- A fixture with no current source revision blocks with `:publication-revision-unresolved`, produces no publish action, and never computes a publish idempotency key.
-- Changing only `:publication/path` emits a publish/move plan, records the new path, and leaves the old path unavailable.
-- Retrying a path-aware publish after an ambiguous external response with the same stable idempotency key does not duplicate materialization.
-- A fake adapter can drive the complete reconciler tests with no OpenPlanner dependency.
-- OpenPlanner can be unplugged/replaced without changing domain publication code or resource contracts.
-- Every successful materialization produces a receipt suitable for revision/path drift calculation and deploy verification.
+- All three child cards are complete.
+- Their points sum to the original 8sp without double-counting this coordination card.
+- The E2E publication path can consume the resulting planner, adapter, and receipt contracts with OpenPlanner REST absent.

--- a/kanban/tasks/knoxx-publication-adapter-boundary.md
+++ b/kanban/tasks/knoxx-publication-adapter-boundary.md
@@ -3,9 +3,9 @@ uuid: "knoxx-publication-adapter-boundary"
 title: "Define publication reconciliation and adapter boundary"
 status: accepted
 priority: P1
-labels: ["tasks", "5sp", "has-parent", "publication", "adapters", "decouple"]
+labels: ["tasks", "8sp", "has-parent", "publication", "adapters", "decouple"]
 created_at: "2026-08-12T00:00:00Z"
-points: 5
+points: 8
 category: tasks
 ---
 # Define publication reconciliation and adapter boundary

--- a/kanban/tasks/knoxx-publication-adapter-boundary.md
+++ b/kanban/tasks/knoxx-publication-adapter-boundary.md
@@ -19,11 +19,13 @@ Make publication effects replaceable. The domain computes the desired materializ
 ## Scope
 
 - Define a narrow publication target protocol/interface at the effect boundary.
-- Keep planning pure: compare desired publication intent with observed receipts/projections and emit actions.
+- Keep planning pure: compare desired publication intent with resource admissibility and observed receipts/projections, then emit actions.
 - Handle non-publication states (`:withheld`, `:archived`) before translation/review blockers so removal can never be prevented by missing/stale translation evidence.
+- Apply garden admissibility before publication blockers: a publication targeting an archived garden must remove any existing materialization even if the publication intent itself still says `:published`.
 - Resolve revision selectors such as `:source/current` to a concrete revision before comparing desired and observed materialization.
-- Require adapters to return receipts describing what they actually materialized, including target, document, locale, concrete revision, adapter identity, and idempotency key.
-- Make retry/idempotency semantics explicit before the first adapter implementation.
+- Treat publication path as part of materialized topology. Path-only changes must produce drift and reconciliation rather than `:noop`.
+- Require adapters to return receipts describing what they actually materialized, including target, document, locale, concrete revision, publication path, adapter identity, and idempotency key.
+- Make retry/idempotency semantics explicit before the first adapter implementation. The stable publish operation key includes every effect-relevant materialization dimension, including path.
 - Provide an OpenPlanner adapter only as transitional compatibility if still needed; do not expose OpenPlanner ids above the adapter.
 - Permit future static-filesystem/Git/object-store publication adapters without changing document/publication laws.
 
@@ -39,30 +41,62 @@ Make publication effects replaceable. The domain computes the desired materializ
                      (:publication/document intent))
     (:publication/revision intent)))
 
-(defn non-public-plan [intent observed]
-  (if observed
-    {:op :remove :intent intent}
-    {:op :noop :intent intent}))
+(defn garden-active? [resource-index intent]
+  (= :active
+     (:garden/status
+      (get-in resource-index
+              [:gardens (:publication/garden intent)]))))
 
-(defn reconcile-plan [intent facts]
+(defn non-public-plan [intent observed reason]
+  (if observed
+    {:op :remove
+     :intent intent
+     :reason reason
+     :observed observed}
+    {:op :noop
+     :intent intent
+     :reason reason}))
+
+(defn desired-materialization [intent revision]
+  {:materialized/revision revision
+   :materialized/path (:publication/path intent)})
+
+(defn observed-materialization [observed]
+  (select-keys observed
+               [:materialized/revision
+                :materialized/path]))
+
+(defn reconcile-plan [resource-index intent facts]
   (let [state    (:publication/state intent)
         observed (facts/materialized-publication facts intent)]
-    (if (contains? #{:withheld :archived} state)
-      (non-public-plan intent observed)
+    (cond
+      (contains? #{:withheld :archived} state)
+      (non-public-plan intent observed :publication-not-public)
+
+      (not (garden-active? resource-index intent))
+      (non-public-plan intent observed :garden-not-active)
+
+      :else
       (let [revision (concrete-revision intent facts)
+            desired  (desired-materialization intent revision)
             blockers (gate/publication-blockers intent facts)]
         (cond
           (seq blockers)
-          {:op :blocked :blockers blockers :intent intent}
+          {:op :blocked
+           :blockers blockers
+           :intent intent}
 
-          (not= revision (:materialized/revision observed))
+          (not= desired (observed-materialization observed))
           {:op :publish
            :intent intent
+           :desired desired
+           :previous observed
            :concrete-revision revision}
 
           :else
           {:op :noop
            :intent intent
+           :desired desired
            :concrete-revision revision})))))
 ```
 
@@ -75,6 +109,7 @@ Stable publish operation identity:
     adapter-id
     (:publication/garden intent)
     (:publication/locale intent)
+    (:publication/path intent)
     concrete-revision]))
 ```
 
@@ -82,8 +117,8 @@ Effect boundary:
 
 ```clojure
 (defprotocol IPublicationTarget
-  (publish! [target ctx intent artifact idempotency-key])
-  (remove! [target ctx intent])
+  (publish! [target ctx intent artifact previous idempotency-key])
+  (remove! [target ctx intent observed])
   (observe! [target ctx intent]))
 
 (defn execute-plan! [adapter ctx plan artifact]
@@ -93,12 +128,20 @@ Effect boundary:
                (adapter/id adapter)
                (:intent plan)
                (:concrete-revision plan))]
-      ;; Adapter must return the prior successful receipt when this key has
-      ;; already materialized the same operation; retries do not duplicate.
-      (publish! adapter ctx (:intent plan) artifact key))
+      ;; Adapter treats publication identity as one logical materialization.
+      ;; If :publication/path moved, the prior path is removed/replaced as part
+      ;; of this convergent operation; the old route cannot remain public.
+      ;; Replaying the same key returns the existing converged receipt.
+      (publish! adapter
+                ctx
+                (:intent plan)
+                artifact
+                (:previous plan)
+                key))
 
-    :remove  (remove! adapter ctx (:intent plan))
-    :noop    {:receipt/type :publication/noop}
+    :remove  (remove! adapter ctx (:intent plan) (:observed plan))
+    :noop    {:receipt/type :publication/noop
+              :reason (:reason plan)}
     :blocked {:receipt/type :publication/blocked
               :blockers (:blockers plan)}))
 ```
@@ -113,14 +156,20 @@ Receipt shape sketch:
  :document/id :knoxx.docs/translation-pipeline
  :locale :es
  :revision "abc123"
- :target :gardens/promethean}
+ :path "/translation-pipeline"
+ :target :gardens/promethean
+ :materialized/revision "abc123"
+ :materialized/path "/translation-pipeline"}
 ```
 
 ## Contract obligations
 
 - `:withheld` and `:archived` can only remove or no-op; they can never enter the publish branch.
-- Removal is not gated by translation/review blockers. An archive request can always remove a stale public artifact.
+- A `:published` intent targeting an archived garden also can only remove or no-op until the garden is active again.
+- Removal is not gated by translation/review blockers. An archive request or garden archive can always remove a stale public artifact.
 - Revision selectors are normalized before desired/observed comparison; unchanged `:source/current` publications do not republish every tick.
+- Desired/observed convergence compares concrete revision **and publication path**. A path-only edit is drift.
+- Path participates in publish idempotency identity. Retrying the same publication/revision/path converges; changing the path creates a distinct operation that replaces/removes the prior route rather than leaving both public.
 - Repeating the same `:publish` operation with the same idempotency key returns the existing materialization receipt or equivalent converged result; it cannot create duplicate public artifacts.
 - Adapter-specific identifiers never become part of publication resource identity.
 - Adapter failure records failure/drift; it does not mutate desired state back to the old observed state.
@@ -129,8 +178,10 @@ Receipt shape sketch:
 ## Done when
 
 - Fake-adapter tests prove `:withheld` and `:archived` never publish and remove existing materializations even when translation facts are blocked/stale.
-- `:source/current` resolves once to a concrete revision and no-ops when the receipt already names that revision.
-- Retrying a publish after an ambiguous external response with the same stable idempotency key does not duplicate materialization.
+- Fake-adapter tests prove archiving a target garden removes an already-public artifact even while its publication intent remains `:published`.
+- `:source/current` resolves once to a concrete revision and no-ops when the receipt already names that revision and path.
+- Changing only `:publication/path` emits a publish/move plan, records the new path, and leaves the old path unavailable.
+- Retrying a path-aware publish after an ambiguous external response with the same stable idempotency key does not duplicate materialization.
 - A fake adapter can drive the complete reconciler tests with no OpenPlanner dependency.
 - OpenPlanner can be unplugged/replaced without changing domain publication code or resource contracts.
-- Every successful materialization produces a receipt suitable for drift calculation and deploy verification.
+- Every successful materialization produces a receipt suitable for revision/path drift calculation and deploy verification.

--- a/kanban/tasks/knoxx-publication-adapter-effects-idempotency.md
+++ b/kanban/tasks/knoxx-publication-adapter-effects-idempotency.md
@@ -1,0 +1,100 @@
+---
+uuid: "knoxx-publication-adapter-effects-idempotency"
+title: "Implement publication adapter effects and idempotency contract"
+status: accepted
+priority: P1
+labels: ["tasks", "3sp", "has-parent", "publication", "adapters", "idempotency"]
+created_at: "2026-08-12T00:00:00Z"
+points: 3
+category: tasks
+---
+# Implement publication adapter effects and idempotency contract
+
+> Parent task: `knoxx-publication-adapter-boundary`
+> Parent epic: `knoxx-contract-owned-publication-pipeline`
+
+## Purpose
+
+Define the effect boundary that executes an already-decided publication plan without owning publication semantics.
+
+## Scope
+
+- Define `IPublicationTarget` with publish, remove, and observe operations.
+- Keep adapter-specific ids below the boundary.
+- Compute one stable publish idempotency key from effect-relevant materialization identity.
+- Include publication id, adapter id, garden, locale, path, and concrete revision in that key.
+- Treat publication identity as one logical materialization: a path move replaces/removes the prior route instead of leaving both public.
+- Define replay behavior after ambiguous external responses: the same key must return the existing converged result or equivalent receipt rather than creating duplicates.
+- Consume `:previous` observation from the pure plan when replacing stale materialization.
+- Keep OpenPlanner, filesystem, Git, or object storage as interchangeable implementations of the same protocol.
+
+## CLJS pseudocode
+
+```clojure
+(ns knoxx.backend.infra.publication-effects)
+
+(defprotocol IPublicationTarget
+  (publish! [target ctx intent artifact previous idempotency-key])
+  (remove! [target ctx intent observed])
+  (observe! [target ctx intent]))
+
+(defn publish-idempotency-key [adapter-id intent concrete-revision]
+  (assert (some? concrete-revision))
+  (stable/hash
+   [(:publication/id intent)
+    adapter-id
+    (:publication/garden intent)
+    (:publication/locale intent)
+    (:publication/path intent)
+    concrete-revision]))
+
+(defn execute-plan! [adapter ctx plan artifact]
+  (case (:op plan)
+    :publish
+    (let [key (publish-idempotency-key
+               (adapter/id adapter)
+               (:intent plan)
+               (:concrete-revision plan))]
+      (publish! adapter
+                ctx
+                (:intent plan)
+                artifact
+                (:previous plan)
+                key))
+
+    :remove
+    (remove! adapter ctx (:intent plan) (:observed plan))
+
+    :noop
+    {:receipt/type :publication/noop
+     :reason (:reason plan)}
+
+    :blocked
+    {:receipt/type :publication/blocked
+     :blockers (:blockers plan)}))
+```
+
+Adapter replay law sketch:
+
+```clojure
+(defn publish-once! [store op]
+  (if-let [receipt (store/by-idempotency-key (:idempotency/key op))]
+    receipt
+    (store/materialize-and-record! op)))
+```
+
+## Laws
+
+- The adapter may execute a plan but may not reinterpret desired publication state.
+- Replaying an identical publish key cannot create another public artifact.
+- A path change creates a distinct operation and makes the previous route unavailable after convergence.
+- Remove operations remain possible regardless of translation/review blockers because the planner already resolved those semantics.
+- Adapter failures produce failure/drift evidence and do not mutate desired resource state.
+
+## Done when
+
+- A fake effect implementation proves repeated identical publish calls converge to one materialization.
+- A path change replaces the old route.
+- Remove works for prior materializations.
+- No OpenPlanner-specific identifier appears in the domain plan or resource contract.
+- Receipt-producing results are ready for the observation/proof child card.

--- a/kanban/tasks/knoxx-publication-intent-resolver.md
+++ b/kanban/tasks/knoxx-publication-intent-resolver.md
@@ -1,0 +1,85 @@
+---
+uuid: "knoxx-publication-intent-resolver"
+title: "Resolve desired publication topology from the Knoxx resource graph"
+status: incoming
+priority: P1
+labels: ["tasks", "5sp", "has-parent", "cms", "publication", "domain"]
+created_at: "2026-08-12T00:00:00Z"
+points: 5
+category: tasks
+---
+# Resolve desired publication topology from the Knoxx resource graph
+
+> Parent epic: `knoxx-contract-owned-publication-pipeline`
+
+## Purpose
+
+Provide one pure Knoxx-owned query model that turns loaded resources into the complete desired publication topology consumed by CMS, translation policy, reconciliation, and deploy verification.
+
+The resolver must not call HTTP, Mongo, OpenPlanner, filesystem effects, or worker state. It consumes already-loaded validated resources and returns deterministic CLJS data.
+
+## Scope
+
+- Build document/garden/publication indexes from the resource registry.
+- Resolve namespace-local refs to canonical ids before comparison.
+- Expose pure queries for documents, gardens, publication intents, target locales, and intended revisions.
+- Return explicit semantic blockers for malformed/incomplete desired state; leave runtime blockers to `knoxx-translation-publication-gate`.
+- Add a Knoxx route/facade that serializes this projection for frontends without exposing the underlying resource-loader implementation.
+
+## CLJS pseudocode
+
+```clojure
+(ns knoxx.backend.domain.publication)
+
+(defn publication-index [resources]
+  (reduce
+   (fn [idx resource]
+     (cond-> idx
+       (:document/id resource)
+       (assoc-in [:documents (:document/id resource)] resource)
+
+       (:garden/id resource)
+       (assoc-in [:gardens (:garden/id resource)] resource)
+
+       (:publication/id resource)
+       (update :publications conj resource)))
+   {:documents {} :gardens {} :publications []}
+   resources))
+
+(defn publication-key [intent]
+  [(:publication/document intent)
+   (:publication/garden intent)
+   (:publication/locale intent)])
+
+(defn desired-publications [idx document-id]
+  (->> (:publications idx)
+       (filter #(= document-id (:publication/document %)))
+       (sort-by publication-key)
+       vec))
+
+(defn document-view [idx document-id]
+  {:document (get-in idx [:documents document-id])
+   :publications (desired-publications idx document-id)})
+```
+
+Thin infra route:
+
+```clojure
+(defn list-publication-documents! [req reply]
+  (let [resources (resource-store/resolved-resources (:context req))
+        idx       (publication/publication-index resources)]
+    (.send reply (publication/list-document-views idx))))
+```
+
+## Laws
+
+- Same resource graph -> byte-equivalent canonical projection regardless of source file enumeration order.
+- Resolver output contains no execution status such as worker state, publish timestamps, or adapter receipts.
+- Duplicate publication keys are rejected or surfaced as deterministic conflicts; never "last one wins" by loader order.
+- The domain namespace remains pure and reusable by CLI/tests without Fastify or Mongo.
+
+## Done when
+
+- CMS can list documents, gardens, targets, locales, and requested publication states from this projection alone.
+- A pure test deletes every OpenPlanner dependency from the fixture and produces the same desired topology.
+- One backend facade serves the projection without `/api/openplanner/...` in its contract.

--- a/kanban/tasks/knoxx-publication-intent-resolver.md
+++ b/kanban/tasks/knoxx-publication-intent-resolver.md
@@ -2,7 +2,7 @@
 uuid: "knoxx-publication-intent-resolver"
 title: "Resolve desired publication topology from the Knoxx resource graph"
 status: accepted
-priority: P1
+priority: P0
 labels: ["tasks", "5sp", "has-parent", "cms", "publication", "domain"]
 created_at: "2026-08-12T00:00:00Z"
 points: 5
@@ -21,7 +21,8 @@ The resolver must not call HTTP, Mongo, OpenPlanner, filesystem effects, or work
 ## Scope
 
 - Build document/garden/publication indexes from the resource registry.
-- Canonicalize resource identities and namespace-local references before indexing, filtering, conflict checks, or key construction.
+- Canonicalize resource identities and namespace-local references before indexing, filtering, conflict checks, key construction, **and before storing document/garden payloads in the index**.
+- Ensure indexed document/garden payload identity fields contain the same canonical IDs used as their index keys, so downstream Malli validation never sees a namespace-local ID where a qualified identity is required.
 - Reject duplicate/revision-conflicting publication intents deterministically before exposing any projection; never rely on enumeration order.
 - Expose pure queries for documents, gardens, publication intents, target locales, and intended revisions.
 - Return explicit semantic blockers for malformed/incomplete desired state; leave runtime blockers to `knoxx-translation-publication-gate`.
@@ -42,6 +43,12 @@ The resolver must not call HTTP, Mongo, OpenPlanner, filesystem effects, or work
 (defn canonical-garden-id [resource]
   (resources/canonical-id (:resource/namespace resource)
                           (:garden/id resource)))
+
+(defn canonicalize-document [resource]
+  (assoc resource :document/id (canonical-document-id resource)))
+
+(defn canonicalize-garden [resource]
+  (assoc resource :garden/id (canonical-garden-id resource)))
 
 (defn canonicalize-intent [resource]
   (let [ns (:resource/namespace resource)]
@@ -71,10 +78,12 @@ The resolver must not call HTTP, Mongo, OpenPlanner, filesystem effects, or work
          (fn [idx resource]
            (cond-> idx
              (:document/id resource)
-             (assoc-in [:documents (canonical-document-id resource)] resource)
+             (assoc-in [:documents (canonical-document-id resource)]
+                       (canonicalize-document resource))
 
              (:garden/id resource)
-             (assoc-in [:gardens (canonical-garden-id resource)] resource)
+             (assoc-in [:gardens (canonical-garden-id resource)]
+                       (canonicalize-garden resource))
 
              (:publication/id resource)
              (update :publications conj (canonicalize-intent resource))))
@@ -140,6 +149,7 @@ If the infra handler is synchronous, `await` still safely accepts its resolved v
 
 - Same resource graph -> byte-equivalent canonical projection regardless of source file enumeration order.
 - Namespace-local and already-qualified references resolve to the same canonical identity before comparison.
+- Every document/garden stored in the resolver index has a canonical identity in both its map key and its own `:document/id` / `:garden/id` field.
 - Resolver output contains no execution status such as worker state, publish timestamps, or adapter receipts.
 - Duplicate publication keys or revision-conflicting intents are surfaced deterministically before projection; never "last one wins" by loader order.
 - The domain namespace remains pure and reusable by CLI/tests without Fastify or Mongo.
@@ -150,7 +160,8 @@ If the infra handler is synchronous, `await` still safely accepts its resolved v
 
 - CMS can list documents, gardens, targets, locales, and requested publication states from this projection alone.
 - A pure test deletes every OpenPlanner dependency from the fixture and produces the same desired topology.
-- Namespace-local reference fixtures produce the same canonical projection as fully-qualified fixtures.
+- Namespace-local reference fixtures produce the same canonical projection as fully-qualified fixtures, including canonical IDs inside the returned document/garden payloads.
+- Hydrating a publication that references a namespace-local document validates against the qualified `Document` law shape.
 - Duplicate/conflicting intents fail before the list/document facade returns data.
 - One backend facade serves the projection without `/api/openplanner/...` in its contract and without raw Fastify interop outside `extern.*`.
 - The Fastify adapter test exercises the route with native `^:async`/`await` and no `.then` chain.

--- a/kanban/tasks/knoxx-publication-intent-resolver.md
+++ b/kanban/tasks/knoxx-publication-intent-resolver.md
@@ -23,7 +23,9 @@ The resolver must not call HTTP, Mongo, OpenPlanner, filesystem effects, or work
 - Build document/garden/publication indexes from the resource registry.
 - Canonicalize resource identities and namespace-local references before indexing, filtering, conflict checks, key construction, **and before storing document/garden payloads in the index**.
 - Ensure indexed document/garden payload identity fields contain the same canonical IDs used as their index keys, so downstream Malli validation never sees a namespace-local ID where a qualified identity is required.
-- Reject duplicate/revision-conflicting publication intents deterministically before exposing any projection; never rely on enumeration order.
+- Detect duplicate canonical document/garden identities before insertion. Byte-equivalent duplicates may collapse; conflicting payloads for the same canonical id fail deterministically instead of using loader enumeration order.
+- Treat publication relation identity as document × garden × locale × revision selector. Different revisions may coexist; only conflicting **non-archived** intents for the same relation key fail projection.
+- Preserve archived publication intents as historical desired-state records without letting them conflict with an active replacement merely because document/garden/locale match.
 - Expose pure queries for documents, gardens, publication intents, target locales, and intended revisions.
 - Return explicit semantic blockers for malformed/incomplete desired state; leave runtime blockers to `knoxx-translation-publication-gate`.
 - Define both document and list facade shapes before routes consume them.
@@ -60,40 +62,76 @@ The resolver must not call HTTP, Mongo, OpenPlanner, filesystem effects, or work
 (defn publication-key [intent]
   [(:publication/document intent)
    (:publication/garden intent)
-   (:publication/locale intent)])
+   (:publication/locale intent)
+   (:publication/revision intent)])
+
+(defn publication-sort-key [intent]
+  [(:publication/document intent)
+   (:publication/garden intent)
+   (:publication/locale intent)
+   (pr-str (:publication/revision intent))
+   (:publication/id intent)])
+
+(defn active-publication-intent? [intent]
+  (not= :archived (:publication/state intent)))
 
 (defn publication-conflicts [publications]
   (->> publications
+       (filter active-publication-intent?)
        (group-by publication-key)
        (keep (fn [[k intents]]
                (when (> (count intents) 1)
                  {:publication/key k
                   :intents (vec (sort-by :publication/id intents))})))
-       (sort-by :publication/key)
+       (sort-by #(mapv pr-str (:publication/key %)))
        vec))
+
+(defn index-canonical! [idx kind id resource]
+  (let [path     [kind id]
+        existing (get-in idx path)]
+    (cond
+      (nil? existing)
+      (assoc-in idx path resource)
+
+      (= existing resource)
+      idx
+
+      :else
+      (throw
+       (ex-info "conflicting canonical resource identity"
+                {:resource/kind kind
+                 :resource/id id
+                 :existing existing
+                 :incoming resource})))))
 
 (defn publication-index [resources]
   (let [idx
         (reduce
          (fn [idx resource]
-           (cond-> idx
-             (:document/id resource)
-             (assoc-in [:documents (canonical-document-id resource)]
-                       (canonicalize-document resource))
-
-             (:garden/id resource)
-             (assoc-in [:gardens (canonical-garden-id resource)]
-                       (canonicalize-garden resource))
-
-             (:publication/id resource)
-             (update :publications conj (canonicalize-intent resource))))
+           (let [idx (if (:document/id resource)
+                       (let [document (canonicalize-document resource)]
+                         (index-canonical! idx
+                                           :documents
+                                           (:document/id document)
+                                           document))
+                       idx)
+                 idx (if (:garden/id resource)
+                       (let [garden (canonicalize-garden resource)]
+                         (index-canonical! idx
+                                           :gardens
+                                           (:garden/id garden)
+                                           garden))
+                       idx)]
+             (if (:publication/id resource)
+               (update idx :publications conj (canonicalize-intent resource))
+               idx)))
          {:documents {} :gardens {} :publications []}
          resources)
         conflicts (publication-conflicts (:publications idx))]
     (when (seq conflicts)
       (throw (ex-info "conflicting publication intents"
                       {:conflicts conflicts})))
-    (update idx :publications #(vec (sort-by publication-key %)))))
+    (update idx :publications #(vec (sort-by publication-sort-key %)))))
 
 (defn desired-publications [idx document-id]
   (let [canonical-id (resources/resolve-query-id document-id)]
@@ -150,8 +188,10 @@ If the infra handler is synchronous, `await` still safely accepts its resolved v
 - Same resource graph -> byte-equivalent canonical projection regardless of source file enumeration order.
 - Namespace-local and already-qualified references resolve to the same canonical identity before comparison.
 - Every document/garden stored in the resolver index has a canonical identity in both its map key and its own `:document/id` / `:garden/id` field.
+- Two differing document or garden payloads cannot silently occupy the same canonical id; projection rejects the conflict rather than picking the last enumerated manifest.
+- Publication conflict identity includes revision selector. Different revisions may coexist, and archived historical intents do not invalidate a non-archived replacement at another/current revision.
+- Two non-archived intents for the same document/garden/locale/revision relation are surfaced deterministically before projection.
 - Resolver output contains no execution status such as worker state, publish timestamps, or adapter receipts.
-- Duplicate publication keys or revision-conflicting intents are surfaced deterministically before projection; never "last one wins" by loader order.
 - The domain namespace remains pure and reusable by CLI/tests without Fastify or Mongo.
 - Native request/reply handles are born and die in the extern adapter.
 - New async extern functions use `^:async`/`await`; Promise chaining is not part of the prescribed implementation shape.
@@ -162,6 +202,8 @@ If the infra handler is synchronous, `await` still safely accepts its resolved v
 - A pure test deletes every OpenPlanner dependency from the fixture and produces the same desired topology.
 - Namespace-local reference fixtures produce the same canonical projection as fully-qualified fixtures, including canonical IDs inside the returned document/garden payloads.
 - Hydrating a publication that references a namespace-local document validates against the qualified `Document` law shape.
-- Duplicate/conflicting intents fail before the list/document facade returns data.
+- Two manifests with the same canonical document/garden id and different payloads fail deterministically regardless of enumeration order; byte-equivalent duplicates do not change projection.
+- Different revision selectors for the same document/garden/locale are not rejected merely for sharing those first three dimensions; duplicate active intent for the exact revision relation does fail.
+- Archived historical intent can coexist with a replacement without becoming an active relation conflict.
 - One backend facade serves the projection without `/api/openplanner/...` in its contract and without raw Fastify interop outside `extern.*`.
 - The Fastify adapter test exercises the route with native `^:async`/`await` and no `.then` chain.

--- a/kanban/tasks/knoxx-publication-intent-resolver.md
+++ b/kanban/tasks/knoxx-publication-intent-resolver.md
@@ -28,6 +28,7 @@ The resolver must not call HTTP, Mongo, OpenPlanner, filesystem effects, or work
 - Define both document and list facade shapes before routes consume them.
 - Add a Knoxx route/facade that serializes this projection for frontends without exposing the underlying resource-loader implementation.
 - Keep raw Fastify request/reply interop inside `knoxx.backend.extern.*`; infra/domain receive and return CLJS data only.
+- New asynchronous CLJS adapter code uses native `^:async` + `await`, not Promise `.then` chains.
 
 ## CLJS pseudocode
 
@@ -120,17 +121,20 @@ Infra handler returns CLJS data; it never touches Fastify handles:
     (publication/list-document-views idx)))
 ```
 
-The owning extern adapter alone decodes/encodes Fastify:
+The owning extern adapter alone decodes/encodes Fastify and uses Knoxx's native async style:
 
 ```clojure
 (ns knoxx.backend.extern.fastify.publications)
 
 (defn register-list-route! [app handler]
   (.get app "/api/publications/documents"
-        (fn [req reply]
-          (-> (handler (decode-request req))
-              (.then #(send-json! reply %))))))
+        (fn ^:async [req reply]
+          (let [request  (decode-request req)
+                response (await (handler request))]
+            (send-json! reply response)))))
 ```
+
+If the infra handler is synchronous, `await` still safely accepts its resolved value; the extern shape therefore remains compatible if the handler later becomes effectful without introducing a `.then` chain.
 
 ## Laws
 
@@ -140,6 +144,7 @@ The owning extern adapter alone decodes/encodes Fastify:
 - Duplicate publication keys or revision-conflicting intents are surfaced deterministically before projection; never "last one wins" by loader order.
 - The domain namespace remains pure and reusable by CLI/tests without Fastify or Mongo.
 - Native request/reply handles are born and die in the extern adapter.
+- New async extern functions use `^:async`/`await`; Promise chaining is not part of the prescribed implementation shape.
 
 ## Done when
 
@@ -148,3 +153,4 @@ The owning extern adapter alone decodes/encodes Fastify:
 - Namespace-local reference fixtures produce the same canonical projection as fully-qualified fixtures.
 - Duplicate/conflicting intents fail before the list/document facade returns data.
 - One backend facade serves the projection without `/api/openplanner/...` in its contract and without raw Fastify interop outside `extern.*`.
+- The Fastify adapter test exercises the route with native `^:async`/`await` and no `.then` chain.

--- a/kanban/tasks/knoxx-publication-intent-resolver.md
+++ b/kanban/tasks/knoxx-publication-intent-resolver.md
@@ -1,7 +1,7 @@
 ---
 uuid: "knoxx-publication-intent-resolver"
 title: "Resolve desired publication topology from the Knoxx resource graph"
-status: incoming
+status: accepted
 priority: P1
 labels: ["tasks", "5sp", "has-parent", "cms", "publication", "domain"]
 created_at: "2026-08-12T00:00:00Z"
@@ -21,65 +21,130 @@ The resolver must not call HTTP, Mongo, OpenPlanner, filesystem effects, or work
 ## Scope
 
 - Build document/garden/publication indexes from the resource registry.
-- Resolve namespace-local refs to canonical ids before comparison.
+- Canonicalize resource identities and namespace-local references before indexing, filtering, conflict checks, or key construction.
+- Reject duplicate/revision-conflicting publication intents deterministically before exposing any projection; never rely on enumeration order.
 - Expose pure queries for documents, gardens, publication intents, target locales, and intended revisions.
 - Return explicit semantic blockers for malformed/incomplete desired state; leave runtime blockers to `knoxx-translation-publication-gate`.
+- Define both document and list facade shapes before routes consume them.
 - Add a Knoxx route/facade that serializes this projection for frontends without exposing the underlying resource-loader implementation.
+- Keep raw Fastify request/reply interop inside `knoxx.backend.extern.*`; infra/domain receive and return CLJS data only.
 
 ## CLJS pseudocode
 
 ```clojure
 (ns knoxx.backend.domain.publication)
 
-(defn publication-index [resources]
-  (reduce
-   (fn [idx resource]
-     (cond-> idx
-       (:document/id resource)
-       (assoc-in [:documents (:document/id resource)] resource)
+(defn canonical-document-id [resource]
+  (resources/canonical-id (:resource/namespace resource)
+                          (:document/id resource)))
 
-       (:garden/id resource)
-       (assoc-in [:gardens (:garden/id resource)] resource)
+(defn canonical-garden-id [resource]
+  (resources/canonical-id (:resource/namespace resource)
+                          (:garden/id resource)))
 
-       (:publication/id resource)
-       (update :publications conj resource)))
-   {:documents {} :gardens {} :publications []}
-   resources))
+(defn canonicalize-intent [resource]
+  (let [ns (:resource/namespace resource)]
+    (-> resource
+        (update :publication/id #(resources/canonical-id ns %))
+        (update :publication/document #(resources/resolve-ref ns %))
+        (update :publication/garden #(resources/resolve-ref ns %)))))
 
 (defn publication-key [intent]
   [(:publication/document intent)
    (:publication/garden intent)
    (:publication/locale intent)])
 
-(defn desired-publications [idx document-id]
-  (->> (:publications idx)
-       (filter #(= document-id (:publication/document %)))
-       (sort-by publication-key)
+(defn publication-conflicts [publications]
+  (->> publications
+       (group-by publication-key)
+       (keep (fn [[k intents]]
+               (when (> (count intents) 1)
+                 {:publication/key k
+                  :intents (vec (sort-by :publication/id intents))})))
+       (sort-by :publication/key)
        vec))
 
+(defn publication-index [resources]
+  (let [idx
+        (reduce
+         (fn [idx resource]
+           (cond-> idx
+             (:document/id resource)
+             (assoc-in [:documents (canonical-document-id resource)] resource)
+
+             (:garden/id resource)
+             (assoc-in [:gardens (canonical-garden-id resource)] resource)
+
+             (:publication/id resource)
+             (update :publications conj (canonicalize-intent resource))))
+         {:documents {} :gardens {} :publications []}
+         resources)
+        conflicts (publication-conflicts (:publications idx))]
+    (when (seq conflicts)
+      (throw (ex-info "conflicting publication intents"
+                      {:conflicts conflicts})))
+    (update idx :publications #(vec (sort-by publication-key %)))))
+
+(defn desired-publications [idx document-id]
+  (let [canonical-id (resources/resolve-query-id document-id)]
+    (->> (:publications idx)
+         (filter #(= canonical-id (:publication/document %)))
+         (mapv #(law.publication/hydrate-publication-intent idx %)))))
+
 (defn document-view [idx document-id]
-  {:document (get-in idx [:documents document-id])
+  {:document (get-in idx [:documents (resources/resolve-query-id document-id)])
    :publications (desired-publications idx document-id)})
+
+(def PublicationListView
+  [:map
+   [:documents [:vector :map]]
+   [:gardens [:vector :map]]])
+
+(defn list-document-views [idx]
+  (let [view {:documents (->> (keys (:documents idx))
+                              sort
+                              (mapv #(document-view idx %)))
+              :gardens (->> (:gardens idx) vals (sort-by :garden/id) vec)}]
+    (law/assert! PublicationListView view)
+    view))
 ```
 
-Thin infra route:
+Infra handler returns CLJS data; it never touches Fastify handles:
 
 ```clojure
-(defn list-publication-documents! [req reply]
-  (let [resources (resource-store/resolved-resources (:context req))
+(ns knoxx.backend.infra.routes.publications)
+
+(defn list-publication-documents! [{:keys [context]}]
+  (let [resources (resource-store/resolved-resources context)
         idx       (publication/publication-index resources)]
-    (.send reply (publication/list-document-views idx))))
+    (publication/list-document-views idx)))
+```
+
+The owning extern adapter alone decodes/encodes Fastify:
+
+```clojure
+(ns knoxx.backend.extern.fastify.publications)
+
+(defn register-list-route! [app handler]
+  (.get app "/api/publications/documents"
+        (fn [req reply]
+          (-> (handler (decode-request req))
+              (.then #(send-json! reply %))))))
 ```
 
 ## Laws
 
 - Same resource graph -> byte-equivalent canonical projection regardless of source file enumeration order.
+- Namespace-local and already-qualified references resolve to the same canonical identity before comparison.
 - Resolver output contains no execution status such as worker state, publish timestamps, or adapter receipts.
-- Duplicate publication keys are rejected or surfaced as deterministic conflicts; never "last one wins" by loader order.
+- Duplicate publication keys or revision-conflicting intents are surfaced deterministically before projection; never "last one wins" by loader order.
 - The domain namespace remains pure and reusable by CLI/tests without Fastify or Mongo.
+- Native request/reply handles are born and die in the extern adapter.
 
 ## Done when
 
 - CMS can list documents, gardens, targets, locales, and requested publication states from this projection alone.
 - A pure test deletes every OpenPlanner dependency from the fixture and produces the same desired topology.
-- One backend facade serves the projection without `/api/openplanner/...` in its contract.
+- Namespace-local reference fixtures produce the same canonical projection as fully-qualified fixtures.
+- Duplicate/conflicting intents fail before the list/document facade returns data.
+- One backend facade serves the projection without `/api/openplanner/...` in its contract and without raw Fastify interop outside `extern.*`.

--- a/kanban/tasks/knoxx-publication-receipts-fake-adapter-proof.md
+++ b/kanban/tasks/knoxx-publication-receipts-fake-adapter-proof.md
@@ -1,0 +1,103 @@
+---
+uuid: "knoxx-publication-receipts-fake-adapter-proof"
+title: "Define publication receipts and prove the boundary with a fake adapter"
+status: accepted
+priority: P1
+labels: ["tasks", "2sp", "has-parent", "publication", "receipts", "tests"]
+created_at: "2026-08-12T00:00:00Z"
+points: 2
+category: tasks
+---
+# Define publication receipts and prove the boundary with a fake adapter
+
+> Parent task: `knoxx-publication-adapter-boundary`
+> Parent epic: `knoxx-contract-owned-publication-pipeline`
+
+## Purpose
+
+Close the adapter boundary with one stable observation shape and focused tests that prove desired state, reconciliation, effects, and observed state remain separable with OpenPlanner absent.
+
+## Scope
+
+- Define the minimum successful materialization receipt needed for drift and deploy verification.
+- Include publication id, adapter id, idempotency key, document, garden/target, locale, concrete revision, and publication path.
+- Define failed/blocked/noop receipts separately from successful materialization evidence.
+- Build an in-memory fake `IPublicationTarget` implementing the same effect protocol as production adapters.
+- Prove publish, replay, path move, withheld/archive removal, archived-garden removal, and observation after convergence.
+- Prove adapter failure leaves desired resource intent untouched and visible as drift.
+- Prove OpenPlanner can be completely absent from these tests.
+
+## CLJS pseudocode
+
+```clojure
+(ns knoxx.backend.domain.publication-receipts)
+
+(def PublicationMaterializedReceipt
+  [:map
+   [:receipt/type [:= :publication/materialized]]
+   [:publication/id qualified-keyword?]
+   [:adapter/id keyword?]
+   [:idempotency/key string?]
+   [:document/id qualified-keyword?]
+   [:target qualified-keyword?]
+   [:locale keyword?]
+   [:revision string?]
+   [:path string?]
+   [:materialized/revision string?]
+   [:materialized/path string?]])
+
+(defn observed-materialization [receipt]
+  (when (= :publication/materialized (:receipt/type receipt))
+    (select-keys receipt
+                 [:materialized/revision
+                  :materialized/path])))
+```
+
+Fake adapter sketch:
+
+```clojure
+(defrecord FakePublicationTarget [state]
+  IPublicationTarget
+  (publish! [_ _ intent artifact previous key]
+    (if-let [receipt (get-in @state [:by-key key])]
+      receipt
+      (let [receipt (fake/materialize! state intent artifact previous key)]
+        (swap! state assoc-in [:by-key key] receipt)
+        receipt)))
+
+  (remove! [_ _ intent observed]
+    (fake/remove! state intent observed))
+
+  (observe! [_ _ intent]
+    (fake/observe state intent)))
+```
+
+Focused proof:
+
+```clojure
+(deftest publication-boundary-without-openplanner
+  (let [adapter (fake-publication-target)
+        plan    (publication-plan/reconcile-plan resources intent facts)
+        first   (effects/execute-plan! adapter ctx plan artifact)
+        replay  (effects/execute-plan! adapter ctx plan artifact)]
+    (is (= first replay))
+    (is (= 1 (fake/materialization-count adapter)))
+    (is (= (publication-receipts/observed-materialization first)
+           {:materialized/revision "abc123"
+            :materialized/path "/docs/demo"}))))
+```
+
+## Laws
+
+- Receipts describe effects; they never become desired-state authority.
+- Only concrete revisions appear in successful materialization receipts.
+- Receipt path and revision are sufficient for the planner's drift comparison.
+- Replaying the same effect identity yields the same converged observation.
+- Removing the fake adapter's runtime projection does not change resource intent.
+
+## Done when
+
+- Fake-adapter tests cover the complete planner/effect/receipt seam with zero OpenPlanner calls.
+- Successful receipts satisfy the schema and feed the planner's observed projection directly.
+- Failure/noop/blocked evidence cannot be mistaken for a successful materialization.
+- The parent `knoxx-publication-adapter-boundary` can close without carrying implementation points of its own.

--- a/kanban/tasks/knoxx-publication-reconcile-plan-laws.md
+++ b/kanban/tasks/knoxx-publication-reconcile-plan-laws.md
@@ -1,0 +1,103 @@
+---
+uuid: "knoxx-publication-reconcile-plan-laws"
+title: "Define pure publication reconciliation plan laws"
+status: accepted
+priority: P1
+labels: ["tasks", "3sp", "has-parent", "publication", "reconciliation", "laws"]
+created_at: "2026-08-12T00:00:00Z"
+points: 3
+category: tasks
+---
+# Define pure publication reconciliation plan laws
+
+> Parent task: `knoxx-publication-adapter-boundary`
+> Parent epic: `knoxx-contract-owned-publication-pipeline`
+
+## Purpose
+
+Extract the pure decision layer that compares desired publication intent with admissibility and observed facts and emits `:publish`, `:remove`, `:noop`, or `:blocked` without performing I/O.
+
+## Scope
+
+- Resolve `:source/current` to a concrete revision before comparing desired and observed state.
+- Add `:publication-revision-unresolved` when a selector cannot resolve.
+- Handle `:withheld` and `:archived` before translation/review blockers.
+- Treat an archived garden as non-public and remove any existing materialization.
+- Compare both concrete revision and publication path for convergence.
+- Preserve prior observation in publish/remove plans so the effect layer can replace or remove stale routes.
+- Keep the function deterministic and independent of OpenPlanner, Fastify, Mongo, or any adapter implementation.
+
+## CLJS pseudocode
+
+```clojure
+(ns knoxx.backend.domain.publication-plan)
+
+(defn concrete-revision [intent facts]
+  (case (:publication/revision intent)
+    :source/current
+    (facts/current-source-revision
+     facts (:publication/document intent))
+
+    (:publication/revision intent)))
+
+(defn desired-materialization [intent revision]
+  {:materialized/revision revision
+   :materialized/path (:publication/path intent)})
+
+(defn reconcile-plan [resource-index intent facts]
+  (let [state     (:publication/state intent)
+        garden    (get-in resource-index
+                          [:gardens (:publication/garden intent)])
+        observed  (facts/materialized-publication facts intent)]
+    (cond
+      (contains? #{:withheld :archived} state)
+      {:op (if observed :remove :noop)
+       :reason :publication-not-public
+       :intent intent
+       :observed observed}
+
+      (not= :active (:garden/status garden))
+      {:op (if observed :remove :noop)
+       :reason :garden-not-active
+       :intent intent
+       :observed observed}
+
+      :else
+      (let [revision (concrete-revision intent facts)
+            blockers (cond-> (vec (gate/publication-blockers intent facts))
+                       (nil? revision)
+                       (conj :publication-revision-unresolved))]
+        (if (seq blockers)
+          {:op :blocked
+           :intent intent
+           :blockers blockers}
+          (let [desired (desired-materialization intent revision)
+                current (select-keys observed
+                                     [:materialized/revision
+                                      :materialized/path])]
+            (if (= desired current)
+              {:op :noop
+               :intent intent
+               :desired desired
+               :concrete-revision revision}
+              {:op :publish
+               :intent intent
+               :desired desired
+               :previous observed
+               :concrete-revision revision})))))))
+```
+
+## Laws
+
+- Non-public states can only remove or no-op.
+- Garden archive dominates publication intent and translation blockers.
+- Removal is never blocked by missing/stale translation evidence.
+- No publish plan may carry a nil concrete revision.
+- Path-only changes are drift.
+- Same resources + facts always produce the same plan.
+
+## Done when
+
+- Pure tests cover published/noop, path-only drift, revision drift, unresolved revision, withheld removal, publication archive removal, archived-garden removal, and translation/review blocking.
+- Tests require no adapter or OpenPlanner process.
+- The next child can consume the plan without reimplementing semantic decisions.

--- a/kanban/tasks/knoxx-publication-reconcile-plan-laws.md
+++ b/kanban/tasks/knoxx-publication-reconcile-plan-laws.md
@@ -19,8 +19,8 @@ Extract the pure decision layer that compares desired publication intent with ad
 
 ## Scope
 
-- Resolve `:source/current` to a concrete revision before comparing desired and observed state.
-- Add `:publication-revision-unresolved` when a selector cannot resolve.
+- Consume `publication-gate/publication-evidence` so `:source/current` is resolved once and the same concrete revision drives translation/review admissibility and materialization.
+- Treat `:publication-revision-unresolved` from that shared evidence result as a hard publication blocker.
 - Handle `:withheld` and `:archived` before translation/review blockers.
 - Treat an archived garden as non-public and remove any existing materialization.
 - Compare both concrete revision and publication path for convergence.
@@ -31,14 +31,6 @@ Extract the pure decision layer that compares desired publication intent with ad
 
 ```clojure
 (ns knoxx.backend.domain.publication-plan)
-
-(defn concrete-revision [intent facts]
-  (case (:publication/revision intent)
-    :source/current
-    (facts/current-source-revision
-     facts (:publication/document intent))
-
-    (:publication/revision intent)))
 
 (defn desired-materialization [intent revision]
   {:materialized/revision revision
@@ -63,15 +55,14 @@ Extract the pure decision layer that compares desired publication intent with ad
        :observed observed}
 
       :else
-      (let [revision (concrete-revision intent facts)
-            blockers (cond-> (vec (gate/publication-blockers intent facts))
-                       (nil? revision)
-                       (conj :publication-revision-unresolved))]
+      (let [{:keys [concrete-revision blockers]}
+            (gate/publication-evidence intent facts)]
         (if (seq blockers)
           {:op :blocked
            :intent intent
-           :blockers blockers}
-          (let [desired (desired-materialization intent revision)
+           :blockers blockers
+           :concrete-revision concrete-revision}
+          (let [desired (desired-materialization intent concrete-revision)
                 current (select-keys observed
                                      [:materialized/revision
                                       :materialized/path])]
@@ -79,12 +70,12 @@ Extract the pure decision layer that compares desired publication intent with ad
               {:op :noop
                :intent intent
                :desired desired
-               :concrete-revision revision}
+               :concrete-revision concrete-revision}
               {:op :publish
                :intent intent
                :desired desired
                :previous observed
-               :concrete-revision revision})))))))
+               :concrete-revision concrete-revision})))))))
 ```
 
 ## Laws
@@ -92,6 +83,7 @@ Extract the pure decision layer that compares desired publication intent with ad
 - Non-public states can only remove or no-op.
 - Garden archive dominates publication intent and translation blockers.
 - Removal is never blocked by missing/stale translation evidence.
+- Reconciliation does not independently resolve a revision after gate evaluation; one concrete revision fact is shared across evidence and materialization.
 - No publish plan may carry a nil concrete revision.
 - Path-only changes are drift.
 - Same resources + facts always produce the same plan.
@@ -99,5 +91,6 @@ Extract the pure decision layer that compares desired publication intent with ad
 ## Done when
 
 - Pure tests cover published/noop, path-only drift, revision drift, unresolved revision, withheld removal, publication archive removal, archived-garden removal, and translation/review blocking.
+- A `:source/current` test proves the exact concrete revision checked by the gate is the one emitted in `:desired` and `:concrete-revision` by the plan.
 - Tests require no adapter or OpenPlanner process.
 - The next child can consume the plan without reimplementing semantic decisions.

--- a/kanban/tasks/knoxx-publication-resource-contracts.md
+++ b/kanban/tasks/knoxx-publication-resource-contracts.md
@@ -1,8 +1,8 @@
 ---
 uuid: "knoxx-publication-resource-contracts"
 title: "Define document, garden, and publication resource contracts"
-status: accepted
-priority: P1
+status: breakdown
+priority: P0
 labels: ["tasks", "5sp", "has-parent", "cms", "publication", "contracts"]
 created_at: "2026-08-12T00:00:00Z"
 points: 5

--- a/kanban/tasks/knoxx-publication-resource-contracts.md
+++ b/kanban/tasks/knoxx-publication-resource-contracts.md
@@ -24,16 +24,29 @@ Publication is a relation over document, garden, locale, and revision. A documen
 - Keep desired state declarative: source location, source locale, title/identity, target garden, route/path, locale, revision selector, requested publication state, translation/review policy.
 - Keep runtime observations out of the resource shape.
 - Define canonical identity and reference resolution rules for cross-namespace document/garden/publication references.
+- Define one authoritative publication-path predicate in the resource law and reuse it in migration/adapters; directly authored resources cannot bypass route validation that migrated resources must satisfy.
 - Add resource-loader validation and focused law tests.
 - Hydrate the resolved publication intent with the owning document's validated source locale so translation laws never guess `:en`.
 
 ## CLJS pseudocode
 
 ```clojure
-(ns knoxx.backend.law.publication)
+(ns knoxx.backend.law.publication
+  (:require [clojure.string :as str]))
 
 (def Locale
   [:and :keyword [:fn qualified-or-language-keyword?]])
+
+(defn valid-publication-path? [path]
+  (and (string? path)
+       (seq path)
+       (str/starts-with? path "/")
+       (not (str/includes? path "?"))
+       (not (str/includes? path "#"))
+       (not (str/includes? path "\u0000"))))
+
+(def PublicationPath
+  [:and :string [:fn valid-publication-path?]])
 
 (def Document
   [:map
@@ -59,7 +72,7 @@ Publication is a relation over document, garden, locale, and revision. A documen
    [:publication/locale Locale]
    [:publication/revision [:or :string [:enum :source/current]]]
    [:publication/state [:enum :published :withheld :archived]]
-   [:publication/path :string]
+   [:publication/path PublicationPath]
    [:translation/review [:enum :none :required]]])
 
 ;; Resolved pure-domain view. Source locale is copied from the referenced
@@ -106,14 +119,16 @@ Example manifest intent:
 ## Contract obligations
 
 - Resource shape says what **should** be true, never whether a deployment side effect succeeded.
-- `document × garden × locale` must not resolve to two conflicting active publication intents for the same revision selector.
+- `document × garden × locale × revision` must not resolve to two conflicting non-archived publication intents for the same relation.
 - Unknown document/garden refs fail validation rather than becoming dangling runtime work.
 - Every document declares its source locale; translation gating receives that resolved value and never supplies a language default.
+- Publication paths are route paths: non-empty, rooted at `/`, and free of query/fragment/NUL components; the same predicate is used by migration and direct resource validation.
 - Archive semantics must be explicit: archived garden or publication intent cannot reconcile to a public materialization.
 
 ## Done when
 
-- A resource-only test fixture can describe multiple documents and mixed publication states across gardens/locales.
-- Invalid references, invalid/missing source locales, and conflicting publication intents fail before effectful reconciliation.
+- A resource-only test fixture can describe multiple documents and mixed publication states across gardens/locales/revisions.
+- Invalid references, invalid/missing source locales, malformed publication paths, and conflicting publication intents fail before effectful reconciliation.
+- Directly authored `""`, non-rooted, query-bearing, fragment-bearing, and NUL-bearing publication paths fail the same authoritative predicate used by migration.
 - The translation gate consumes the source locale resolved from the owning document.
 - No OpenPlanner type, route, collection, or identifier is required by the laws.

--- a/kanban/tasks/knoxx-publication-resource-contracts.md
+++ b/kanban/tasks/knoxx-publication-resource-contracts.md
@@ -1,0 +1,97 @@
+---
+uuid: "knoxx-publication-resource-contracts"
+title: "Define document, garden, and publication resource contracts"
+status: incoming
+priority: P1
+labels: ["tasks", "5sp", "has-parent", "cms", "publication", "contracts"]
+created_at: "2026-08-12T00:00:00Z"
+points: 5
+category: tasks
+---
+# Define document, garden, and publication resource contracts
+
+> Parent epic: `knoxx-contract-owned-publication-pipeline`
+
+## Purpose
+
+Make document identity and publication intent fully describable from Knoxx resources, without consulting OpenPlanner or any mutable projection.
+
+Publication is a relation over document, garden, locale, and revision. A document-level `published` boolean is explicitly insufficient.
+
+## Scope
+
+- Add Malli-backed law shapes for first-class `document`, `garden`, and `publication` resource facets/kinds.
+- Keep desired state declarative: source location, title/identity, target garden, route/path, locale, revision selector, requested publication state, translation/review policy.
+- Keep runtime observations out of the resource shape.
+- Define canonical identity and reference resolution rules for cross-namespace document/garden/publication references.
+- Add resource-loader validation and focused law tests.
+
+## CLJS pseudocode
+
+```clojure
+(ns knoxx.backend.law.publication)
+
+(def Document
+  [:map
+   [:document/id qualified-keyword?]
+   [:document/title :string]
+   [:document/source
+    [:map
+     [:path :string]]]])
+
+(def Garden
+  [:map
+   [:garden/id qualified-keyword?]
+   [:garden/title :string]
+   [:garden/status [:enum :active :archived]]])
+
+(def PublicationIntent
+  [:map
+   [:publication/id qualified-keyword?]
+   [:publication/document qualified-keyword?]
+   [:publication/garden qualified-keyword?]
+   [:publication/locale :keyword]
+   [:publication/revision [:or :string [:enum :source/current]]]
+   [:publication/state [:enum :published :withheld :archived]]
+   [:publication/path :string]
+   [:translation/review [:enum :none :required]]])
+
+(defn admissible-publication? [resource-index intent]
+  (and (contains? (:documents resource-index) (:publication/document intent))
+       (contains? (:gardens resource-index) (:publication/garden intent))
+       (not= :archived
+             (:garden/status
+              (get-in resource-index [:gardens (:publication/garden intent)])))))
+```
+
+Example manifest intent:
+
+```clojure
+{:namespace :knoxx.docs
+ :resources
+ [{:document/id :translation-pipeline
+   :document/title "Translation Pipeline"
+   :document/source {:path "docs/translation-pipeline.md"}}
+
+  {:publication/id :translation-pipeline-es
+   :publication/document :knoxx.docs/translation-pipeline
+   :publication/garden :gardens/promethean
+   :publication/locale :es
+   :publication/revision :source/current
+   :publication/state :published
+   :publication/path "/translation-pipeline"
+   :translation/review :required}]}
+```
+
+## Contract obligations
+
+- Resource shape says what **should** be true, never whether a deployment side effect succeeded.
+- `document × garden × locale` must not resolve to two conflicting active publication intents for the same revision selector.
+- Unknown document/garden refs fail validation rather than becoming dangling runtime work.
+- Archive semantics must be explicit: archived garden or publication intent cannot reconcile to a public materialization.
+
+## Done when
+
+- A resource-only test fixture can describe multiple documents and mixed publication states across gardens/locales.
+- Invalid references and conflicting publication intents fail before effectful reconciliation.
+- No OpenPlanner type, route, collection, or identifier is required by the laws.

--- a/kanban/tasks/knoxx-publication-resource-contracts.md
+++ b/kanban/tasks/knoxx-publication-resource-contracts.md
@@ -1,7 +1,7 @@
 ---
 uuid: "knoxx-publication-resource-contracts"
 title: "Define document, garden, and publication resource contracts"
-status: incoming
+status: accepted
 priority: P1
 labels: ["tasks", "5sp", "has-parent", "cms", "publication", "contracts"]
 created_at: "2026-08-12T00:00:00Z"
@@ -21,20 +21,25 @@ Publication is a relation over document, garden, locale, and revision. A documen
 ## Scope
 
 - Add Malli-backed law shapes for first-class `document`, `garden`, and `publication` resource facets/kinds.
-- Keep desired state declarative: source location, title/identity, target garden, route/path, locale, revision selector, requested publication state, translation/review policy.
+- Keep desired state declarative: source location, source locale, title/identity, target garden, route/path, locale, revision selector, requested publication state, translation/review policy.
 - Keep runtime observations out of the resource shape.
 - Define canonical identity and reference resolution rules for cross-namespace document/garden/publication references.
 - Add resource-loader validation and focused law tests.
+- Hydrate the resolved publication intent with the owning document's validated source locale so translation laws never guess `:en`.
 
 ## CLJS pseudocode
 
 ```clojure
 (ns knoxx.backend.law.publication)
 
+(def Locale
+  [:and :keyword [:fn qualified-or-language-keyword?]])
+
 (def Document
   [:map
    [:document/id qualified-keyword?]
    [:document/title :string]
+   [:document/source-locale Locale]
    [:document/source
     [:map
      [:path :string]]]])
@@ -45,16 +50,30 @@ Publication is a relation over document, garden, locale, and revision. A documen
    [:garden/title :string]
    [:garden/status [:enum :active :archived]]])
 
-(def PublicationIntent
+;; Raw declarative relation stored in resource data.
+(def PublicationIntentResource
   [:map
    [:publication/id qualified-keyword?]
    [:publication/document qualified-keyword?]
    [:publication/garden qualified-keyword?]
-   [:publication/locale :keyword]
+   [:publication/locale Locale]
    [:publication/revision [:or :string [:enum :source/current]]]
    [:publication/state [:enum :published :withheld :archived]]
    [:publication/path :string]
    [:translation/review [:enum :none :required]]])
+
+;; Resolved pure-domain view. Source locale is copied from the referenced
+;; document after reference validation; it is not duplicated as resource truth.
+(def PublicationIntent
+  [:merge PublicationIntentResource
+   [:map [:document/source-locale Locale]]])
+
+(defn hydrate-publication-intent [resource-index intent]
+  (let [document (get-in resource-index
+                         [:documents (:publication/document intent)])]
+    (law/assert! Document document)
+    (assoc intent :document/source-locale
+                  (:document/source-locale document))))
 
 (defn admissible-publication? [resource-index intent]
   (and (contains? (:documents resource-index) (:publication/document intent))
@@ -71,6 +90,7 @@ Example manifest intent:
  :resources
  [{:document/id :translation-pipeline
    :document/title "Translation Pipeline"
+   :document/source-locale :en
    :document/source {:path "docs/translation-pipeline.md"}}
 
   {:publication/id :translation-pipeline-es
@@ -88,10 +108,12 @@ Example manifest intent:
 - Resource shape says what **should** be true, never whether a deployment side effect succeeded.
 - `document × garden × locale` must not resolve to two conflicting active publication intents for the same revision selector.
 - Unknown document/garden refs fail validation rather than becoming dangling runtime work.
+- Every document declares its source locale; translation gating receives that resolved value and never supplies a language default.
 - Archive semantics must be explicit: archived garden or publication intent cannot reconcile to a public materialization.
 
 ## Done when
 
 - A resource-only test fixture can describe multiple documents and mixed publication states across gardens/locales.
-- Invalid references and conflicting publication intents fail before effectful reconciliation.
+- Invalid references, invalid/missing source locales, and conflicting publication intents fail before effectful reconciliation.
+- The translation gate consumes the source locale resolved from the owning document.
 - No OpenPlanner type, route, collection, or identifier is required by the laws.

--- a/kanban/tasks/knoxx-translation-pipeline-config-resource.md
+++ b/kanban/tasks/knoxx-translation-pipeline-config-resource.md
@@ -16,12 +16,17 @@ category: tasks
 
 Remove the remaining translation configuration authority at `/api/openplanner/v1/translations/config`. Translation model/policy selection should resolve from Knoxx resources just like agent/model/capability configuration.
 
+The cutover includes **every runtime consumer**, not only the review UI. The production ingestion worker currently reads OpenPlanner `/v1/translations/config` as its first-choice model authority; that worker must move to the Knoxx-owned config boundary before the OpenPlanner endpoint can be retired.
+
 ## Scope
 
 - Represent translation pipeline configuration as Knoxx resource data using an existing suitable resource kind/facet where possible; do not invent a mutable config database.
 - Resolve org/tenant-specific overrides deterministically from the resource graph.
 - Replace frontend reads/writes of `/api/openplanner/v1/translations/config` with a Knoxx-owned translation config facade.
+- Replace the ingestion worker's direct OpenPlanner config fetch (`ingestion/src/kms_ingestion/translation/worker.clj`) with the same Knoxx-owned resolved configuration boundary.
+- Inventory repo-wide callers of both `/api/openplanner/v1/translations/config` and direct OpenPlanner `/v1/translations/config`; no worker/service may retain a hidden second authority.
 - Resolve and validate referenced model ids against the Knoxx model resource catalog on both reads and writes.
+- Define worker fallback semantics explicitly: transport/config lookup failure is surfaced as configuration failure or uses a deliberately declared Knoxx fallback policy; it must not silently fall back to an unrelated env/default model that disagrees with the resource graph.
 - Preserve runtime hot-reload only if it can be expressed as an explicit resource write/reload; do not keep OpenPlanner as a hidden second authority.
 
 ## CLJS pseudocode
@@ -72,6 +77,22 @@ Resolution and catalog validation:
     (resources/write! ctx validated)))
 ```
 
+One Knoxx-owned read boundary is used by both UI and workers:
+
+```clojure
+(defn resolved-translation-config! [{:keys [resource-index org-id principal]}]
+  (auth/require! principal :translations/config-read)
+  (translation-config resource-index {:org-id org-id}))
+
+(defn worker-config-response [ctx]
+  (let [config (resolved-translation-config! ctx)]
+    {:model (:translation/model config)
+     :source-locale (:translation/source-locale config)
+     :default-review (:translation/default-review config)}))
+```
+
+The ingestion worker may consume that boundary through an authenticated Knoxx endpoint or through an injected resolved config artifact, but it may not call OpenPlanner directly or independently reinterpret model precedence.
+
 Frontend API:
 
 ```clojure
@@ -88,10 +109,15 @@ Frontend API:
 
 - A translation config cannot resolve successfully if its model reference is absent from the Knoxx model catalog.
 - Global/org merging happens before catalog validation, so an org override cannot smuggle an invalid model past a validated global default.
-- Reads and writes use the same reference normalization and validation path.
+- Reads, writes, UI consumers, and worker consumers use the same reference normalization and validation path.
+- The ingestion worker cannot choose a model from OpenPlanner, environment, or a hard-coded default when that differs from the authoritative Knoxx resource configuration.
+- If a fallback policy exists, it is represented in Knoxx-owned configuration/law and therefore produces the same answer for UI and worker consumers.
 
 ## Done when
 
 - Translation review/pipeline UI no longer calls `/api/openplanner/v1/translations/config`.
+- `ingestion/src/kms_ingestion/translation/worker.clj` no longer calls OpenPlanner `/v1/translations/config` and obtains the same resolved model the Knoxx config facade reports.
+- Repo-wide search finds no production translation-config consumer using OpenPlanner as authority.
 - Model selection is reconstructable from Knoxx resources with OpenPlanner unavailable.
 - Invalid model refs fail catalog/contract validation before a worker attempts translation or a config response is served.
+- A test changes the resource-selected model and proves both the config facade and ingestion worker select the same canonical model id.

--- a/kanban/tasks/knoxx-translation-pipeline-config-resource.md
+++ b/kanban/tasks/knoxx-translation-pipeline-config-resource.md
@@ -1,0 +1,76 @@
+---
+uuid: "knoxx-translation-pipeline-config-resource"
+title: "Move translation pipeline configuration out of OpenPlanner"
+status: incoming
+priority: P1
+labels: ["tasks", "3sp", "has-parent", "translations", "contracts", "openplanner"]
+created_at: "2026-08-12T00:00:00Z"
+points: 3
+category: tasks
+---
+# Move translation pipeline configuration out of OpenPlanner
+
+> Parent epic: `knoxx-contract-owned-publication-pipeline`
+
+## Purpose
+
+Remove the remaining translation configuration authority at `/api/openplanner/v1/translations/config`. Translation model/policy selection should resolve from Knoxx resources just like agent/model/capability configuration.
+
+## Scope
+
+- Represent translation pipeline configuration as Knoxx resource data using an existing suitable resource kind/facet where possible; do not invent a mutable config database.
+- Resolve org/tenant-specific overrides deterministically from the resource graph.
+- Replace frontend reads/writes of `/api/openplanner/v1/translations/config` with a Knoxx-owned translation config facade.
+- Validate referenced model ids against the Knoxx model resource catalog.
+- Preserve runtime hot-reload only if it can be expressed as an explicit resource write/reload; do not keep OpenPlanner as a hidden second authority.
+
+## CLJS pseudocode
+
+Resource shape sketch:
+
+```clojure
+{:namespace :knoxx.translation
+ :resources
+ [{:policy/id :pipeline-default
+   :translation/model :models/glm-5
+   :translation/source-locale :en
+   :translation/default-review :required}]}
+```
+
+Resolution:
+
+```clojure
+(defn translation-config [resource-index {:keys [org-id]}]
+  (let [global (resources/get resource-index :knoxx.translation/pipeline-default)
+        org    (resources/get resource-index
+                              (keyword (str "orgs." org-id) "translation-pipeline"))]
+    (-> global
+        (merge org)
+        (select-keys [:translation/model
+                      :translation/source-locale
+                      :translation/default-review]))))
+
+(defn update-translation-config! [ctx patch]
+  (let [current (translation-config-resource ctx)
+        next    (merge current patch)]
+    (law/assert! publication/TranslationPipelineConfig next)
+    (resources/write! ctx next)))
+```
+
+Frontend API:
+
+```clojure
+(defn pipeline-config []
+  (api/request "/api/translations/config"))
+
+(defn update-pipeline-config [model-id]
+  (api/request "/api/translations/config"
+               {:method "PATCH"
+                :body {:translation/model model-id}}))
+```
+
+## Done when
+
+- Translation review/pipeline UI no longer calls `/api/openplanner/v1/translations/config`.
+- Model selection is reconstructable from Knoxx resources with OpenPlanner unavailable.
+- Invalid model refs fail contract validation before a worker attempts translation.

--- a/kanban/tasks/knoxx-translation-pipeline-config-resource.md
+++ b/kanban/tasks/knoxx-translation-pipeline-config-resource.md
@@ -1,7 +1,7 @@
 ---
 uuid: "knoxx-translation-pipeline-config-resource"
 title: "Move translation pipeline configuration out of OpenPlanner"
-status: incoming
+status: accepted
 priority: P1
 labels: ["tasks", "3sp", "has-parent", "translations", "contracts", "openplanner"]
 created_at: "2026-08-12T00:00:00Z"
@@ -21,7 +21,7 @@ Remove the remaining translation configuration authority at `/api/openplanner/v1
 - Represent translation pipeline configuration as Knoxx resource data using an existing suitable resource kind/facet where possible; do not invent a mutable config database.
 - Resolve org/tenant-specific overrides deterministically from the resource graph.
 - Replace frontend reads/writes of `/api/openplanner/v1/translations/config` with a Knoxx-owned translation config facade.
-- Validate referenced model ids against the Knoxx model resource catalog.
+- Resolve and validate referenced model ids against the Knoxx model resource catalog on both reads and writes.
 - Preserve runtime hot-reload only if it can be expressed as an explicit resource write/reload; do not keep OpenPlanner as a hidden second authority.
 
 ## CLJS pseudocode
@@ -37,24 +37,39 @@ Resource shape sketch:
    :translation/default-review :required}]}
 ```
 
-Resolution:
+Resolution and catalog validation:
 
 ```clojure
+(defn validate-model-ref! [resource-index config]
+  (let [model-id (resources/resolve-ref :knoxx.translation
+                                        (:translation/model config))
+        model    (get-in resource-index [:models model-id])]
+    (when-not model
+      (throw (ex-info "unknown translation model"
+                      {:translation/model model-id})))
+    (assoc config :translation/model model-id)))
+
 (defn translation-config [resource-index {:keys [org-id]}]
   (let [global (resources/get resource-index :knoxx.translation/pipeline-default)
         org    (resources/get resource-index
-                              (keyword (str "orgs." org-id) "translation-pipeline"))]
-    (-> global
-        (merge org)
-        (select-keys [:translation/model
-                      :translation/source-locale
-                      :translation/default-review]))))
+                              (keyword (str "orgs." org-id) "translation-pipeline"))
+        merged (-> global
+                   (merge org)
+                   (select-keys [:translation/model
+                                 :translation/source-locale
+                                 :translation/default-review]))]
+    (->> merged
+         (validate-model-ref! resource-index)
+         (law/assert! publication/TranslationPipelineConfig))))
 
 (defn update-translation-config! [ctx patch]
-  (let [current (translation-config-resource ctx)
-        next    (merge current patch)]
-    (law/assert! publication/TranslationPipelineConfig next)
-    (resources/write! ctx next)))
+  (let [resource-index (resources/resolved-index ctx)
+        current        (translation-config-resource ctx)
+        next           (merge current patch)
+        validated      (->> next
+                            (validate-model-ref! resource-index)
+                            (law/assert! publication/TranslationPipelineConfig))]
+    (resources/write! ctx validated)))
 ```
 
 Frontend API:
@@ -69,8 +84,14 @@ Frontend API:
                 :body {:translation/model model-id}}))
 ```
 
+## Laws
+
+- A translation config cannot resolve successfully if its model reference is absent from the Knoxx model catalog.
+- Global/org merging happens before catalog validation, so an org override cannot smuggle an invalid model past a validated global default.
+- Reads and writes use the same reference normalization and validation path.
+
 ## Done when
 
 - Translation review/pipeline UI no longer calls `/api/openplanner/v1/translations/config`.
 - Model selection is reconstructable from Knoxx resources with OpenPlanner unavailable.
-- Invalid model refs fail contract validation before a worker attempts translation.
+- Invalid model refs fail catalog/contract validation before a worker attempts translation or a config response is served.

--- a/kanban/tasks/knoxx-translation-pipeline-config-resource.md
+++ b/kanban/tasks/knoxx-translation-pipeline-config-resource.md
@@ -3,9 +3,9 @@ uuid: "knoxx-translation-pipeline-config-resource"
 title: "Move translation pipeline configuration out of OpenPlanner"
 status: accepted
 priority: P1
-labels: ["tasks", "3sp", "has-parent", "translations", "contracts", "openplanner"]
+labels: ["tasks", "5sp", "has-parent", "translations", "contracts", "openplanner"]
 created_at: "2026-08-12T00:00:00Z"
-points: 3
+points: 5
 category: tasks
 ---
 # Move translation pipeline configuration out of OpenPlanner

--- a/kanban/tasks/knoxx-translation-publication-gate.md
+++ b/kanban/tasks/knoxx-translation-publication-gate.md
@@ -20,11 +20,13 @@ Do **not** encode `:translating`, `:reviewing`, `:worker-failed`, or similar ope
 
 ## Scope
 
-- Define the minimum receipt/projection facts needed to admit a translated publication: translation exists for requested revision/locale, required review passed, no superseding source revision invalidated it.
+- Define the minimum receipt/projection facts needed to admit a translated publication: translation exists for the requested **concrete** revision/locale, required review passed for that same revision, and no superseding source revision invalidated it.
+- Resolve revision selectors such as `:source/current` exactly once before any translation/review evidence lookup; selector tokens are never used as receipt revision identities.
+- Return the resolved concrete revision alongside blocker data so reconciliation, queueing, and materialization all consume the same revision fact.
 - Consume the resolved document source locale from `PublicationIntent`; never default source language in the gate.
 - Compute blockers as pure domain data.
 - Feed blockers into CMS and the publication reconciler.
-- Trigger/queue translation work from missing **or stale** publication evidence without making the queue authoritative.
+- Trigger/queue translation work from missing **or stale** publication evidence without making the queue authoritative; work is keyed to the concrete revision, not `:source/current`.
 - Treat approval as revision-specific: when the source revision changes, the old approval remains historical evidence but cannot satisfy the replacement translation.
 - Ensure a corrected/re-reviewed translation can satisfy the same immutable publication intent without editing that intent solely to clear a workflow state.
 
@@ -37,43 +39,71 @@ Do **not** encode `:translating`, `:reviewing`, `:worker-failed`, or similar ope
   (not= (:publication/locale intent)
         (:document/source-locale intent)))
 
+(defn resolve-concrete-revision [intent facts]
+  (case (:publication/revision intent)
+    :source/current
+    (facts/current-source-revision
+     facts (:publication/document intent))
+
+    (:publication/revision intent)))
+
+(defn publication-evidence [intent facts]
+  (let [revision (resolve-concrete-revision intent facts)
+        blockers
+        (cond-> []
+          (nil? revision)
+          (conj :publication-revision-unresolved)
+
+          (and revision
+               (translation-required? intent)
+               (not (translation/translated-revision?
+                     facts
+                     (:publication/document intent)
+                     (:publication/locale intent)
+                     revision)))
+          (conj :translation-missing)
+
+          (and revision
+               (= :required (:translation/review intent))
+               (not (review/approved?
+                     facts
+                     (:publication/document intent)
+                     (:publication/locale intent)
+                     revision)))
+          (conj :translation-review-required)
+
+          (and revision
+               (translation/source-revision-superseded?
+                facts intent revision))
+          (conj :translation-stale))]
+    {:concrete-revision revision
+     :blockers blockers}))
+
 (defn publication-blockers [intent facts]
-  (cond-> []
-    (and (translation-required? intent)
-         (not (translation/translated-revision?
-               facts
-               (:publication/document intent)
-               (:publication/locale intent)
-               (:publication/revision intent))))
-    (conj :translation-missing)
-
-    (and (= :required (:translation/review intent))
-         (not (review/approved?
-               facts
-               (:publication/document intent)
-               (:publication/locale intent)
-               (:publication/revision intent))))
-    (conj :translation-review-required)
-
-    (translation/source-revision-superseded? facts intent)
-    (conj :translation-stale)))
+  (:blockers (publication-evidence intent facts)))
 
 (defn publication-admissible? [intent facts]
-  (and (= :published (:publication/state intent))
-       (empty? (publication-blockers intent facts))))
+  (let [{:keys [concrete-revision blockers]}
+        (publication-evidence intent facts)]
+    (and (= :published (:publication/state intent))
+         (some? concrete-revision)
+         (empty? blockers))))
 ```
 
-Queueing is derivative and handles stale evidence as replacement work:
+Queueing is derivative and uses the exact same concrete revision selected for evidence checks:
 
 ```clojure
 (defn reconcile-translation-work [intent facts]
-  (let [blockers (set (publication-blockers intent facts))]
-    (when (or (contains? blockers :translation-missing)
-              (contains? blockers :translation-stale))
+  (let [{:keys [concrete-revision blockers]}
+        (publication-evidence intent facts)
+        blockers (set blockers)]
+    (when (and concrete-revision
+               (or (contains? blockers :translation-missing)
+                   (contains? blockers :translation-stale)))
       {:action/id :actions/request-translation
        :action/with {:document (:publication/document intent)
                      :locale (:publication/locale intent)
-                     :revision (:publication/revision intent)
+                     :revision concrete-revision
                      :replace-stale? (contains? blockers :translation-stale)}})))
 ```
 
@@ -91,16 +121,21 @@ A stale translation does **not** delete the old approval receipt. The old receip
 
 ## Laws
 
+- A revision selector is resolved before translation or review evidence is queried; `:source/current` is never compared directly to a receipt revision.
+- One `publication-evidence` result supplies the concrete revision used by blockers, translation work, reconciliation, and materialization.
+- If `:source/current` cannot resolve, the gate emits `:publication-revision-unresolved`; it does not query evidence or queue revisionless translation work.
 - Removing all worker/job rows must not change desired publication intent.
 - A new source revision invalidates a translation/review receipt for the old revision unless the contract explicitly pins the old revision.
 - Stale evidence queues replacement translation work; it cannot remain blocked indefinitely with no derivable action.
 - Required review cannot be bypassed by an adapter directly observing a translated artifact.
-- Re-running the pure gate over the same intent + facts produces the same blocker set.
+- Re-running the pure gate over the same intent + facts produces the same concrete revision and blocker set.
 
 ## Done when
 
 - CMS can explain exactly why a requested publication is blocked.
+- A `:source/current` fixture resolving to `"probe-revision"` checks translation and approval receipts against `"probe-revision"`, never against `:source/current`.
+- The reconciler consumes the same `:concrete-revision` returned by `publication-evidence` rather than independently selecting another revision.
 - The reconciler refuses to publish a locale/revision that lacks required translation/review evidence.
-- Missing and stale translations both derive translation work.
+- Missing and stale translations both derive translation work keyed to the concrete revision.
 - A replacement revision cannot inherit approval from an older translation, while historical approval receipts remain intact.
 - No mutable worker/review state is promoted into the declarative resource graph.

--- a/kanban/tasks/knoxx-translation-publication-gate.md
+++ b/kanban/tasks/knoxx-translation-publication-gate.md
@@ -1,0 +1,87 @@
+---
+uuid: "knoxx-translation-publication-gate"
+title: "Gate publication on translation and review receipts without making workflow state contractual"
+status: incoming
+priority: P1
+labels: ["tasks", "5sp", "has-parent", "translations", "publication", "review"]
+created_at: "2026-08-12T00:00:00Z"
+points: 5
+category: tasks
+---
+# Gate publication on translation and review receipts without making workflow state contractual
+
+> Parent epic: `knoxx-contract-owned-publication-pipeline`
+
+## Purpose
+
+Make translation/review a publication prerequisite derived from contract intent plus runtime receipts. Desired state says what must eventually be published; receipts say what has actually happened; a pure decision computes blockers.
+
+Do **not** encode `:translating`, `:reviewing`, `:worker-failed`, or similar operational states into publication resources.
+
+## Scope
+
+- Define the minimum receipt/projection facts needed to admit a translated publication: translation exists for requested revision/locale, required review passed, no superseding source revision invalidated it.
+- Compute blockers as pure domain data.
+- Feed blockers into CMS and the publication reconciler.
+- Trigger/queue translation work from unmet publication intent without making the queue authoritative.
+- Ensure a corrected/re-reviewed translation can satisfy the same immutable publication intent without editing that intent solely to clear a workflow state.
+
+## CLJS pseudocode
+
+```clojure
+(ns knoxx.backend.domain.publication-gate)
+
+(defn translation-required? [intent]
+  (not= (:publication/locale intent)
+        (:document/source-locale intent :en)))
+
+(defn publication-blockers [intent facts]
+  (cond-> []
+    (and (translation-required? intent)
+         (not (translation/translated-revision?
+               facts
+               (:publication/document intent)
+               (:publication/locale intent)
+               (:publication/revision intent))))
+    (conj :translation-missing)
+
+    (and (= :required (:translation/review intent))
+         (not (review/approved?
+               facts
+               (:publication/document intent)
+               (:publication/locale intent)
+               (:publication/revision intent))))
+    (conj :translation-review-required)
+
+    (translation/source-revision-superseded? facts intent)
+    (conj :translation-stale)))
+
+(defn publication-admissible? [intent facts]
+  (and (= :published (:publication/state intent))
+       (empty? (publication-blockers intent facts))))
+```
+
+Queueing is derivative:
+
+```clojure
+(defn reconcile-translation-work [intent facts]
+  (when (some #{:translation-missing}
+              (publication-blockers intent facts))
+    {:action/id :actions/request-translation
+     :action/with {:document (:publication/document intent)
+                   :locale (:publication/locale intent)
+                   :revision (:publication/revision intent)}}))
+```
+
+## Laws
+
+- Removing all worker/job rows must not change desired publication intent.
+- A new source revision invalidates a translation/review receipt for the old revision unless the contract explicitly pins the old revision.
+- Required review cannot be bypassed by an adapter directly observing a translated artifact.
+- Re-running the pure gate over the same intent + facts produces the same blocker set.
+
+## Done when
+
+- CMS can explain exactly why a requested publication is blocked.
+- The reconciler refuses to publish a locale/revision that lacks required translation/review evidence.
+- No mutable worker/review state is promoted into the declarative resource graph.

--- a/kanban/tasks/knoxx-translation-publication-gate.md
+++ b/kanban/tasks/knoxx-translation-publication-gate.md
@@ -1,7 +1,7 @@
 ---
 uuid: "knoxx-translation-publication-gate"
 title: "Gate publication on translation and review receipts without making workflow state contractual"
-status: incoming
+status: accepted
 priority: P1
 labels: ["tasks", "5sp", "has-parent", "translations", "publication", "review"]
 created_at: "2026-08-12T00:00:00Z"
@@ -21,9 +21,11 @@ Do **not** encode `:translating`, `:reviewing`, `:worker-failed`, or similar ope
 ## Scope
 
 - Define the minimum receipt/projection facts needed to admit a translated publication: translation exists for requested revision/locale, required review passed, no superseding source revision invalidated it.
+- Consume the resolved document source locale from `PublicationIntent`; never default source language in the gate.
 - Compute blockers as pure domain data.
 - Feed blockers into CMS and the publication reconciler.
-- Trigger/queue translation work from unmet publication intent without making the queue authoritative.
+- Trigger/queue translation work from missing **or stale** publication evidence without making the queue authoritative.
+- Treat approval as revision-specific: when the source revision changes, the old approval remains historical evidence but cannot satisfy the replacement translation.
 - Ensure a corrected/re-reviewed translation can satisfy the same immutable publication intent without editing that intent solely to clear a workflow state.
 
 ## CLJS pseudocode
@@ -33,7 +35,7 @@ Do **not** encode `:translating`, `:reviewing`, `:worker-failed`, or similar ope
 
 (defn translation-required? [intent]
   (not= (:publication/locale intent)
-        (:document/source-locale intent :en)))
+        (:document/source-locale intent)))
 
 (defn publication-blockers [intent facts]
   (cond-> []
@@ -61,22 +63,37 @@ Do **not** encode `:translating`, `:reviewing`, `:worker-failed`, or similar ope
        (empty? (publication-blockers intent facts))))
 ```
 
-Queueing is derivative:
+Queueing is derivative and handles stale evidence as replacement work:
 
 ```clojure
 (defn reconcile-translation-work [intent facts]
-  (when (some #{:translation-missing}
-              (publication-blockers intent facts))
-    {:action/id :actions/request-translation
-     :action/with {:document (:publication/document intent)
-                   :locale (:publication/locale intent)
-                   :revision (:publication/revision intent)}}))
+  (let [blockers (set (publication-blockers intent facts))]
+    (when (or (contains? blockers :translation-missing)
+              (contains? blockers :translation-stale))
+      {:action/id :actions/request-translation
+       :action/with {:document (:publication/document intent)
+                     :locale (:publication/locale intent)
+                     :revision (:publication/revision intent)
+                     :replace-stale? (contains? blockers :translation-stale)}})))
 ```
+
+Review reset is semantic rather than destructive:
+
+```clojure
+(defn review-satisfies-intent? [approval intent concrete-revision]
+  (and (= (:review/document approval) (:publication/document intent))
+       (= (:review/locale approval) (:publication/locale intent))
+       (= (:review/revision approval) concrete-revision)
+       (= :approved (:review/state approval))))
+```
+
+A stale translation does **not** delete the old approval receipt. The old receipt simply stops satisfying the new concrete revision, so the replacement translation requires a new approval when review is `:required`.
 
 ## Laws
 
 - Removing all worker/job rows must not change desired publication intent.
 - A new source revision invalidates a translation/review receipt for the old revision unless the contract explicitly pins the old revision.
+- Stale evidence queues replacement translation work; it cannot remain blocked indefinitely with no derivable action.
 - Required review cannot be bypassed by an adapter directly observing a translated artifact.
 - Re-running the pure gate over the same intent + facts produces the same blocker set.
 
@@ -84,4 +101,6 @@ Queueing is derivative:
 
 - CMS can explain exactly why a requested publication is blocked.
 - The reconciler refuses to publish a locale/revision that lacks required translation/review evidence.
+- Missing and stale translations both derive translation work.
+- A replacement revision cannot inherit approval from an older translation, while historical approval receipts remain intact.
 - No mutable worker/review state is promoted into the declarative resource graph.


### PR DESCRIPTION
## Summary

Breaks down the final OpenPlanner publication-authority decoupling as one **P1 epic in `breakdown`** with prioritized execution cards. The first foundation task is **P0 / `breakdown`**, and the former 8sp publication adapter task is now also a zero-point `breakdown` roll-up over three smaller implementation cards.

The target invariant is:

- Knoxx resources own desired document/garden/locale/revision publication state.
- Knoxx laws/domain own admissibility and reconciliation.
- Runtime receipts/projections own observed execution state.
- Publication adapters perform effects; OpenPlanner is optional implementation detail rather than semantic authority.

## Board state

### P0 — foundation + authority transfer

1. **breakdown / 5sp** `knoxx-publication-resource-contracts`
2. **accepted / 5sp** `knoxx-publication-intent-resolver`
3. **accepted / 5sp** `knoxx-openplanner-publication-state-migration`

### P1 — runtime semantics + reconciliation — 18sp total

4. **accepted / 5sp** `knoxx-translation-pipeline-config-resource`
5. **accepted / 5sp** `knoxx-translation-publication-gate`
6. **breakdown / 0sp roll-up** `knoxx-publication-adapter-boundary`
   - **accepted / 3sp** `knoxx-publication-reconcile-plan-laws`
   - **accepted / 3sp** `knoxx-publication-adapter-effects-idempotency`
   - **accepted / 2sp** `knoxx-publication-receipts-fake-adapter-proof`

The adapter split is deliberately `3 + 3 + 2`: pure decision law first, effect/idempotency contract second, then receipt/proof closure. The parent carries zero points so the original 8sp is not double-counted.

### P2 — cutover + retirement + proof

7. **accepted / 5sp** `knoxx-cms-resource-backed-publication-ui`
8. **accepted / 3sp** `knoxx-openplanner-rest-retirement`
9. **accepted / 5sp** `knoxx-contract-publication-e2e`

Priority here means dependency urgency, not optionality.

## Review follow-up

All current inline Codex and CodeRabbit review threads are resolved.

The latest pass established:

- deploy/retirement smoke verification is native `^:async` and awaits authorized and unauthorized requests before inspecting response status;
- CMS has explicit JSON wire contracts/codecs for documents, gardens, and publications, including canonical `namespace/name` ids and keyword enum round-trips;
- publication relation conflict identity is `document × garden × locale × revision`; archived historical intents do not conflict merely because an active replacement shares the first three dimensions;
- duplicate canonical document/garden ids with differing payloads are rejected deterministically instead of becoming loader-order-dependent last-write-wins state;
- publication path validation is owned by the authoritative resource law and reused by migration, so direct and migrated resources satisfy the same route predicate;
- `:source/current` resolves before translation/review evidence lookup, and one `publication-evidence` result carries the concrete revision through blocker calculation, translation work, reconciliation, and materialization.

Earlier passes established decoded Fastify params, colon-free resource-id wire encoding, migration validation/idempotency, ingestion-worker config cutover, archived-garden removal, path-aware adapter drift/idempotency, source-locale ownership, model catalog validation, stale-translation replacement, exact E2E receipts/public reads, and shared deploy-surface verification.

The reviewer request to move the epic/foundation task back to `accepted` was intentionally not applied because `breakdown` is the requested board workflow state.

## Relationship to existing cards

- Makes `knoxx-cms-contract-validation` concrete.
- Does not duplicate `knoxx-translations-event-sourced`; translation history remains that card's concern.
- Aligns with CMS route retirement while giving publication semantics a non-OpenPlanner home first.

## Verification

Docs/kanban only. PR contains one epic plus twelve task files. The original adapter 8sp has been decomposed into 3sp + 3sp + 2sp children; its parent is a zero-point breakdown roll-up. Current review-thread check is clean. No implementation or merge is included.