### PR TITLE
add katamorph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,13 @@ jobs:
           # (class file version 65).
           java-version: "21"
 
-      - name: Install clj-kondo
+      - name: Setup Clojure CLI
         uses: DeLaGuardo/setup-clojure@13
         with:
+          # backend/shadow-cljs.edn runs in :deps mode, so shadow-cljs resolves
+          # its classpath (including the katamorph Git dependency) through
+          # tools.deps and needs the clojure CLI on PATH.
+          cli: latest
           clj-kondo: latest
 
       - uses: pnpm/action-setup@v4
@@ -67,11 +71,9 @@ jobs:
 
       - name: Build linked OpenPlanner SDK
         run: |
-          # Knoxx currently resolves these linked sources through sibling paths:
+          # Knoxx currently resolves this linked source through a sibling path:
           # backend/package.json -> ../../openplanner/packages/openplanner-sdk
-          # backend/shadow-cljs.edn -> ../../contract-runtime/src/cljs
           ln -sfn "$GITHUB_WORKSPACE/_deps/openplanner" "$GITHUB_WORKSPACE/../openplanner"
-          ln -sfn "$GITHUB_WORKSPACE/_deps/openplanner/packages/contract-runtime" "$GITHUB_WORKSPACE/../contract-runtime"
           pnpm -C _deps/openplanner --filter @open-hax/openplanner-sdk... install --frozen-lockfile
           pnpm -C _deps/openplanner --filter @open-hax/openplanner-sdk... run build
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -32,6 +32,14 @@ jobs:
           distribution: temurin
           java-version: "21"
 
+      - name: Setup Clojure CLI
+        uses: DeLaGuardo/setup-clojure@13
+        with:
+          # backend/shadow-cljs.edn runs in :deps mode, so shadow-cljs resolves
+          # its classpath (including the katamorph Git dependency) through
+          # tools.deps and needs the clojure CLI on PATH.
+          cli: latest
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -32,6 +32,14 @@ jobs:
           distribution: temurin
           java-version: "21"
 
+      - name: Setup Clojure CLI
+        uses: DeLaGuardo/setup-clojure@13
+        with:
+          # backend/shadow-cljs.edn runs in :deps mode, so shadow-cljs resolves
+          # its classpath (including the katamorph Git dependency) through
+          # tools.deps and needs the clojure CLI on PATH.
+          cli: latest
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/deploy-testing.yml
+++ b/.github/workflows/deploy-testing.yml
@@ -102,6 +102,14 @@ jobs:
           distribution: temurin
           java-version: "21"
 
+      - name: Setup Clojure CLI
+        uses: DeLaGuardo/setup-clojure@13
+        with:
+          # backend/shadow-cljs.edn runs in :deps mode, so shadow-cljs resolves
+          # its classpath (including the katamorph Git dependency) through
+          # tools.deps and needs the clojure CLI on PATH.
+          cli: latest
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ Prerequisites:
 
 - Node.js 22+ and pnpm.
 - Java 21+ for shadow-cljs / Closure Compiler.
-- Clojure CLI for `ingestion/`.
+- Clojure CLI for `ingestion/` and for every backend shadow-cljs command.
+  `backend/shadow-cljs.edn` runs in `:deps` mode, so shadow-cljs resolves its
+  classpath through tools.deps and launches via `clojure`.
 - Redis and PostgreSQL for sessions/policy/ingestion state.
 - Proxx for model access, usually on `http://127.0.0.1:8789`.
 - OpenPlanner for durable memory/events/graph, usually on

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,14 +49,17 @@ card-link stability; scope is compliance, extraction is a listed non-goal).
 
 ## Knoxx's position in the drift ledger
 
-- **References katamorph nowhere.** No dep in `deps.edn`, `package.json`, or
-  `shadow-cljs.edn`. Consumes `open-hax.contract-runtime` instead.
+- **Consumes katamorph as a pinned Git dependency.** `backend/deps.edn` pins
+  `io.github.open-hax/katamorph` at `v0.2.0`, and `backend/shadow-cljs.edn`
+  takes its classpath from that alias. The `open-hax.contract-runtime.*`
+  requires are now `katamorph.*`; the injected config key is still
+  `:contract-runtime/deps`, which katamorph reads under that name.
 - Carries `open-hax.contracts.schema` — *byte-identical lineage; katamorph was
-  extracted from it; never cut over.*
-- **Builds `contract-runtime` from the openplanner copy**, not the standalone
-  repo: `backend/shadow-cljs.edn` source path `../../contract-runtime/src/cljs`,
-  staged in CI from `openplanner/packages/`. Repointing this is a cheap, early
-  win in the openplanner teardown.
+  extracted from it; still not cut over.*
+- **No longer builds `contract-runtime` from the openplanner copy.** The
+  `../../contract-runtime/src/cljs` source path and its CI symlink from
+  `openplanner/packages/` are gone. The remaining openplanner sibling link is
+  the JS SDK (`backend/package.json`), not the contract runtime.
 
 ## Why compliance has not happened by itself
 

