### PR TITLE
ci: pin eta-mu evidence-first review workflow

### DIFF
--- a/.github/workflows/eta-mu-review.yml
+++ b/.github/workflows/eta-mu-review.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   review:
     name: Evidence-first review (eta-mu)
-    uses: open-hax/eta-mu/.github/workflows/opencode-code-review.yml@976d45fea52dcea97c63787f8b62b4c2f22a4838
+    uses: open-hax/eta-mu/.github/workflows/opencode-code-review.yml@a82ecf7e8ed2d770039424f0d88c38252bf58a0e
     with:
       setup_eta_mu_toolchain: false
       evidence_gates_script: |

--- a/.github/workflows/eta-mu-review.yml
+++ b/.github/workflows/eta-mu-review.yml
@@ -1,0 +1,15 @@
+name: eta-mu evidence review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  review:
+    name: Evidence-first review (eta-mu)
+    uses: open-hax/eta-mu/.github/workflows/opencode-code-review.yml@976d45fea52dcea97c63787f8b62b4c2f22a4838
+    with:
+      setup_eta_mu_toolchain: false
+      evidence_gates_script: |
+        run_gate diff_stat git diff --stat "${PR_BASE_SHA}...HEAD"
+    secrets: inherit

--- a/.github/workflows/eta-mu-review.yml
+++ b/.github/workflows/eta-mu-review.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   review:
     name: Evidence-first review (eta-mu)
-    uses: open-hax/eta-mu/.github/workflows/opencode-code-review.yml@a82ecf7e8ed2d770039424f0d88c38252bf58a0e
+    uses: open-hax/eta-mu/.github/workflows/opencode-code-review.yml@a7b65017cacc7624037318f79c05fb18d7e9f7cb
     with:
       setup_eta_mu_toolchain: false
       evidence_gates_script: |

--- a/.github/workflows/eta-mu-review.yml
+++ b/.github/workflows/eta-mu-review.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   review:
     name: Evidence-first review (eta-mu)
-    uses: open-hax/eta-mu/.github/workflows/opencode-code-review.yml@a7b65017cacc7624037318f79c05fb18d7e9f7cb
+    uses: open-hax/eta-mu/.github/workflows/opencode-code-review.yml@2cde056e6d0b97d2a5cb37d41b7901ffeacad76a
     with:
       setup_eta_mu_toolchain: false
       evidence_gates_script: |

--- a/.github/workflows/eta-mu-review.yml
+++ b/.github/workflows/eta-mu-review.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+# Reusable workflow calls run with `none` unless the caller grants scopes;
+# the called jobs request contents:read and pull-requests:read.
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   review:
     name: Evidence-first review (eta-mu)

--- a/.github/workflows/eta-mu-review.yml
+++ b/.github/workflows/eta-mu-review.yml
@@ -18,4 +18,8 @@ jobs:
       setup_eta_mu_toolchain: false
       evidence_gates_script: |
         run_gate diff_stat git diff --stat "${PR_BASE_SHA}...HEAD"
-    secrets: inherit
+    # Least privilege: forward only the secrets the review job consumes.
+    secrets:
+      ETA_MU_APP_ID: ${{ secrets.ETA_MU_APP_ID }}
+      ETA_MU_APP_PRIVATE_KEY: ${{ secrets.ETA_MU_APP_PRIVATE_KEY }}
+      DISCORD_REVIEW_WEBHOOK_URL: ${{ secrets.DISCORD_REVIEW_WEBHOOK_URL }}


### PR DESCRIPTION
Adopts the reusable evidence-first PR review workflow from open-hax/eta-mu, pinned to commit 2cde056e6d0b97d2a5cb37d41b7901ffeacad76a. The reviewer (eta-mu-ai) drives a tool-enforced state machine (review_begin → record_evidence → propose/classify findings → review_submit) and publishes one GitHub PR review per run. Requires org secrets ETA_MU_APP_ID / ETA_MU_APP_PRIVATE_KEY to be visible to this repo (explicit least-privilege secret mapping).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated pull request review checks for key pull request events.
  * Reviews compare proposed changes with the target branch and provide evidence-based feedback.
  * Checks use read-only access and follow configured repository security settings.
  * Pull requests receive consistent review results without requiring manual setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->