### PR TITLE
Provision repeatable development admin login

### DIFF
--- a/backend/scripts/smoke_test.sh
+++ b/backend/scripts/smoke_test.sh
@@ -48,7 +48,7 @@ request() {
   local -a args=(-sS -o "$out" -w '%{http_code}' -X "$method" "$url" -H 'Accept: application/json')
 
   if [[ -n "$API_KEY" ]]; then
-    args+=(-H "X-API-Key: $API_KEY")
+    args+=(-H "X-API-Key: $API_KEY" -H "Authorization: Bearer $API_KEY")
   fi
 
   if [[ -n "$body" ]]; then

--- a/backend/src/cljs/knoxx/backend/bootstrap.cljs
+++ b/backend/src/cljs/knoxx/backend/bootstrap.cljs
@@ -81,6 +81,7 @@
        :primaryOrgKind (env "KNOXX_PRIMARY_ORG_KIND" "platform_owner")
        :bootstrapSystemAdminEmail (env "KNOXX_BOOTSTRAP_SYSTEM_ADMIN_EMAIL" "system-admin@open-hax.local")
        :bootstrapSystemAdminName (env "KNOXX_BOOTSTRAP_SYSTEM_ADMIN_NAME" "Knoxx System Admin")
+       :bootstrapSystemAdminPassword (env "KNOXX_BOOTSTRAP_SYSTEM_ADMIN_PASSWORD" "")
        :bootstrapAllowlistEmails (env "KNOXX_BOOTSTRAP_ALLOWLIST_EMAILS" "")
        :bootstrapAllowlistRoleSlugs (env "KNOXX_BOOTSTRAP_ALLOWLIST_ROLE_SLUGS" "")})
 

--- a/backend/src/cljs/knoxx/backend/extern/crypto.cljs
+++ b/backend/src/cljs/knoxx/backend/extern/crypto.cljs
@@ -1,0 +1,19 @@
+(ns knoxx.backend.extern.crypto
+  "Node crypto boundary for Knoxx-owned hashing and comparison operations."
+  (:require ["node:crypto" :as crypto]))
+
+(defn random-hex
+  [byte-count]
+  (.toString (.randomBytes crypto byte-count) "hex"))
+
+(defn scrypt-hex
+  [value salt byte-count]
+  (.toString (.scryptSync crypto (str value) (str salt) byte-count) "hex"))
+
+(defn secure-hex=
+  [expected actual]
+  (let [expected-buffer (.from js/Buffer (str expected) "hex")
+        actual-buffer (.from js/Buffer (str actual) "hex")]
+    (and (pos? (.-length expected-buffer))
+         (= (.-length expected-buffer) (.-length actual-buffer))
+         (.timingSafeEqual crypto expected-buffer actual-buffer))))

--- a/backend/src/cljs/knoxx/backend/infra/auth/password.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/auth/password.cljs
@@ -1,0 +1,22 @@
+(ns knoxx.backend.infra.auth.password
+  "Password credential encoding and verification for Knoxx-owned local auth."
+  (:require [knoxx.backend.extern.crypto :as crypto]))
+
+(defn hash-password
+  [password]
+  (let [salt (crypto/random-hex 16)
+        hash (crypto/scrypt-hex password salt 64)]
+    {:algorithm "scrypt"
+     :salt salt
+     :hash hash}))
+
+(defn valid-password?
+  [password secret]
+  (let [salt (:salt secret)
+        expected (:hash secret)]
+    (and (= "scrypt" (:algorithm secret))
+         (string? salt)
+         (boolean (re-matches #"[0-9a-f]{32}" salt))
+         (string? expected)
+         (boolean (re-matches #"[0-9a-f]{128}" expected))
+         (crypto/secure-hex= expected (crypto/scrypt-hex password salt 64)))))

--- a/backend/src/cljs/knoxx/backend/infra/db/policy.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/db/policy.cljs
@@ -13,6 +13,7 @@
    so existing callers that pass (context-pool ctx) into policy functions need
    not change. The pool first arg on policy functions is ignored."
   (:require [clojure.string :as str]
+            [knoxx.backend.infra.auth.password :as password]
             [knoxx.backend.infra.mongo-client :as mongo-client]
             [knoxx.backend.infra.stores.mongo-policy-store :as mongo-policy]
             [knoxx.backend.infra.stores.mongo-policy-directory :as mongo-directory]
@@ -669,6 +670,30 @@
                                                          :replace true}))
     (await (set-membership-actor-id! pool (:id membership) "system_admin"))
     {:user user :membership membership}))