--- a/backend/deps.edn
+++ b/backend/deps.edn
@@ -6,7 +6,16 @@
   rewrite-clj/rewrite-clj {:mvn/version "1.1.49"}}
 
  :aliases
- {:mutation
+ {;; Katamorph (open-hax/katamorph) is the successor to the openplanner
+  ;; contract-runtime package. Consumed as CLJS source via tools.deps git
+  ;; dependency — see shadow-cljs.edn's top-level :deps, which merges this
+  ;; alias's classpath into every build.
+  :katamorph
+  {:extra-deps {io.github.open-hax/katamorph
+                {:git/tag "v0.2.0"
+                 :git/sha "305a5e49d834aca27566f739e8510f6b409fda78"}}}
+
+  :mutation
   {:main-opts ["-m" "knoxx.mutation-test"]}
 
   :mutation-test

--- a/backend/deps.edn
+++ b/backend/deps.edn
@@ -6,14 +6,29 @@
   rewrite-clj/rewrite-clj {:mvn/version "1.1.49"}}
 
  :aliases
- {;; Katamorph (open-hax/katamorph) is the successor to the openplanner
-  ;; contract-runtime package. Consumed as CLJS source via tools.deps git
-  ;; dependency — see shadow-cljs.edn's top-level :deps, which merges this
-  ;; alias's classpath into every build.
-  :katamorph
-  {:extra-deps {io.github.open-hax/katamorph
-                {:git/tag "v0.2.0"
-                 :git/sha "305a5e49d834aca27566f739e8510f6b409fda78"}}}
+ {;; The ClojureScript build classpath. shadow-cljs.edn selects this alias
+  ;; through its :deps key, and in that mode tools.deps — not shadow-cljs.edn —
+  ;; owns the classpath: shadow-cljs.edn's own :source-paths and :dependencies
+  ;; are ignored. So every CLJS source root and JVM dependency the builds need
+  ;; lives here.
+  ;;
+  ;; Katamorph (open-hax/katamorph) is the successor to the openplanner
+  ;; contract-runtime package and provides the same katamorph.* namespaces the
+  ;; ../../contract-runtime sibling checkout used to supply. Pinning it by Git
+  ;; tag + sha replaces that filesystem path with a reproducible ref.
+  :cljs
+  {:extra-paths ["src/cljs" "test/cljs"]
+   :extra-deps
+   {io.github.open-hax/katamorph   {:git/tag "v0.2.0"
+                                    :git/sha "305a5e49d834aca27566f739e8510f6b409fda78"}
+    ;; ../shared/src/cljs, as a local lib rather than an external :extra-path
+    ;; (tools.deps deprecates paths that escape the project directory).
+    open-hax/knoxx-shared          {:local/root "../shared"}
+    thheller/shadow-cljs           {:mvn/version "3.4.11"}
+    metosin/malli                  {:mvn/version "0.16.4"}
+    funcool/promesa                {:mvn/version "11.0.678"}
+    cider/cider-nrepl              {:mvn/version "0.50.2"}
+    refactor-nrepl/refactor-nrepl  {:mvn/version "3.9.1"}}}
 
   :mutation
   {:main-opts ["-m" "knoxx.mutation-test"]}

--- a/backend/mutation/README.md
+++ b/backend/mutation/README.md
@@ -26,8 +26,8 @@ pnpm run mutation:harness-test
 
 1. Parse CLJS source with `tools.reader` as a sanity pass and `rewrite-clj` as a position-preserving zipper.
 2. Apply pure mutation operators over s-expressions, e.g. `if` test negation, comparison flips, arithmetic operator flips, and literal flips.
-3. Emit one temporary source overlay per mutant under `target/mutation/mutants/<id>/src/cljs/...`.
-4. Invoke Shadow with a dynamic `--config-merge` source-path overlay so the mutant shadows the original namespace.
+3. Write the mutated form into the real source file for the duration of one mutant, restoring the original afterwards (with a JVM shutdown hook as a backstop). `shadow-cljs.edn` runs in `:deps` mode, where `:source-paths` is ignored — including via `--config-merge` — so a mutant cannot be layered in as an extra source path ahead of `src/cljs`.
+4. Invoke Shadow normally; it compiles the mutated file because that file *is* the source.
 5. Run the compiled node-test bundle and classify mutants as `:killed` or `:survived`.
 6. Write an EDN report to `target/mutation/report.edn`.
 

--- a/backend/mutation/knoxx/mutation_test.clj
+++ b/backend/mutation/knoxx/mutation_test.clj
@@ -6,6 +6,7 @@
   execution to shadow-cljs. It intentionally stays in Clojure so mutation
   operators work on Lisp data, not generated JavaScript."
   (:require [clojure.java.io :as io]
+            [clojure.java.shell :as shell]
             [clojure.pprint :as pprint]
             [clojure.string :as str]
             [clojure.tools.reader :as reader]
@@ -225,6 +226,23 @@
   [{:keys [src-dir] :or {src-dir default-src-dir}} mutant]
   (io/file src-dir (:relative-path mutant)))
 
+(defn assert-clean-tree!
+  "with-mutated-source! restores src-dir via try/finally plus a JVM shutdown
+  hook, but neither runs on SIGKILL or power loss. Refusing to start against
+  a dirty tree means that worst case is always safely recoverable with
+  `git checkout -- <src-dir>`, since nothing uncommitted was ever at risk."
+  [{:keys [src-dir] :or {src-dir default-src-dir}}]
+  (let [result (shell/sh "git" "status" "--porcelain" "--" src-dir)]
+    (when (not= 0 (:exit result))
+      (throw (ex-info "git status failed while checking for uncommitted changes"
+                      {:src-dir src-dir :result result})))
+    (when-let [dirty (seq (remove str/blank? (str/split-lines (:out result))))]
+      (throw (ex-info (str "Refusing to run mutation tests against a dirty " src-dir
+                           ". Mutation runs temporarily overwrite real source files; "
+                           "commit or stash first so a killed run can always recover "
+                           "with `git checkout`.")
+                      {:src-dir src-dir :dirty-paths dirty})))))
+
 (defn with-mutated-source!
   "backend/shadow-cljs.edn runs shadow-cljs in :deps mode, which hands the
   entire classpath to tools.deps and ignores :source-paths outright (even via
@@ -397,6 +415,8 @@
 
 (defn run-suite!
   [opts]
+  (when (:run? opts)
+    (assert-clean-tree! opts))
   (let [mutants (discover-mutants opts)
         results (if (:run? opts)
                   (mapv #(evaluate-mutant! opts %) mutants)

--- a/backend/mutation/knoxx/mutation_test.clj
+++ b/backend/mutation/knoxx/mutation_test.clj
@@ -1,10 +1,10 @@
 (ns knoxx.mutation-test
   "S-expression mutation harness for Knoxx ClojureScript backend sources.
 
-  The harness mutates original CLJS forms with rewrite-clj, emits a temporary
-  source overlay per mutant, and delegates compile/test execution to shadow-cljs.
-  It intentionally stays in Clojure so mutation operators work on Lisp data, not
-  generated JavaScript."
+  The harness mutates original CLJS forms with rewrite-clj, temporarily
+  overwrites the real source file per mutant, and delegates compile/test
+  execution to shadow-cljs. It intentionally stays in Clojure so mutation
+  operators work on Lisp data, not generated JavaScript."
   (:require [clojure.java.io :as io]
             [clojure.pprint :as pprint]
             [clojure.string :as str]
@@ -221,26 +221,32 @@
       :else
       (recur (z/next loc)))))
 
-(defn mutant-overlay-source-path
-  [output-dir mutant]
-  (.getPath (io/file output-dir "mutants" (:id mutant) "src" "cljs" (:relative-path mutant))))
+(defn mutant-source-path
+  [{:keys [src-dir] :or {src-dir default-src-dir}} mutant]
+  (io/file src-dir (:relative-path mutant)))
 
-(defn emit-mutant-source!
-  [{:keys [src-dir output-dir] :or {src-dir default-src-dir output-dir default-output-dir}}
-   mutant]
-  (let [original-path (io/file src-dir (:relative-path mutant))
-        mutated-path (io/file (mutant-overlay-source-path output-dir mutant))
-        mutated-source (apply-mutant-to-source (slurp original-path) mutant)]
-    (.mkdirs (.getParentFile mutated-path))
-    (spit mutated-path mutated-source)
-    (assoc mutant
-           :overlay-path (.getPath mutated-path))))
-
-(defn shadow-config-merge
-  [mutant]
-  {:source-paths [(str "target/mutation/mutants/" (:id mutant) "/src/cljs")
-                  "src/cljs"
-                  "test/cljs"]})
+(defn with-mutated-source!
+  "backend/shadow-cljs.edn runs shadow-cljs in :deps mode, which hands the
+  entire classpath to tools.deps and ignores :source-paths outright (even via
+  --config-merge), so a mutant can no longer be layered in ahead of src/cljs
+  as an overlay path. Mutating the real file for the duration of one
+  compile+test cycle sidesteps that restriction entirely. Mutants run
+  strictly sequentially (see run-suite!), so there is never more than one
+  file mutated at a time. The shutdown hook guards against the file being
+  left mutated if the process is killed mid-mutation."
+  [opts mutant f]
+  (let [target (mutant-source-path opts mutant)
+        original (slurp target)
+        mutated (apply-mutant-to-source original mutant)
+        restore! #(spit target original)
+        hook (Thread. restore!)]
+    (.addShutdownHook (Runtime/getRuntime) hook)
+    (try
+      (spit target mutated)
+      (f)
+      (finally
+        (restore!)
+        (.removeShutdownHook (Runtime/getRuntime) hook)))))
 
 (defn process-result
   [exit-code timed-out? output]
@@ -278,11 +284,8 @@
         (pos? (or errors 0)))))
 
 (defn compile-mutant!
-  [{:keys [shadow-build timeout-ms] :or {shadow-build default-shadow-build timeout-ms default-timeout-ms}}
-   mutant]
-  (run-process! {:cmd ["pnpm" "exec" "shadow-cljs" "--force-spawn"
-                       "--config-merge" (pr-str (shadow-config-merge mutant))
-                       "compile" shadow-build]
+  [{:keys [shadow-build timeout-ms] :or {shadow-build default-shadow-build timeout-ms default-timeout-ms}}]
+  (run-process! {:cmd ["pnpm" "exec" "shadow-cljs" "--force-spawn" "compile" shadow-build]
                  :timeout-ms timeout-ms}))
 
 (defn run-mutant-tests!
@@ -292,19 +295,20 @@
 
 (defn evaluate-mutant!
   [opts mutant]
-  (let [emitted (emit-mutant-source! opts mutant)
-        compile-result (compile-mutant! opts emitted)]
-    (if (killed? compile-result)
-      (assoc emitted
-             :status :killed
-             :phase :compile
-             :result (select-keys compile-result [:exit-code :timed-out?]))
-      (let [test-result (run-mutant-tests! opts)]
-        (assoc emitted
-               :status (if (killed? test-result) :killed :survived)
-               :phase :test
-               :result (merge (select-keys test-result [:exit-code :timed-out?])
-                              (or (test-counters (:output test-result)) {})))))))
+  (with-mutated-source! opts mutant
+    (fn []
+      (let [compile-result (compile-mutant! opts)]
+        (if (killed? compile-result)
+          (assoc mutant
+                 :status :killed
+                 :phase :compile
+                 :result (select-keys compile-result [:exit-code :timed-out?]))
+          (let [test-result (run-mutant-tests! opts)]
+            (assoc mutant
+                   :status (if (killed? test-result) :killed :survived)
+                   :phase :test
+                   :result (merge (select-keys test-result [:exit-code :timed-out?])
+                                  (or (test-counters (:output test-result)) {})))))))))
 
 (defn report-summary
   [results]

--- a/backend/scripts/dev-watch.sh
+++ b/backend/scripts/dev-watch.sh
@@ -39,6 +39,13 @@ if ! command -v java >/dev/null 2>&1; then
   exit 1
 fi
 
+# shadow-cljs.edn runs in :deps mode, so it resolves its classpath through
+# tools.deps and launches via the Clojure CLI rather than its own resolver.
+if ! command -v clojure >/dev/null 2>&1; then
+  echo "[knoxx-backend-dev] clojure is required for shadow-cljs (:deps mode)" >&2
+  exit 1
+fi
+
 if ! command -v pnpm >/dev/null 2>&1; then
   corepack enable >/dev/null 2>&1 || true
   corepack prepare pnpm@10.14.0 --activate >/dev/null 2>&1 || true

--- a/backend/scripts/rebuild-image.sh
+++ b/backend/scripts/rebuild-image.sh
@@ -42,6 +42,13 @@ if [[ "$SKIP_COMPILE" != "1" ]]; then
     exit 1
   fi
 
+  # shadow-cljs.edn runs in :deps mode, so it resolves its classpath through
+  # tools.deps and launches via the Clojure CLI rather than its own resolver.
+  if ! command -v clojure >/dev/null 2>&1; then
+    echo "clojure is required for shadow-cljs builds (:deps mode)" >&2
+    exit 1
+  fi
+
   if [[ ! -d node_modules ]]; then
     echo ">>> Installing backend dependencies from lockfile"
     pnpm install --frozen-lockfile

--- a/backend/shadow-cljs.edn
+++ b/backend/shadow-cljs.edn
@@ -1,12 +1,8 @@
-{:source-paths ["src/cljs" "test/cljs"],
- ;; Merges the :katamorph alias's classpath (deps.edn) into every build below,
- ;; making katamorph.* namespaces resolvable without a filesystem source-path.
- :deps {:aliases [:katamorph]},
- :dependencies
- [[cider/cider-nrepl "0.50.2"]
-  [refactor-nrepl "3.9.1"]
-  [metosin/malli "0.16.4"]
-  [funcool/promesa "11.0.678"]],
+;; deps.edn's :cljs alias is the classpath for every build below: source roots
+;; (src/cljs, test/cljs, ../shared), JVM dependencies, and katamorph pinned by
+;; Git ref. :source-paths and :dependencies are intentionally absent — in :deps
+;; mode shadow-cljs ignores both and defers to tools.deps.
+{:deps {:aliases [:cljs]},
  :nrepl {:port 4500},
  :js-options {:js-provider :import},
  :builds

--- a/backend/shadow-cljs.edn
+++ b/backend/shadow-cljs.edn
@@ -1,6 +1,7 @@
-{:source-paths ["src/cljs" "test/cljs"
-                "../shared/src/cljs"
-                "../../contract-runtime/src/cljs"],
+{:source-paths ["src/cljs" "test/cljs"],
+ ;; Merges the :katamorph alias's classpath (deps.edn) into every build below,
+ ;; making katamorph.* namespaces resolvable without a filesystem source-path.
+ :deps {:aliases [:katamorph]},
  :dependencies
  [[cider/cider-nrepl "0.50.2"]
   [refactor-nrepl "3.9.1"]

--- a/backend/src/cljs/knoxx/backend/contract_runtime_deps.cljs
+++ b/backend/src/cljs/knoxx/backend/contract_runtime_deps.cljs
@@ -1,7 +1,7 @@
 (ns knoxx.backend.contract-runtime-deps
-  "Wires Knoxx-specific implementations into the contract-runtime dependency
+  "Wires Knoxx-specific implementations into the katamorph dependency
    injection system. This is the single integration point between Knoxx's
-   deployment logic and the reusable contract runtime core."
+   deployment logic and the reusable katamorph contract runtime."
   (:require [knoxx.backend.domain.action.registry :as action-registry]
             [knoxx.backend.domain.contracts.loader :as contract-loader]
             [knoxx.backend.domain.filter.registry :as filter-registry]
@@ -22,7 +22,7 @@
    :resource-class (fn [resource-kind] (resources/resource-class resource-kind))})
 
 (defn inject-deps!
-  "Inject contract-runtime dependencies into the runtime config.
-   Call this during bootstrap to wire the contract runtime."
+  "Inject the :contract-runtime/deps map katamorph reads into the runtime
+   config. Call this during bootstrap to wire the contract runtime."
   [config]
   (assoc config :contract-runtime/deps (build-deps)))

--- a/backend/src/cljs/knoxx/backend/domain/action/anonymous.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/action/anonymous.cljs
@@ -1,6 +1,6 @@
 (ns knoxx.backend.domain.action.anonymous
-  "Delegates to the contract-runtime action anonymous module.
+  "Delegates to the katamorph action anonymous module.
    Re-exports all public vars for backward compatibility."
-  (:require [open-hax.contract-runtime.action.anonymous :as core]))
+  (:require [katamorph.action.anonymous :as core]))
 
 (def compile-action-fn core/compile-action-fn)

--- a/backend/src/cljs/knoxx/backend/domain/action/interpreter.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/action/interpreter.cljs
@@ -1,13 +1,13 @@
 (ns knoxx.backend.domain.action.interpreter
-  "Action interpreter: delegates to the contract-runtime action interpreter.
+  "Action interpreter: delegates to the katamorph action interpreter.
 
    This is a thin wrapper that provides backward compatibility for existing
    Knoxx callers. The actual implementation lives in the extracted
-   contract-runtime package.
+   katamorph package.
 
    The config map must contain :contract-runtime/deps (see
    knoxx.backend.contract-runtime-deps/build-deps)."
-  (:require [open-hax.contract-runtime.action.interpreter :as core-interpreter]))
+  (:require [katamorph.action.interpreter :as core-interpreter]))
 
 (defn resolve-scope-decl
   "Resolve an :action/scope declaration {:actions [...] :filters [...]

--- a/backend/src/cljs/knoxx/backend/domain/agent/agent_context.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/agent/agent_context.cljs
@@ -1,7 +1,7 @@
 (ns knoxx.backend.domain.agent.agent-context
-  "Delegates to the contract-runtime agent context module.
+  "Delegates to the katamorph agent context module.
    Re-exports all public vars for backward compatibility."
-  (:require [open-hax.contract-runtime.agent.context :as core]))
+  (:require [katamorph.agent.context :as core]))
 
 (def set-context! core/set-context!)
 (def clear-context! core/clear-context!)

--- a/backend/src/cljs/knoxx/backend/domain/agent/reasoning.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/agent/reasoning.cljs
@@ -1,7 +1,7 @@
 (ns knoxx.backend.domain.agent.reasoning
-  "Delegates to the contract-runtime agent reasoning module.
+  "Delegates to the katamorph agent reasoning module.
    Re-exports all public vars for backward compatibility."
-  (:require [open-hax.contract-runtime.agent.reasoning :as core]))
+  (:require [katamorph.agent.reasoning :as core]))
 
 (def split-think-tags core/split-think-tags)
 (def route-think-delta core/route-think-delta)

--- a/backend/src/cljs/knoxx/backend/domain/agent/text_delta.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/agent/text_delta.cljs
@@ -1,7 +1,7 @@
 (ns knoxx.backend.domain.agent.text-delta
-  "Delegates to the contract-runtime agent text-delta module.
+  "Delegates to the katamorph agent text-delta module.
    Re-exports all public vars for backward compatibility."
-  (:require [open-hax.contract-runtime.agent.text-delta :as core]))
+  (:require [katamorph.agent.text-delta :as core]))
 
 (def diff-appended-text core/diff-appended-text)
 (def suppress-replayed-prefix-delta core/suppress-replayed-prefix-delta)

--- a/backend/src/cljs/knoxx/backend/domain/agent/tool_lifecycle.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/agent/tool_lifecycle.cljs
@@ -1,7 +1,7 @@
 (ns knoxx.backend.domain.agent.tool-lifecycle
-  "Delegates to the contract-runtime agent tool-lifecycle module.
+  "Delegates to the katamorph agent tool-lifecycle module.
    Re-exports all public vars for backward compatibility."
-  (:require [open-hax.contract-runtime.agent.tool-lifecycle :as core]))
+  (:require [katamorph.agent.tool-lifecycle :as core]))
 
 (def empty-tool-call-id-state core/empty-tool-call-id-state)
 (def resolve-tool-call-start-id core/resolve-tool-call-start-id)

--- a/backend/src/cljs/knoxx/backend/domain/agent/turn_guards.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/agent/turn_guards.cljs
@@ -1,7 +1,7 @@
 (ns knoxx.backend.domain.agent.turn-guards
-  "Delegates to the contract-runtime agent turn-guards module.
+  "Delegates to the katamorph agent turn-guards module.
    Re-exports all public vars for backward compatibility."
-  (:require [open-hax.contract-runtime.agent.turn-guards :as core]))
+  (:require [katamorph.agent.turn-guards :as core]))
 
 (def default-death-spiral-streak-limit core/default-death-spiral-streak-limit)
 (def default-death-spiral-total-limit core/default-death-spiral-total-limit)

--- a/backend/src/cljs/knoxx/backend/domain/condition/registry.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/condition/registry.cljs
@@ -1,7 +1,7 @@
 (ns knoxx.backend.domain.condition.registry
-  "Delegates to the contract-runtime condition registry.
+  "Delegates to the katamorph condition registry.
    Re-exports all public vars for backward compatibility."
-  (:require [open-hax.contract-runtime.condition.registry :as core]))
+  (:require [katamorph.condition.registry :as core]))
 
 (def register-condition! core/register-condition!)
 (def condition-fn core/condition-fn)

--- a/backend/src/cljs/knoxx/backend/domain/driver/registry.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/driver/registry.cljs
@@ -1,8 +1,8 @@
 (ns knoxx.backend.domain.driver.registry
-  "Delegates to the contract-runtime driver registry.
+  "Delegates to the katamorph driver registry.
    Re-exports all public vars for backward compatibility.
-   Protocol and record types must be used from open-hax.contract-runtime.driver.registry."
-  (:require [open-hax.contract-runtime.driver.registry :as core]))
+   Protocol and record types must be used from katamorph.driver.registry."
+  (:require [katamorph.driver.registry :as core]))
 
 ;; Protocol functions
 (def driver-id core/driver-id)

--- a/backend/src/cljs/knoxx/backend/domain/filter/registry.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/filter/registry.cljs
@@ -1,7 +1,7 @@
 (ns knoxx.backend.domain.filter.registry
-  "Delegates to the contract-runtime filter registry.
+  "Delegates to the katamorph filter registry.
    Re-exports all public vars for backward compatibility."
-  (:require [open-hax.contract-runtime.filter.registry :as core]))
+  (:require [katamorph.filter.registry :as core]))
 
 (def register-filter! core/register-filter!)
 (def filter-fn core/filter-fn)

--- a/backend/src/cljs/knoxx/backend/domain/registry/resource.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/registry/resource.cljs
@@ -1,13 +1,13 @@
 (ns knoxx.backend.domain.registry.resource
-  "Generic registry protocol: delegates to the contract-runtime resource registry.
+  "Generic registry protocol: delegates to the katamorph resource registry.
 
    This is a thin wrapper that provides backward compatibility for existing
    Knoxx callers. The actual implementation lives in the extracted
-   contract-runtime package.
+   katamorph package.
 
    The config map must contain :contract-runtime/deps (see
    knoxx.backend.contract-runtime-deps/build-deps)."
-  (:require [open-hax.contract-runtime.registry.resource :as core-registry]))
+  (:require [katamorph.registry.resource :as core-registry]))
 
 (def registry-id core-registry/registry-id)
 (def registry-resource-kind core-registry/registry-resource-kind)

--- a/backend/src/cljs/knoxx/backend/domain/resources/namespace_file.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/resources/namespace_file.cljs
@@ -1,7 +1,7 @@
 (ns knoxx.backend.domain.resources.namespace-file
-  "Delegates to the contract-runtime manifest module.
+  "Delegates to the katamorph manifest module.
    Re-exports all public vars for backward compatibility."
-  (:require [open-hax.contract-runtime.manifest :as core]))
+  (:require [katamorph.manifest :as core]))
 
 (def kind-id-keys core/kind-id-keys)
 (def kind->id-key core/kind->id-key)

--- a/backend/src/cljs/knoxx/backend/infra/store/memory.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/store/memory.cljs
@@ -1,6 +1,6 @@
 (ns knoxx.backend.infra.store.memory
-  "Delegates to the contract-runtime store memory module.
+  "Delegates to the katamorph store memory module.
    Re-exports all public vars for backward compatibility."
-  (:require [open-hax.contract-runtime.store.memory :as core]))
+  (:require [katamorph.store.memory :as core]))
 
 (def memory-collection core/memory-collection)

--- a/backend/src/cljs/knoxx/backend/infra/store/mongo.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/store/mongo.cljs
@@ -5,9 +5,9 @@
    knoxx.backend.extern.mongo) — Knoxx does not own a Mongo client; whatever
    runtime provides the handle decides connection lifecycle. Documents are
    schema-guarded before they cross the boundary."
-  (:require [knoxx.backend.extern.mongo :as mongo-extern]
+  (:require [katamorph.store.law :as store-law]
             [katamorph.store.protocol :as store]
-            [katamorph.store.law :as store-law]))
+            [knoxx.backend.extern.mongo :as mongo-extern]))
 
 (defrecord MongoCollection [store-id guard collection-handle]
   store/IStore

--- a/backend/src/cljs/knoxx/backend/infra/store/mongo.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/store/mongo.cljs
@@ -6,8 +6,8 @@
    runtime provides the handle decides connection lifecycle. Documents are
    schema-guarded before they cross the boundary."
   (:require [knoxx.backend.extern.mongo :as mongo-extern]
-            [open-hax.contract-runtime.store.protocol :as store]
-            [open-hax.contract-runtime.store.law :as store-law]))
+            [katamorph.store.protocol :as store]
+            [katamorph.store.law :as store-law]))
 
 (defrecord MongoCollection [store-id guard collection-handle]
   store/IStore

--- a/backend/src/cljs/knoxx/backend/infra/store/protocol.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/store/protocol.cljs
@@ -1,13 +1,13 @@
 (ns knoxx.backend.infra.store.protocol
-  "Delegates to the contract-runtime store protocol.
+  "Delegates to the katamorph store protocol.
    Re-exports all public vars for backward compatibility."
-  (:require [open-hax.contract-runtime.store.protocol :as core]))
+  (:require [katamorph.store.protocol :as core]))
 
 ;; Re-export the protocol functions
 (def insert! core/insert!)
 (def find-docs core/find-docs)
 
