### PR TITLE
ci: repin eta-mu evidence review to hardened provider

### DIFF
--- a/.github/workflows/eta-mu-review.yml
+++ b/.github/workflows/eta-mu-review.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   review:
     name: Evidence-first review (eta-mu)
-    uses: open-hax/eta-mu/.github/workflows/opencode-code-review.yml@2cde056e6d0b97d2a5cb37d41b7901ffeacad76a
+    uses: open-hax/eta-mu/.github/workflows/opencode-code-review.yml@2b918cdab2ebd30e745bb8fa86d077d7a3af0030
     with:
       setup_eta_mu_toolchain: false
       evidence_gates_script: |


### PR DESCRIPTION
Repins the active eta-mu evidence-first PR review caller from `2cde056e6d0b97d2a5cb37d41b7901ffeacad76a` to reviewed eta-mu merge commit `2b918cdab2ebd30e745bb8fa86d077d7a3af0030`.

The provider repair landed in open-hax/eta-mu#292 after the Foresight rollout exposed that the old reusable-workflow commit still delegated to mutable nested GitHub Action tags. The new provider commit pins all nested action invocations by full commit SHA while preserving workflow behavior.

This PR changes only the reusable-workflow revision in `.github/workflows/eta-mu-review.yml`; permissions, deterministic `diff_stat` evidence gate, and explicit least-privilege secret mapping remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated code review workflow to use a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->