+
+(defn ^:async ensure-bootstrap-local-password!
+  "Idempotently project the environment-owned bootstrap password into the
+   local credential store. Blank passwords leave local login unprovisioned."
+  ([db primary-org bootstrap opts]
+   (ensure-bootstrap-local-password!
+    db primary-org bootstrap opts
+    {:encode-password password/hash-password
+     :upsert-credential! mongo-actor-creds/upsert-actor-credential!}))
+  ([db primary-org bootstrap opts {:keys [encode-password upsert-credential!]}]
+   (let [configured-password (some-> (or (:bootstrapSystemAdminPassword opts)
+                                         (:bootstrap-system-admin-password opts))
+                                     str not-empty)]
+     (when configured-password
+       (await (upsert-credential!
+               db
+               (get-in bootstrap [:user :id])
+               (:id primary-org)
+               "local"
+               {:kind "password"
+                :account-identifier (get-in bootstrap [:user :email])
+                :secret-json (encode-password configured-password)
+                :status "active"})))
+     nil)))
 
 ;; ---------------------------------------------------------------------------
 ;; Audit
@@ -1437,6 +1462,7 @@
     (let [primary-org (await (ensure-primary-org! nil opts))]
       (await (sync-contract-role-projections! nil))
       (let [bootstrap (await (ensure-bootstrap-user! nil primary-org opts))]
+        (await (ensure-bootstrap-local-password! db primary-org bootstrap opts))
         (await (allowlist-best-effort! nil primary-org opts))
         (await (sync-actor-contracts-best-effort! nil primary-org))
         (await (cleanup-expired-sessions-best-effort! nil))

--- a/backend/src/cljs/knoxx/backend/infra/db/policy.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/db/policy.cljs
@@ -673,26 +673,29 @@
 
 (defn ^:async ensure-bootstrap-local-password!
   "Idempotently project the environment-owned bootstrap password into the
-   local credential store. Blank passwords leave local login unprovisioned."
+   local credential store. Blank passwords revoke any previously provisioned
+   local bootstrap credential."
   ([db primary-org bootstrap opts]
    (ensure-bootstrap-local-password!
     db primary-org bootstrap opts
-    {:encode-password password/hash-password
+    {:deactivate-credential! mongo-actor-creds/deactivate-actor-credential!
+     :encode-password password/hash-password
      :upsert-credential! mongo-actor-creds/upsert-actor-credential!}))
-  ([db primary-org bootstrap opts {:keys [encode-password upsert-credential!]}]
+  ([db primary-org bootstrap opts
+    {:keys [deactivate-credential! encode-password upsert-credential!]}]
    (let [configured-password (some-> (or (:bootstrapSystemAdminPassword opts)
                                          (:bootstrap-system-admin-password opts))
-                                     str not-empty)]
-     (when configured-password
+                                     str not-empty)
+         user-id (get-in bootstrap [:user :id])
+         org-id (:id primary-org)]
+     (if configured-password
        (await (upsert-credential!
-               db
-               (get-in bootstrap [:user :id])
-               (:id primary-org)
-               "local"
+               db user-id org-id "local"
                {:kind "password"
                 :account-identifier (get-in bootstrap [:user :email])
                 :secret-json (encode-password configured-password)
-                :status "active"})))
+                :status "active"}))
+       (await (deactivate-credential! db user-id org-id "local" "password")))
      nil)))
 
 ;; ---------------------------------------------------------------------------