-;; The IStore protocol is defined in open-hax.contract-runtime.store.protocol
+;; The IStore protocol is defined in katamorph.store.protocol
 ;; and should be used directly from there. This namespace provides backward
 ;; compatibility for callers that use the old namespace.
-;; For protocol implementation, use: open-hax.contract-runtime.store.protocol/IStore
+;; For protocol implementation, use: katamorph.store.protocol/IStore

--- a/backend/src/cljs/knoxx/backend/infra/store/registry.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/store/registry.cljs
@@ -1,13 +1,13 @@
 (ns knoxx.backend.infra.store.registry
-  "Store registry: delegates to the contract-runtime store registry.
+  "Store registry: delegates to the katamorph store registry.
 
    This is a thin wrapper that provides backward compatibility for existing
    Knoxx callers. The actual implementation lives in the extracted
-   contract-runtime package.
+   katamorph package.
 
    The config map must contain :contract-runtime/deps (see
    knoxx.backend.contract-runtime-deps/build-deps)."
-  (:require [open-hax.contract-runtime.store.registry :as core-registry]))
+  (:require [katamorph.store.registry :as core-registry]))
 
 (defn register-store!
   "Register a store instance under its qualified id. Returns the store."

--- a/backend/src/cljs/knoxx/backend/law/store.cljs
+++ b/backend/src/cljs/knoxx/backend/law/store.cljs
@@ -1,6 +1,6 @@
 (ns knoxx.backend.law.store
-  "Delegates to the contract-runtime store law module.
+  "Delegates to the katamorph store law module.
    Re-exports all public vars for backward compatibility."
-  (:require [open-hax.contract-runtime.store.law :as core]))
+  (:require [katamorph.store.law :as core]))
 
 (def compile-schema-guard core/compile-schema-guard)

--- a/backend/src/cljs/knoxx/backend/law/url.cljs
+++ b/backend/src/cljs/knoxx/backend/law/url.cljs
@@ -1,7 +1,7 @@
 (ns knoxx.backend.law.url
-  "Delegates to the contract-runtime law url module.
+  "Delegates to the katamorph law url module.
    Re-exports all public vars for backward compatibility."
-  (:require [open-hax.contract-runtime.law.url :as core]))
+  (:require [katamorph.law.url :as core]))
 
 (def looks-like-url? core/looks-like-url?)
 (def media-url? core/media-url?)

--- a/backend/test/clj/knoxx/mutation_test_test.clj
+++ b/backend/test/clj/knoxx/mutation_test_test.clj
@@ -42,26 +42,34 @@
     (is (str/includes? mutated "(if (not (= x 1)) (+ x 1) false)"))
     (is (str/includes? mutated "(ns demo.core)"))))
 
-(deftest emit-mutant-source-creates-shadow-overlay-path
+(deftest with-mutated-source-mutates-in-place-then-restores
   (let [tmp-dir (.toFile (java.nio.file.Files/createTempDirectory "knoxx-mutation-test" (make-array java.nio.file.attribute.FileAttribute 0)))
         src-dir (io/file tmp-dir "src/cljs")
         source-file (io/file src-dir "demo/core.cljs")
-        output-dir (io/file tmp-dir "target/mutation")
-        source "(ns demo.core)\n(defn f [x] (if (= x 1) true false))\n"]
+        source "(ns demo.core)\n(defn f [x] (if (= x 1) true false))\n"
+        opts {:src-dir (.getPath src-dir)}]
     (try
       (.mkdirs (.getParentFile source-file))
       (spit source-file source)
       (let [mutant (->> (mutation/discover-mutants {:src-dir (.getPath src-dir)
                                                     :include-regex "demo/core.cljs$"
-                                                    :limit 1})
+                                                    :limit 0})
+                        (filter #(= :if-test-negation (:operator %)))
                         first)
-            emitted (mutation/emit-mutant-source! {:src-dir (.getPath src-dir)
-                                                   :output-dir (.getPath output-dir)}
-                                                  mutant)]
-        (is (.exists (io/file (:overlay-path emitted))))
-        (is (str/ends-with? (:overlay-path emitted) "target/mutation/mutants/m0001/src/cljs/demo/core.cljs"))
-        (is (= ["target/mutation/mutants/m0001/src/cljs" "src/cljs" "test/cljs"]
-               (:source-paths (mutation/shadow-config-merge emitted)))))
+            during (atom nil)]
+        (is (= (.getPath source-file)
+               (.getPath (mutation/mutant-source-path opts mutant))))
+
+        ;; The mutant is only in the tracked file while the body runs.
+        (mutation/with-mutated-source! opts mutant #(reset! during (slurp source-file)))
+        (is (str/includes? @during "(not (= x 1))"))
+        (is (= source (slurp source-file)))
+
+        ;; A throwing body must still restore, or the run leaves the tree dirty.
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (mutation/with-mutated-source! opts mutant
+                       #(throw (ex-info "boom" {})))))
+        (is (= source (slurp source-file))))
       (finally
         (doseq [f (reverse (file-seq tmp-dir))]
           (.delete f))))))