--- a/backend/src/cljs/knoxx/backend/infra/routes/auth.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/auth.cljs
@@ -1,9 +1,9 @@
 (ns knoxx.backend.infra.routes.auth
   (:require [clojure.string :as str]
             [knoxx.backend.infra.auth.authz :as authz]
+            [knoxx.backend.infra.auth.password :as password]
             [knoxx.backend.infra.auth.session :as auth-session]
-            [knoxx.backend.infra.db.policy :as policy-db]
-            ["node:crypto" :as crypto]))
+            [knoxx.backend.infra.db.policy :as policy-db]))
 
 (defn- body-map
   [req]
@@ -41,26 +41,6 @@
       (str proto "://" host)
       configured-base-url)))
 
-(defn- password-hash
-  [password]
-  (let [salt (.toString (.randomBytes crypto 16) "hex")
-        hash (.toString (.scryptSync crypto (str password) salt 64) "hex")]
-    {:algorithm "scrypt"
-     :salt salt
-     :hash hash}))
-
-(defn- verify-password?
-  [password secret-json]
-  (try
-    (let [salt (:salt secret-json)
-          expected (:hash secret-json)
-          expected-buf (.from js/Buffer (str expected) "hex")
-          actual-buf (.scryptSync crypto (str password) (str salt) (.-length expected-buf))]
-      (and (= "scrypt" (:algorithm secret-json))
-           (pos? (.-length expected-buf))
-           (.timingSafeEqual crypto expected-buf actual-buf)))
-    (catch :default _ false)))
-
 (defn- password-too-short?
   [password]
   (< (count (str password)) 8))
@@ -74,7 +54,7 @@
            :provider "local"
            :kind "password"
            :account-identifier (get-in ctx [:user :email])
-           :secret-json (password-hash password)
+           :secret-json (password/hash-password password)
            :status "active"})))
 
 (defn- register-auth-config-route!
@@ -155,7 +135,7 @@
 
         :else
         (let [auth-record (await (policy-db/local-password-auth-record-for-context! policy-context email))]
-          (if-not (verify-password? password (:secret-json auth-record))
+          (if-not (password/valid-password? password (:secret-json auth-record))
             (.send (.code reply 401) (clj->js {:error "Invalid username or password"}))
             (let [ctx (await (policy-db/resolve-context!
                               policy-context

--- a/backend/src/cljs/knoxx/backend/infra/stores/mongo_policy_actor_credentials.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/stores/mongo_policy_actor_credentials.cljs
@@ -291,3 +291,18 @@
                                                       "provider" (str provider)
                                                       "kind" (str kind)})))]
        (credential-doc->row doc)))))
+
+(defn ^:async deactivate-actor-credential!
+  "Deactivate an existing credential tuple without creating one when absent."
+  ([user-id org-id provider kind]
+   (deactivate-actor-credential! (mongo-client/get-db) user-id org-id provider kind))
+  ([db user-id org-id provider kind]
+   (await (.updateOne (credentials-coll db)
+                      #js {"user_id" (str user-id)
+                           "org_id" (str org-id)
+                           "provider" (str provider)
+                           "kind" (str kind)}
+                      #js {"$set" #js {"status" "inactive"
+                                       "updated_at" (js/Date.)
+                                       "system_instance_id" (system-instance/current-id)}}))
+   nil))

--- a/backend/test/cljs/knoxx/backend/extern_crypto_test.cljs
+++ b/backend/test/cljs/knoxx/backend/extern_crypto_test.cljs
@@ -1,0 +1,12 @@
+(ns knoxx.backend.extern-crypto-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [knoxx.backend.extern.crypto :as crypto]))
+
+(deftest crypto-boundary-produces-and-compares-hex-data
+  (let [salt (crypto/random-hex 16)
+        hash (crypto/scrypt-hex "password" salt 64)]
+    (testing "native buffers remain behind a scalar CLJS-facing API"
+      (is (= 32 (count salt)))
+      (is (= 128 (count hash)))
+      (is (crypto/secure-hex= hash hash))
+      (is (not (crypto/secure-hex= hash (crypto/scrypt-hex "wrong" salt 64)))))))

--- a/backend/test/cljs/knoxx/backend/infra/auth/password_test.cljs
+++ b/backend/test/cljs/knoxx/backend/infra/auth/password_test.cljs
@@ -1,0 +1,17 @@
+(ns knoxx.backend.infra.auth.password-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [knoxx.backend.infra.auth.password :as password]))
+
+(deftest password-secret-round-trip-test
+  (let [secret (password/hash-password "correct horse battery staple")]
+    (testing "the encoded credential names its algorithm and verifies only the source password"
+      (is (= "scrypt" (:algorithm secret)))
+      (is (password/valid-password? "correct horse battery staple" secret))
+      (is (false? (password/valid-password? "wrong password" secret))))
+    (testing "each encoding receives a fresh salt"
+      (is (not= (:salt secret)
+                (:salt (password/hash-password "correct horse battery staple")))))))
+
+(deftest malformed-password-secret-fails-closed-test
+  (is (false? (password/valid-password? "password" nil)))
+  (is (false? (password/valid-password? "password" {:algorithm "unknown"}))))

--- a/backend/test/cljs/knoxx/backend/infra/stores/mongo_policy_actor_credentials_test.cljs
+++ b/backend/test/cljs/knoxx/backend/infra/stores/mongo_policy_actor_credentials_test.cljs
@@ -108,6 +108,16 @@
             docs (js->clj (await (.toArray cursor)) :keywordize-keys true)]
         (is (= 1 (count docs)) "only one credential doc")))))
 
+(deftest ^:async deactivate-actor-credential-test
+  (testing "deactivation makes a previously active credential unavailable"
+    (let [db (mock-db)]
+      (await (creds/upsert-actor-credential!
+              db "u1" "o1" "local"
+              {:kind "password" :secret-json {:hash "secret"} :status "active"}))
+      (await (creds/deactivate-actor-credential! db "u1" "o1" "local" "password"))
+      (is (nil? (await (creds/get-credential-by-user-org-provider-kind!
+                        db "u1" "o1" "local" "password")))))))
+
 (deftest ^:async credential-doc->row-test
   (testing "credential-doc->row renames credential_id to :id and drops Mongo fields"
     (let [r (creds/credential-doc->row {:credential_id "c1" :_id "x" :user_id "u1"

--- a/backend/test/cljs/knoxx/backend/policy_db_credentials_test.cljs
+++ b/backend/test/cljs/knoxx/backend/policy_db_credentials_test.cljs
@@ -30,7 +30,9 @@
         org {:id "org-open-hax"}]
     (await (policy-db/ensure-bootstrap-local-password!
             #js {} org bootstrap {:bootstrapSystemAdminPassword "dev-password"}
-            {:encode-password (fn [value] {:encoded value})
+            {:deactivate-credential! (fn [& _]
+                                       (js/Promise.resolve nil))
+             :encode-password (fn [value] {:encoded value})
              :upsert-credential! (fn [_db user-id org-id provider payload]
                                    (reset! captured* [user-id org-id provider payload])
                                    (js/Promise.resolve nil))}))
@@ -41,12 +43,15 @@
              :status "active"}]
            @captured*))))
 