--- a/backend/test/cljs/knoxx/backend/infra/store_test.cljs
+++ b/backend/test/cljs/knoxx/backend/infra/store_test.cljs
@@ -2,12 +2,12 @@
   "Tests for the IStore protocol: schema guard, memory backend, registry, and
    the MongoCollection record against a stubbed collection handle."
   (:require [cljs.test :refer [deftest is testing]]
+            [katamorph.store.law :as store-law]
+            [knoxx.backend.domain.resources.loader :as resources]
             [knoxx.backend.infra.store.memory :as memory]
             [knoxx.backend.infra.store.mongo :as mongo]
             [knoxx.backend.infra.store.protocol :as store]
-            [knoxx.backend.infra.store.registry :as store-registry]
-            [knoxx.backend.domain.resources.loader :as resources]
-            [katamorph.store.law :as store-law]))
+            [knoxx.backend.infra.store.registry :as store-registry]))
 
 (defn- build-test-deps
   "Build contract-runtime deps for tests."

--- a/backend/test/cljs/knoxx/backend/infra/store_test.cljs
+++ b/backend/test/cljs/knoxx/backend/infra/store_test.cljs
@@ -7,7 +7,7 @@
             [knoxx.backend.infra.store.protocol :as store]
             [knoxx.backend.infra.store.registry :as store-registry]
             [knoxx.backend.domain.resources.loader :as resources]
-            [open-hax.contract-runtime.store.law :as store-law]))
+            [katamorph.store.law :as store-law]))
 
 (defn- build-test-deps
   "Build contract-runtime deps for tests."

--- a/shared/deps.edn
+++ b/shared/deps.edn
@@ -1,0 +1,5 @@
+{;; Shared ClojureScript (open-hax.uxx.*) consumed by the backend and frontend
+ ;; builds. The backend resolves this directory as a :local/root lib from
+ ;; backend/deps.edn; the frontend still reads ../shared/src/cljs directly as a
+ ;; shadow-cljs :source-paths entry.
+ :paths ["src/cljs"]}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated backend and shared build configuration to support ClojureScript development and testing.
  * Added a dedicated Katamorph dependency configuration while preserving the existing mutation setup.
  * Pinned the Katamorph version for consistent builds.
* **Refactor**
  * Migrated internal runtime integrations to Katamorph while preserving existing compatibility layers and public behavior.
  * Retained existing store, registry, agent, and action functionality without user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->