-(deftest ^:async blank-bootstrap-local-password-does-not-write-test
-  (let [called? (atom false)]
+(deftest ^:async blank-bootstrap-local-password-revokes-credential-test
+  (let [captured* (atom nil)]
     (await (policy-db/ensure-bootstrap-local-password!
             #js {} {:id "org"} {:user {:id "user"}} {:bootstrapSystemAdminPassword ""}
-            {:encode-password identity
+            {:deactivate-credential! (fn [_db user-id org-id provider kind]
+                                       (reset! captured* [user-id org-id provider kind])
+                                       (js/Promise.resolve nil))
+             :encode-password identity
              :upsert-credential! (fn [& _]
-                                   (reset! called? true)
+                                   (is false "blank password must not be upserted")
                                    (js/Promise.resolve nil))}))
-    (is (false? @called?))))
+    (is (= ["user" "org" "local" "password"] @captured*))))

--- a/backend/test/cljs/knoxx/backend/policy_db_credentials_test.cljs
+++ b/backend/test/cljs/knoxx/backend/policy_db_credentials_test.cljs
@@ -23,3 +23,30 @@
     (let [result (await (policy-db/list-actor-credentials! #js {} "discord_bot"))]
       (is (map? result) "result is a CLJS map")
       (is (vector? (:credentials result)) "credentials is a vector"))))
+
+(deftest ^:async bootstrap-local-password-projection-test
+  (let [captured* (atom nil)
+        bootstrap {:user {:id "user-admin" :email "admin@example.com"}}
+        org {:id "org-open-hax"}]
+    (await (policy-db/ensure-bootstrap-local-password!
+            #js {} org bootstrap {:bootstrapSystemAdminPassword "dev-password"}
+            {:encode-password (fn [value] {:encoded value})
+             :upsert-credential! (fn [_db user-id org-id provider payload]
+                                   (reset! captured* [user-id org-id provider payload])
+                                   (js/Promise.resolve nil))}))
+    (is (= ["user-admin" "org-open-hax" "local"
+            {:kind "password"
+             :account-identifier "admin@example.com"
+             :secret-json {:encoded "dev-password"}
+             :status "active"}]
+           @captured*))))
+
+(deftest ^:async blank-bootstrap-local-password-does-not-write-test
+  (let [called? (atom false)]
+    (await (policy-db/ensure-bootstrap-local-password!
+            #js {} {:id "org"} {:user {:id "user"}} {:bootstrapSystemAdminPassword ""}
+            {:encode-password identity
+             :upsert-credential! (fn [& _]
+                                   (reset! called? true)
+                                   (js/Promise.resolve nil))}))
+    (is (false? @called?))))

--- a/docs/auth-and-onboarding.md
+++ b/docs/auth-and-onboarding.md
@@ -117,6 +117,8 @@ On every backend start Knoxx ensures this user belongs to the primary org,
 replaces its role assignment with `system-admin`, assigns the `system_admin`
 actor, and upserts a scrypt password credential. Changing the environment
 password and restarting the development backend rotates the login password.
+Removing the password setting and restarting revokes the previously provisioned
+local credential.
 Ordinary `/signup` users remain `basic-user`; this bootstrap does not weaken
 self-signup or infer admin rights from arbitrary email/password logins.
 

--- a/docs/auth-and-onboarding.md
+++ b/docs/auth-and-onboarding.md
@@ -4,7 +4,8 @@
 
 Knoxx supports **GitHub OAuth** login with **cookie-backed sessions** stored in Redis. The system includes:
 
-- **Admin seed**: The `KNOXX_BOOTSTRAP_SYSTEM_ADMIN_EMAIL` user is automatically created as a system admin on first boot
+- **Admin seed**: The `KNOXX_BOOTSTRAP_SYSTEM_ADMIN_EMAIL` user is automatically created as a system admin on every boot
+- **Repeatable local admin login**: `KNOXX_BOOTSTRAP_SYSTEM_ADMIN_PASSWORD` idempotently provisions that admin's local password credential
 - **Invite system**: Admins can create invite codes that auto-provision users with org memberships
 - **GitHub OAuth**: "Continue with GitHub" button on the login page
 - **Cookie sessions**: Secure, HttpOnly, SameSite cookies with Redis-backed session storage
@@ -57,6 +58,7 @@ journalctl --user -u knoxx-tunnel -f    # Follow logs
 | `KNOXX_SESSION_TTL_SECONDS` | No | `86400` | Session cookie lifetime (24h default) |
 | `KNOXX_BOOTSTRAP_SYSTEM_ADMIN_EMAIL` | Yes | `system-admin@open-hax.local` | Email of the auto-seeded system admin |
 | `KNOXX_BOOTSTRAP_SYSTEM_ADMIN_NAME` | No | `Knoxx System Admin` | Display name for the bootstrap admin |
+| `KNOXX_BOOTSTRAP_SYSTEM_ADMIN_PASSWORD` | For local admin login | - | Password for the bootstrap admin; keep it in the uncommitted host environment |
 | `KNOXX_POLICY_DATABASE_URL` | Yes | - | PostgreSQL connection string |
 | `REDIS_URL` | Yes | `redis://127.0.0.1:6379` | Redis for session storage |
 | `GMAIL_APP_EMAIL` | For invite emails | - | Gmail address for sending invite emails |
@@ -99,6 +101,24 @@ A user can log in if they pass **any** of these checks:
 3. **Invite holder**: Has a pending invite (redeemed during login)
 
 If none match, the GitHub callback redirects to `/login?error=not_whitelisted` where the user can enter an invite code.
+
+## Repeatable local administrator
+
+For a development instance that needs a browser-login administrator without
+GitHub OAuth, define the identity and secret in the host environment:
+
+```bash
+KNOXX_BOOTSTRAP_SYSTEM_ADMIN_EMAIL=developer@example.com
+KNOXX_BOOTSTRAP_SYSTEM_ADMIN_NAME="Development Administrator"
+KNOXX_BOOTSTRAP_SYSTEM_ADMIN_PASSWORD=replace-with-a-long-random-secret
+```
+
+On every backend start Knoxx ensures this user belongs to the primary org,
+replaces its role assignment with `system-admin`, assigns the `system_admin`
+actor, and upserts a scrypt password credential. Changing the environment
+password and restarting the development backend rotates the login password.
+Ordinary `/signup` users remain `basic-user`; this bootstrap does not weaken
+self-signup or infer admin rights from arbitrary email/password logins.
 
 ## Setting Up GitHub OAuth
 

--- a/docs/development-vps.md
+++ b/docs/development-vps.md
@@ -1,0 +1,127 @@
+# Development VPS deployment
+
+This checkout has a source-based development instance alongside the existing
+containerized Knoxx deployment. The production containers are not restarted or
+modified by this setup.
+
+## Installed host prerequisites
+
+- Node.js 22.23.2 in `/usr/local`
+- pnpm 10.15.1 through Corepack
+- Clojure CLI 1.12.4.1582 in `/usr/local`
+- The root, `backend`, and `frontend` pnpm lockfiles installed independently
+- PM2 6.0.13 for the three long-running development processes
+
+Java 21 was already installed on the VPS.
+
+## Local development environment
+
+The ignored repository-root `.env` contains the development API key and public
+URL overrides. The same random credential protects `KNOXX_API_KEY`, the
+OpenAI-compatible `MODEL_LAB_OPENAI_API_KEY` boundary, and the repeatable local
+password login for the `pi@open-hax.local` bootstrap system administrator. It
+is intentionally not committed. Load the host's shared Knoxx configuration
+first, then the development overrides:
+
+```bash
+set -a
+source /home/err/.env
+source /home/err/spaces/knoxx/.env
+set +a
+```
+
+Retrieve the development API key locally when needed:
+
+```bash
+sed -n 's/^KNOXX_API_KEY=//p' /home/err/spaces/knoxx/.env
+```
+
+The frontend login credentials are:
+
+```text
+Email: pi@open-hax.local
+Password: the KNOXX_BOOTSTRAP_SYSTEM_ADMIN_PASSWORD value in .env
+```
+
+On backend startup this identity is repeatably assigned `system-admin` and its
+local password credential is upserted. Updating the environment value and
+restarting the development backend rotates the password.
+
+The key is a randomly generated 256-bit hexadecimal value. Never copy it into a
+tracked file.
+
+Knoxx links `@open-hax/openplanner-sdk` from the sibling OpenPlanner checkout.
+That dependency was installed at `/home/err/spaces/openplanner` and its
+`openplanner-document-hydration` and `openplanner-sdk` packages were built. No
+OpenPlanner source was changed.
+
+## Processes and ports
+
+Run the backend compiler, backend server, and frontend development server from
+three shells after loading the environment above:
+
+```bash
+pnpm -C backend run watch
+pnpm -C backend run start:dev
+pnpm -C frontend run dev
+```
+
+The source backend listens on `0.0.0.0:8000`; the source frontend listens on
+`:5173` and proxies `/api`, `/ws`, and `/health` to the backend. Caddy routes
+`https://knoxx-dev.promethean.rest` to the frontend through
+the `open-hax` Docker bridge gateway at `172.18.0.1:5173`.
+
+UFW permits TCP `5173` and `8000` only from the internal `172.18.0.0/16`
+Docker bridge so Caddy can reach the source frontend and direct backend routes.
+Neither development port is opened to the public internet.
+
+The frontend shadow-cljs server owns its default control port `9630`, so the
+backend shadow-cljs server selects `9631`. The ignored `.env` explicitly points
+the backend launcher at `http://127.0.0.1:9631` and allows four minutes for the
+initial cold compile.
+
+The processes are saved under PM2 as `knoxx-dev-shadow`,
+`knoxx-dev-backend`, and `knoxx-dev-frontend`. The `pm2-err` systemd unit is
+enabled so the saved process list is resurrected after a VPS reboot. Inspect
+them with:
+
+```bash
+pm2 status
+pm2 logs knoxx-dev-backend
+```
+
+The dev backend's saved PM2 environment reuses the deployed Knoxx container's
+Atlas MongoDB URI and Proxx authentication token. It overrides the deployed
+service's `openplanner` database name with `MONGODB_DB=knoxx_dev`, keeping the
+development policy, sessions, runs, and OpenPlanner SDK data isolated in a new
+database on the same Atlas cluster. Credentials are not written into this
+checkout. Recreate the process environment from the host service configuration
+if the deployed service rotates either credential.
+
+## DNS and ingress
+
+Cloudflare has an A record for `knoxx-dev.promethean.rest` pointing to the VPS
+public address `157.245.125.134`. Caddy terminates HTTPS and forwards this
+hostname to the development frontend. The Caddy configuration is owned by the
+host service layer at `/srv/open-hax/services/caddy/Caddyfile`, outside this
+repository.
+
+Validate the public route with:
+
+```bash
+curl --fail --show-error \
+  -H "X-API-Key: $KNOXX_API_KEY" \
+  https://knoxx-dev.promethean.rest/health
+```
+
+## Verification
+
+After dependency or backend changes, use the repository-required checks:
+
+```bash
+pnpm -C backend run typecheck
+pnpm -C backend exec shadow-cljs compile test
+pnpm -C frontend run typecheck
+pnpm -C frontend run test
+pnpm -C frontend run test:cljs
+```


### PR DESCRIPTION
## Summary

- add `KNOXX_BOOTSTRAP_SYSTEM_ADMIN_PASSWORD` so the configured bootstrap identity receives a repeatable local password credential and remains a system administrator
- share scrypt password hashing/verification behind a Knoxx-owned crypto boundary
- fix authenticated OpenAI-compatible smoke requests to send the Bearer credential expected by `/v1`
- document the development VPS, shared Atlas cluster with isolated `knoxx_dev` database, PM2 processes, Cloudflare/Caddy ingress, and secret handling

## Verification

- `pnpm -C backend typecheck` — 0 warnings
- `pnpm -C backend exec shadow-cljs compile test` — 800 tests, 2,358 assertions, 0 failures, 0 errors, 0 warnings
- `pnpm -C backend exec shadow-cljs compile server` — 0 warnings
- `node backend/scripts/check-js-boundary.mjs --check`
- `backend/scripts/smoke_test.sh https://knoxx-dev.promethean.rest`

The repository-wide error-boundary inventory still reports its pre-existing unallowlisted catch sites; this PR introduces none. The unrelated local `contracts/actors/foamy125_gmail_om.edn` file is intentionally excluded.
