### PR TITLE
feat(knoxx): declare PublicationArtifact and validate at the effect boundary

### DIFF
--- a/backend/src/cljs/knoxx/backend/infra/publication_effects.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/publication_effects.cljs
@@ -8,9 +8,13 @@
   storage are interchangeable implementations of one protocol; no
   adapter-specific identifier crosses upward, and no adapter is named here.
 
-  Both directions are validated. The plan is checked before any effect runs, and
-  the adapter's return value is checked before a caller reads fields off it — an
-  adapter is replaceable, so its output is untrusted input."
+  Both directions are validated. The plan and the artifact are checked before any
+  effect runs, and the adapter's return value is checked before a caller reads
+  fields off it — an adapter is replaceable, so its output is untrusted input.
+
+  The artifact is produced ABOVE this boundary: `execute-plan!` receives one, and
+  no protocol method below returns or constructs one. `law.publication`'s
+  `PublicationArtifact` docstring records why, and a test pins it."
   (:require [clojure.string :as str]
             [malli.core :as m]
             [knoxx.backend.law.publication-receipts :as law]))
@@ -148,16 +152,24 @@
 ;; ── Plan execution ─────────────────────────────────────────────────────────
 
 (defn- ^:async execute-publish!
+  "Validate the artifact, then publish under a reservation.
+
+   The artifact is checked BEFORE the key is derived and before the store is
+   touched. Reserved first and validated after, a refusal leaves a claim nobody
+   will ever complete: the next attempt reads `:in-flight` and has to go observe
+   a target where nothing was written, to learn what was already decided here."
   [store target ctx plan artifact]
   (let [intent (:intent plan)
+        concrete-revision (:concrete-revision plan)
+        checked (law/assert-artifact! artifact concrete-revision)
         idempotency-key (publish-idempotency-key (target-id target)
                                                  intent
-                                                 (:concrete-revision plan))]
+                                                 concrete-revision)]
     (await (publish-once! store target ctx
                           {:intent intent
-                           :artifact artifact
+                           :artifact checked
                            :previous (:previous plan)
-                           :concrete-revision (:concrete-revision plan)
+                           :concrete-revision concrete-revision
                            :idempotency/key idempotency-key}))))
 
 (defn- ^:async dispatch-plan!
@@ -181,17 +193,27 @@
     (throw (ex-info "unrecognized publication plan op" {:op (:op plan)}))))
 
 (defn- failure-receipt
+  "Every refusal becomes a receipt, and a *typed* refusal keeps its evidence.
+
+   An artifact-revision conflict is the one failure where the reader has to know
+   which side was stale, so both revisions are copied onto the receipt rather
+   than left inside the message string — `:failure/reason` alone cannot be read
+   by anything but a human."
   [target plan err]
-  (law/assert-receipt!
-   (cond-> {:receipt/type :publication/failed
-            :failure/reason (or (not-empty (str (ex-message err))) "unknown failure")
-            :failure/drift? true}
-     (= :publish (:op plan))
-     (assoc :idempotency/key
-            (try (publish-idempotency-key (target-id target)
-                                          (:intent plan)
-                                          (:concrete-revision plan))
-                 (catch :default _ nil))))))
+  (let [evidence (ex-data err)]
+    (law/assert-receipt!
+     (cond-> {:receipt/type :publication/failed
+              :failure/reason (or (not-empty (str (ex-message err))) "unknown failure")
+              :failure/drift? true}
+       (= :publish (:op plan))
+       (assoc :idempotency/key
+              (try (publish-idempotency-key (target-id target)
+                                            (:intent plan)
+                                            (:concrete-revision plan))
+                   (catch :default _ nil)))
+
+       (law/artifact-revision-conflict? evidence)
+       (assoc :failure/conflict evidence)))))
 
 (defn ^:async execute-plan!
   "Execute a validated plan and return a validated receipt.

--- a/backend/src/cljs/knoxx/backend/infra/publication_target_memory.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/publication_target_memory.cljs
@@ -9,7 +9,8 @@
   publication would be *observable* rather than assumed away. The store honours
   the same atomic reservation contract production must: a single swap claims the
   key, with no await between reading it and claiming it."
-  (:require [knoxx.backend.infra.publication-effects :as effects]))
+  (:require [knoxx.backend.infra.publication-effects :as effects]
+            [knoxx.backend.law.publication-receipts :as law]))
 
 (defn memory-store
   []
@@ -55,6 +56,22 @@
        (filter #(= (:publication/id %) (:publication/id intent)))
        first))
 
+(defn- assert-publishable!
+  "An adapter validates what it is handed rather than trusting its caller.
+
+   `publish!` is a protocol method, reachable without going through
+   `execute-plan!`, so the boundary's check is not this adapter's check. Storing
+   the artifact unexamined is what made a malformed one invisible: it became a
+   *served* route while every assertion about the materialization — all of which
+   read receipt metadata — stayed green. A test double that accepts anything
+   proves the seam against a payload no real adapter could write.
+
+   Deliberately the same `law` call the boundary makes, not a looser copy: an
+   adapter that admitted more than the boundary would be the one place a
+   contradiction could live."
+  [op]
+  (law/assert-artifact! (:artifact op) (:concrete-revision op)))
+
 (defn- record-route!
   "Materialize `op`, replacing the prior route rather than leaving it public
    alongside the new one.
@@ -64,14 +81,25 @@
    dropped on the floor: a caller could corrupt or omit the published body and
    every assertion about the materialization still passed, because they all read
    receipt metadata. The returned receipt is unchanged — an artifact is content,
-   not evidence, and receipts carry evidence."
-  [routes adapter-id op]
+   not evidence, and receipts carry evidence.
+
+   The artifact is stored EXACTLY as handed over. This adapter transports; it
+   does not render, re-encode, or fill anything in.
+
+   `publish-count` is bumped here rather than at the call site so both pieces of
+   evidence that a materialization happened — the route and the count — are owned
+   by the one function that can only reach them after the artifact was accepted.
+   Counted before validation, a refused artifact reads as a materialization that
+   occurred, which is the exact claim this adapter exists to make checkable."
+  [routes publish-count adapter-id op]
+  (assert-publishable! op)
   (let [receipt (materialization adapter-id op)]
     (swap! routes (fn [current]
                     (-> current
                         (dissoc (get-in op [:previous :materialized/path]))
                         (assoc (:materialized/path receipt)
                                (assoc receipt :route/artifact (:artifact op))))))
+    (swap! publish-count inc)
     receipt))
 
 (defn memory-target
@@ -91,8 +119,7 @@
         (publish! [_ _ctx op]
           (when fail?
             (throw (ex-info "memory target publish failed" {})))
-          (swap! publish-count inc)
-          (js/Promise.resolve (record-route! routes id op)))
+          (js/Promise.resolve (record-route! routes publish-count id op)))
         (remove! [_ _ctx intent observed]
           (swap! routes dissoc (:materialized/path observed))
           ;; `:publication/id` is what `observed-for` filters on. Without it the

--- a/backend/src/cljs/knoxx/backend/law/publication.cljs
+++ b/backend/src/cljs/knoxx/backend/law/publication.cljs
@@ -231,3 +231,151 @@
         (= :active
            (:garden/status
             (get-in resource-index [:gardens (:publication/garden intent)]))))))
+
+;; ── The materialized artifact ──────────────────────────────────────────────
+
+(defn artifact-bytes?
+  "Bytes as this runtime spells them. A *predicate* over a value arriving from
+   above — not interop that decodes, encodes, or mutates anything — and the one
+   thing here with no portable spelling, so it is also why this namespace stays
+   `.cljs`. Non-empty, matching `nonblank-string?` on the string side: an
+   artifact carrying no content is not something to publish."
+  [value]
+  (and (instance? js/Uint8Array value)
+       (pos? (alength value))))
+
+(def ArtifactContent
+  "Bytes or a string. Both are content; the difference is only whether the
+   renderer already applied `:artifact/encoding` or left it to the adapter."
+  [:or NonBlankString [:fn artifact-bytes?]])
+
+(defn valid-media-type?
+  "`type/subtype`, with no parameters.
+
+   `text/html; charset=utf-8` is refused on purpose: the character encoding is
+   its own declared field, and accepting it in two places is accepting that the
+   two can disagree, after which nothing decides which one the adapter honours."
+  [value]
+  (boolean
+   (and (string? value)
+        (re-matches #"[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*"
+                    value))))
+
+(def MediaType
+  [:and string? [:fn valid-media-type?]])
+
+(defn valid-character-encoding?
+  "An IANA charset name (`utf-8`), declared rather than defaulted.
+
+   A static file server told nothing serves bytes and lets the reader guess, and
+   a guess that lands wrong corrupts exactly the accented text a translation
+   pipeline exists to deliver — only in the locales nobody proofreads."
+  [value]
+  (boolean
+   (and (string? value)
+        (re-matches #"[A-Za-z0-9][A-Za-z0-9._:+-]*" value))))
+
+(def CharacterEncoding
+  [:and string? [:fn valid-character-encoding?]])
+
+(def revision-selector-namespace
+  "The keyword namespace every revision *selector* lives in. Named as a
+   namespace rather than as the single member `:source/current`, so a sibling
+   selector cannot be introduced without inheriting the refusal below."
+  "source")
+
+(defn revision-selector?
+  [value]
+  (and (keyword? value)
+       (= revision-selector-namespace (namespace value))))
+
+(defn free-of-revision-selectors?
+  "No selector keyword anywhere in `value` — nested, and in map keys too.
+
+   Refused for the same reason `publish-idempotency-key` refuses one: a selector
+   gives a stable-looking identity to a moving target. `:artifact/revision` is
+   already `ConcreteRevision`, so this covers everything *else* an artifact may
+   carry — an extra key holding `:source/current` would otherwise reach an
+   adapter and be written beside the bytes as \"whatever is current\", forever."
+  [value]
+  (not-any? revision-selector? (tree-seq coll? seq value)))
+
+(def PublicationArtifact
+  "The bytes a publication materializes, plus everything an adapter needs to put
+   them somewhere without re-deciding anything.
+
+   Produced ABOVE the effect boundary. `infra.publication-effects/execute-plan!`
+   receives one as an argument; no `IPublicationTarget` method returns one and no
+   adapter constructs one. One renderer, adapters that only transport. The
+   rejected alternative — producing it below, each adapter rendering from the
+   intent it was handed — reads cheaper and is the shape that diverges: two
+   targets asked to publish the same intent at the same revision can then serve
+   different bytes, and nothing in the receipt chain can say which is right.
+   Pinned by `the-artifact-is-produced-above-the-effect-boundary`, not left as
+   prose.
+
+   `:artifact/revision` is the one field cross-checked against the op, by
+   `artifact-revision-conflict` below: it is the axis `publish-idempotency-key`
+   is built from, so a disagreement there is the difference between replay-safe
+   and republishing other content under a key that already reports `done`.
+   `:artifact/locale` is declared so an adapter can address bytes by locale
+   without re-deriving it from intent, and is deliberately *not* cross-checked
+   here — which locales a target accepts at all is a separate question, owned by
+   the locale-catalog resource rather than by this shape."
+  [:and
+   [:map
+    [:artifact/content ArtifactContent]
+    [:artifact/media-type MediaType]
+    [:artifact/encoding CharacterEncoding]
+    [:artifact/locale Locale]
+    [:artifact/revision ConcreteRevision]]
+   [:fn {:error/message "a publication artifact must carry no revision selector"}
+    free-of-revision-selectors?]])
+
+(def ArtifactRevisionConflict
+  "The renderer and the planner disagreeing about what is being published. Both
+   revisions are `:any` on purpose: this record exists to carry values that
+   FAILED the revision law, so typing them as `ConcreteRevision` would make the
+   evidence unrepresentable in its own contract."
+  [:map
+   [:conflict/type [:= :publication/artifact-revision-conflict]]
+   [:conflict/artifact-revision :any]
+   [:conflict/concrete-revision :any]])
+
+(defn artifact-revision-conflict
+  "nil when the artifact and the op agree about what is being published;
+   otherwise the typed conflict, carrying BOTH revisions.
+
+   A conflict rather than a warning, because there is no safe way to pick a
+   winner: the bytes were rendered from one source state and the idempotency key
+   names another, so publishing either way records a materialization that did
+   not happen."
+  [artifact concrete-revision]
+  (let [artifact-revision (:artifact/revision artifact)]
+    (when (not= artifact-revision concrete-revision)
+      {:conflict/type :publication/artifact-revision-conflict
+       :conflict/artifact-revision artifact-revision
+       :conflict/concrete-revision concrete-revision})))
+
+(defn artifact-revision-conflict?
+  "True when `value` is the record `artifact-revision-conflict` produces, so the
+   effect boundary can carry the conflict onto a receipt instead of flattening it
+   into a message string where both revisions would be lost."
+  [value]
+  (m/validate ArtifactRevisionConflict value))
+
+(defn assert-artifact!
+  "Return the artifact when it is publishable at `concrete-revision`; otherwise
+   throw.
+
+   Shape first, then agreement — a malformed artifact has no revision worth
+   comparing. Called above any effect, so nothing is reserved, written, or
+   recorded on behalf of a publication that cannot lawfully happen."
+  [artifact concrete-revision]
+  (assert-valid! :publication/artifact PublicationArtifact artifact)
+  (when-let [conflict (artifact-revision-conflict artifact concrete-revision)]
+    (throw
+     (ex-info (str "Publication artifact revision conflict: the artifact was "
+                   "rendered from a different source state than the plan publishes")
+              conflict)))
+  artifact)

--- a/backend/src/cljs/knoxx/backend/law/publication_receipts.cljs
+++ b/backend/src/cljs/knoxx/backend/law/publication_receipts.cljs
@@ -16,6 +16,15 @@
    `PublicationRevision`."
   publication/ConcreteRevision)
 
+(def PublicationArtifact
+  "Re-exported for the same reason as `ConcreteRevision`: the effect boundary
+   depends on one law namespace. Declared in `law.publication` — see the note
+   above it recording that the artifact is produced ABOVE this boundary."
+  publication/PublicationArtifact)
+
+(def ArtifactRevisionConflict
+  publication/ArtifactRevisionConflict)
+
 ;; ── Plans entering the effect layer ────────────────────────────────────────
 
 (def PlanOp
@@ -82,12 +91,19 @@
 
 (def FailedReceipt
   "Adapter failure is evidence, not an exception the caller must catch. Drift is
-   reported so reconciliation can see desired and observed disagree."
+   reported so reconciliation can see desired and observed disagree.
+
+   `:failure/conflict` carries a *structured* refusal rather than only the
+   message string `:failure/reason` already holds. An artifact-revision conflict
+   is the one failure where the reader has to know which side was stale, so both
+   revisions travel on the receipt; flattened into prose they are unrecoverable
+   by anything but a human reading logs."
   [:map
    [:receipt/type [:= :publication/failed]]
    [:failure/reason publication/NonBlankString]
    [:failure/drift? [:= true]]
-   [:idempotency/key {:optional true} [:maybe :string]]])
+   [:idempotency/key {:optional true} [:maybe :string]]
+   [:failure/conflict {:optional true} [:maybe ArtifactRevisionConflict]]])
 
 (def Receipt
   [:multi {:dispatch :receipt/type}
@@ -104,3 +120,22 @@
 (defn assert-receipt!
   [receipt]
   (publication/assert-valid! :publication/receipt Receipt receipt))
+
+;; ── The artifact entering the effect layer ─────────────────────────────────
+
+(defn assert-artifact!
+  "The other half of \"both directions\": the artifact is validated on the way
+   IN, exactly as the adapter's receipt is validated on the way OUT.
+
+   Called before the idempotency key is derived and before the store is touched,
+   so a publication that cannot lawfully happen leaves no reservation behind for
+   a later attempt to reconcile."
+  [artifact concrete-revision]
+  (publication/assert-artifact! artifact concrete-revision))
+
+(defn artifact-revision-conflict?
+  "True when a thrown `ex-data` is the typed artifact-revision conflict, so the
+   boundary can put it on the failure receipt instead of losing both revisions
+   inside a message string."
+  [value]
+  (publication/artifact-revision-conflict? value))

--- a/backend/test/cljs/knoxx/backend/domain/publication_boundary_test.cljs
+++ b/backend/test/cljs/knoxx/backend/domain/publication_boundary_test.cljs
@@ -24,6 +24,16 @@
    :translation/review :required
    :document/source-locale :en})
 
+(def artifact
+  "Rendered ABOVE the boundary and handed to it, at the same revision `facts`
+   reports as current — an artifact naming a different one is a conflict, not
+   something the seam is allowed to publish."
+  {:artifact/content "<!doctype html><p>demo</p>"
+   :artifact/media-type "text/html"
+   :artifact/encoding "utf-8"
+   :artifact/locale :es
+   :artifact/revision "abc123"})
+
 (def resource-index
   {:gardens {:knoxx.docs/promethean {:garden/id :knoxx.docs/promethean
                                      :garden/status :active}
@@ -54,7 +64,7 @@
                                           (facts target-bundle))]
     {:plan current-plan
      :receipt (await (effects/execute-plan! store (:target target-bundle)
-                                            {} current-plan nil))}))
+                                            {} current-plan artifact))}))
 
 ;; ── 5 the card's own sketch ───────────────────────────────────────────────
 
@@ -81,9 +91,9 @@
           target-bundle (memory/memory-target)
           publish-plan (plan/reconcile-plan resource-index intent (facts target-bundle))
           first-receipt (await (effects/execute-plan!
-                                store (:target target-bundle) {} publish-plan nil))
+                                store (:target target-bundle) {} publish-plan artifact))
           replay-receipt (await (effects/execute-plan!
-                                 store (:target target-bundle) {} publish-plan nil))]
+                                 store (:target target-bundle) {} publish-plan artifact))]
       (is (= first-receipt replay-receipt))
       (is (= 1 (memory/materialization-count target-bundle)))
       (is (= 1 (count (memory/public-routes target-bundle)))))))

--- a/backend/test/cljs/knoxx/backend/e2e/contract_publication_test.cljs
+++ b/backend/test/cljs/knoxx/backend/e2e/contract_publication_test.cljs
@@ -207,10 +207,16 @@
 
 (def translated-artifact
   "Distinctive content, so \"the public route serves the translated artifact\" is
-   an assertion about what is served rather than about receipt metadata."
-  {:artifact/locale target-locale
-   :artifact/revision concrete-revision
-   :artifact/body "Sonda — contenido traducido"})
+   an assertion about what is served rather than about receipt metadata.
+
+   A full `law.publication/PublicationArtifact`, not a loose bag: this journey is
+   the thing that has to fail when a renderer produces something an adapter
+   cannot write, so the fixture is held to the same contract production is."
+  {:artifact/content "Sonda — contenido traducido"
+   :artifact/media-type "text/html"
+   :artifact/encoding "utf-8"
+   :artifact/locale target-locale
+   :artifact/revision concrete-revision})
 
 (defn- ^:async converge!
   "Drive the fixture to convergence and return the receipt."
@@ -277,10 +283,36 @@
               left every assertion here green"
       (is (= translated-artifact
              (memory/served-artifact (:target-bundle system) publication-path)))
-      (is (str/includes? (:artifact/body
+      (is (str/includes? (:artifact/content
                           (memory/served-artifact (:target-bundle system)
                                                   publication-path))
                          "traducido")))))
+
+;; ── 6b a malformed artifact fails the journey instead of being served ──────
+
+(deftest ^:async a-malformed-artifact-fails-the-journey-rather-than-being-stored
+  (testing "the memory target used to store `:artifact` unexamined, so a renderer
+            that dropped the media type, the declared encoding, or the content
+            itself still produced a public route — and every assertion in this
+            file, all of which read receipt metadata, stayed green"
+    (doseq [[label bad] [["no content" (dissoc translated-artifact :artifact/content)]
+                         ["no media type" (dissoc translated-artifact :artifact/media-type)]
+                         ["no declared encoding"
+                          (dissoc translated-artifact :artifact/encoding)]
+                         ["a revision selector instead of a revision"
+                          (assoc translated-artifact :artifact/revision :source/current)]
+                         ["a revision the planner is not publishing"
+                          (assoc translated-artifact :artifact/revision "rev-stale")]]]
+      (let [system (fixture)]
+        (record-translation! system target-locale concrete-revision)
+        (record-approval! system target-locale concrete-revision)
+        (let [receipt (await (converge! system bad))]
+          (testing label
+            (is (= :publication/failed (:receipt/type receipt)))
+            (is (empty? (memory/public-routes (:target-bundle system)))
+                "nothing is public")
+            (is (zero? (memory/materialization-count (:target-bundle system)))
+                "and nothing counts as materialized")))))))
 
 ;; ── 7 one walkable receipt chain ──────────────────────────────────────────
 

--- a/backend/test/cljs/knoxx/backend/infra/publication_effects_test.cljs
+++ b/backend/test/cljs/knoxx/backend/infra/publication_effects_test.cljs
@@ -26,6 +26,15 @@
    :previous nil
    :concrete-revision "probe-revision"})
 
+(def artifact
+  "What the renderer hands the boundary. Produced ABOVE it — `execute-plan!`
+   takes it as an argument, which is the whole reason it can be a fixture here."
+  {:artifact/content "<!doctype html><p>Sonda</p>"
+   :artifact/media-type "text/html"
+   :artifact/encoding "utf-8"
+   :artifact/locale :es
+   :artifact/revision "probe-revision"})
+
 ;; ── In-memory adapter and store ────────────────────────────────────────────
 
 (defn- fake-store []
@@ -134,7 +143,7 @@
   (let [{:keys [store]} (fake-store)
         {:keys [target calls]} (fake-target {})
         receipt (await (effects/execute-plan!
-                        store target {} (dissoc publish-plan :concrete-revision) nil))]
+                        store target {} (dissoc publish-plan :concrete-revision) artifact))]
     (is (= :publication/failed (:receipt/type receipt)))
     (is (empty? @calls) "no effect may run for an invalid plan")))
 
@@ -147,7 +156,7 @@
           previous {:materialized/revision "old" :materialized/path "/old-route"}
           _ (swap! routes assoc "/old-route" previous)
           receipt (await (effects/execute-plan!
-                          store target {} (assoc publish-plan :previous previous) nil))]
+                          store target {} (assoc publish-plan :previous previous) artifact))]
       (is (= :publication/materialized (:receipt/type receipt)))
       (is (= ["/probe"] (keys @routes)) "the stale route is gone")))
   (testing ":remove uses the plan's :observed"
@@ -175,8 +184,8 @@
 (deftest ^:async replay-of-identical-publish-converges
   (let [{:keys [store]} (fake-store)
         {:keys [target routes calls]} (fake-target {})
-        first-receipt (await (effects/execute-plan! store target {} publish-plan nil))
-        second-receipt (await (effects/execute-plan! store target {} publish-plan nil))]
+        first-receipt (await (effects/execute-plan! store target {} publish-plan artifact))
+        second-receipt (await (effects/execute-plan! store target {} publish-plan artifact))]
     (is (= first-receipt second-receipt))
     (is (= 1 (count @routes)) "exactly one materialization")
     (is (= 1 (count (filter #(= :publish! (first %)) @calls)))
@@ -187,14 +196,14 @@
             replay must converge on the existing route, not duplicate it"
     (let [{:keys [store]} (fake-store)
           {:keys [target routes calls]} (fake-target {:swallow-response? true})
-          failed (await (effects/execute-plan! store target {} publish-plan nil))]
+          failed (await (effects/execute-plan! store target {} publish-plan artifact))]
       (is (= :publication/failed (:receipt/type failed)))
       (is (= 1 (count @routes)) "the artifact WAS created despite the failure")
       (testing "the claim is retained, so the replay OBSERVES rather than
                 republishing — convergence must not depend on the adapter
                 deduplicating on our behalf"
         (reset! calls [])
-        (let [replay (await (effects/execute-plan! store target {} publish-plan nil))]
+        (let [replay (await (effects/execute-plan! store target {} publish-plan artifact))]
           (is (= :publication/materialized (:receipt/type replay)))
           (is (= 1 (count @routes)) "no second artifact")
           (is (not-any? #(= :publish! (first %)) @calls)
@@ -212,7 +221,7 @@
       (swap! state assoc idempotency-key {:claimed? true})
       (swap! routes assoc "/probe" {:materialized/revision "probe-revision"
                                     :materialized/path "/probe"})
-      (let [receipt (await (effects/execute-plan! store target {} publish-plan nil))]
+      (let [receipt (await (effects/execute-plan! store target {} publish-plan artifact))]
         (is (= :publication/materialized (:receipt/type receipt)))
         (is (= 1 (count @routes)))
         (is (not-any? #(= :publish! (first %)) @calls)
@@ -227,7 +236,7 @@
         previous {:materialized/revision "probe-revision" :materialized/path "/old-route"}
         _ (swap! routes assoc "/old-route" previous)
         receipt (await (effects/execute-plan!
-                        store target {} (assoc publish-plan :previous previous) nil))]
+                        store target {} (assoc publish-plan :previous previous) artifact))]
     (is (= :publication/materialized (:receipt/type receipt)))
     (is (= ["/probe"] (keys @routes)))
     (is (nil? (get @routes "/old-route")) "the old route is unavailable")
@@ -273,7 +282,7 @@
   (let [{:keys [store]} (fake-store)
         {:keys [target]} (fake-target {:fail? true})
         before intent
-        receipt (await (effects/execute-plan! store target {} publish-plan nil))]
+        receipt (await (effects/execute-plan! store target {} publish-plan artifact))]
     (is (= :publication/failed (:receipt/type receipt)))
     (is (true? (:failure/drift? receipt)))
     (is (str/includes? (:failure/reason receipt) "adapter exploded"))
@@ -283,7 +292,7 @@
     (testing "and a retry still proceeds: the retained claim is reconciled by
               observation, which finds nothing and then republishes"
       (let [{:keys [target routes]} (fake-target {})
-            retry (await (effects/execute-plan! store target {} publish-plan nil))]
+            retry (await (effects/execute-plan! store target {} publish-plan artifact))]
         (is (= :publication/materialized (:receipt/type retry)))
         (is (= 1 (count @routes)))))))
 
@@ -350,9 +359,103 @@
                                wrong)))
                      (remove! [_ _ctx _intent _observed] (js/Promise.resolve nil))
                      (observe! [_ _ctx _intent] (js/Promise.resolve nil)))
-            receipt (await (effects/execute-plan! store target {} publish-plan nil))]
+            receipt (await (effects/execute-plan! store target {} publish-plan artifact))]
         (testing label
           (is (= :publication/failed (:receipt/type receipt)))
           (is (not-any? :receipt (vals @state))
               "nothing may be recorded as done for a materialization we cannot confirm"))))))
 
+
+;; ── the artifact is checked on the way IN, as the receipt is on the way OUT ──
+
+(deftest ^:async a-malformed-artifact-fails-before-any-effect
+  (testing "`:artifact` used to be an unnamed payload the boundary forwarded and
+            the target stored, so an artifact with no media type, no declared
+            encoding, or no content at all became a SERVED route while every
+            assertion about the materialization stayed green"
+    (doseq [[label bad] [["absent entirely" nil]
+                         ["not a map" "<!doctype html>"]
+                         ["no content" (dissoc artifact :artifact/content)]
+                         ["blank content" (assoc artifact :artifact/content "   ")]
+                         ["empty bytes" (assoc artifact :artifact/content
+                                               (js/Uint8Array. 0))]
+                         ["no media type" (dissoc artifact :artifact/media-type)]
+                         ["media type with a charset parameter"
+                          (assoc artifact :artifact/media-type "text/html; charset=utf-8")]
+                         ["no declared encoding" (dissoc artifact :artifact/encoding)]
+                         ["no locale" (dissoc artifact :artifact/locale)]
+                         ["a namespaced locale" (assoc artifact :artifact/locale :locale/es)]
+                         ["no revision" (dissoc artifact :artifact/revision)]]]
+      (let [{:keys [store state]} (fake-store)
+            {:keys [target calls routes]} (fake-target {})
+            receipt (await (effects/execute-plan! store target {} publish-plan bad))]
+        (testing label
+          (is (= :publication/failed (:receipt/type receipt)))
+          (is (true? (:failure/drift? receipt)))
+          (is (empty? @calls) "no effect may run for a malformed artifact")
+          (is (empty? @routes) "and nothing may be served")
+          (is (empty? @state)
+              "not even a reservation: a claim for a publication that cannot
+               happen is a claim nobody will ever complete"))))))
+
+(deftest ^:async the-artifact-refuses-a-revision-selector-anywhere
+  (testing "for the reason publish-idempotency-key refuses one — a selector gives
+            a stable-looking identity to a moving target. `:artifact/revision` is
+            typed, so the interesting cases are the ones a shape check alone
+            misses: a selector riding along on some other key."
+    (doseq [[label bad] [["as the revision itself"
+                          (assoc artifact :artifact/revision :source/current)]
+                         ["on an extra top-level key"
+                          (assoc artifact :render/from :source/current)]
+                         ["nested inside a map"
+                          (assoc artifact :render/provenance {:revision :source/current})]
+                         ["nested inside a vector"
+                          (assoc artifact :render/inputs [:source/current])]
+                         ["as a map KEY"
+                          (assoc artifact :render/by {:source/current "probe-revision"})]
+                         ["a sibling selector nobody has invented yet"
+                          (assoc artifact :render/from :source/head)]]]
+      (let [{:keys [store state]} (fake-store)
+            {:keys [target calls]} (fake-target {})
+            receipt (await (effects/execute-plan! store target {} publish-plan bad))]
+        (testing label
+          (is (= :publication/failed (:receipt/type receipt)))
+          (is (empty? @calls))
+          (is (empty? @state)))))))
+
+(deftest ^:async an-artifact-revision-conflict-is-typed-and-carries-both-revisions
+  (testing "the renderer and the planner disagreeing about what is being
+            published is a CONFLICT, not a warning: the bytes came from one
+            source state and the idempotency key names another, so publishing
+            either way records a materialization that did not happen"
+    (let [{:keys [store state]} (fake-store)
+          {:keys [target calls routes]} (fake-target {})
+          stale (assoc artifact :artifact/revision "an-older-revision")
+          receipt (await (effects/execute-plan! store target {} publish-plan stale))]
+      (is (= :publication/failed (:receipt/type receipt)))
+      (testing "and BOTH revisions survive onto the receipt — a reader has to be
+                able to tell which side was stale, which a message string cannot"
+        (is (= {:conflict/type :publication/artifact-revision-conflict
+                :conflict/artifact-revision "an-older-revision"
+                :conflict/concrete-revision "probe-revision"}
+               (:failure/conflict receipt)))
+        (is (true? (law/artifact-revision-conflict? (:failure/conflict receipt)))))
+      (is (empty? @calls) "nothing was published")
+      (is (empty? @routes))
+      (is (empty? @state) "and nothing was claimed"))))
+
+(deftest ^:async an-agreeing-artifact-publishes-as-bytes-or-as-a-string
+  (testing "bytes and a string are both content; the difference is only whether
+            the renderer already applied the declared encoding"
+    (doseq [[label content] [["a string" "<!doctype html><p>Sonda</p>"]
+                             ["bytes" (.encode (js/TextEncoder.)
+                                               "<!doctype html><p>Sonda</p>")]]]
+      (let [{:keys [store]} (fake-store)
+            {:keys [target routes]} (fake-target {})
+            receipt (await (effects/execute-plan!
+                            store target {}
+                            publish-plan
+                            (assoc artifact :artifact/content content)))]
+        (testing label
+          (is (= :publication/materialized (:receipt/type receipt)))
+          (is (= 1 (count @routes))))))))

--- a/backend/test/cljs/knoxx/backend/infra/publication_target_memory_test.cljs
+++ b/backend/test/cljs/knoxx/backend/infra/publication_target_memory_test.cljs
@@ -1,0 +1,126 @@
+(ns knoxx.backend.infra.publication-target-memory-test
+  "The test double held to the adapter contract, and the one place the artifact's
+  *production side* is pinned rather than described.
+
+  Two claims live here because they are the same claim from both ends: an
+  adapter validates what it is handed, and an adapter never produces what it
+  transports."
+  (:require [cljs.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [knoxx.backend.infra.publication-effects :as effects]
+            [knoxx.backend.infra.publication-target-memory :as memory]
+            ["node:fs" :as node-fs]
+            ["node:path" :as path]))
+
+;; ── Fixtures ───────────────────────────────────────────────────────────────
+
+(def intent
+  {:publication/id :knoxx.docs/probe-es
+   :publication/document :knoxx.docs/probe
+   :publication/garden :knoxx.docs/promethean
+   :publication/locale :es
+   :publication/revision :source/current
+   :publication/state :published
+   :publication/path "/probe"
+   :translation/review :required
+   :document/source-locale :en})
+
+(def artifact
+  {:artifact/content "<!doctype html><p>Sonda — contenido traducido</p>"
+   :artifact/media-type "text/html"
+   :artifact/encoding "utf-8"
+   :artifact/locale :es
+   :artifact/revision "probe-revision"})
+
+(def publish-plan
+  {:op :publish
+   :intent intent
+   :desired {:materialized/revision "probe-revision" :materialized/path "/probe"}
+   :previous nil
+   :concrete-revision "probe-revision"})
+
+(defn- op-with
+  "The op shape `execute-publish!` builds, so calling `publish!` directly here
+   exercises the adapter against the same input production hands it."
+  [candidate]
+  {:intent intent
+   :artifact candidate
+   :previous nil
+   :concrete-revision "probe-revision"
+   :idempotency/key "probe-key"})
+
+;; ── the adapter validates rather than storing anything ────────────────────
+
+(deftest the-memory-target-validates-what-it-is-handed
+  (testing "`:artifact` was stored unexamined and handed back, which is fine for
+            recording metadata and useless for proving a publication: a dropped
+            media type, a missing declared encoding, or no content at all became
+            a SERVED route, and every assertion about the materialization — all
+            of them reading receipt metadata — stayed green"
+    (doseq [[label bad] [["absent entirely" nil]
+                         ["no content" (dissoc artifact :artifact/content)]
+                         ["no media type" (dissoc artifact :artifact/media-type)]
+                         ["no declared encoding" (dissoc artifact :artifact/encoding)]
+                         ["no locale" (dissoc artifact :artifact/locale)]
+                         ["a revision selector"
+                          (assoc artifact :artifact/revision :source/current)]
+                         ["a selector hidden on another key"
+                          (assoc artifact :render/from :source/current)]
+                         ["a revision the op is not publishing"
+                          (assoc artifact :artifact/revision "some-other-revision")]]]
+      (let [bundle (memory/memory-target)]
+        (testing label
+          (is (thrown? js/Error (effects/publish! (:target bundle) {} (op-with bad))))
+          (is (empty? (memory/public-routes bundle))
+              "refused, not stored")
+          (is (zero? (memory/materialization-count bundle))
+              "and not counted as a materialization either"))))))
+
+(deftest ^:async a-lawful-artifact-is-stored-and-served-unchanged
+  (let [bundle (memory/memory-target)
+        receipt (await (effects/publish! (:target bundle) {} (op-with artifact)))]
+    (is (= :publication/materialized (:receipt/type receipt)))
+    (is (= 1 (memory/materialization-count bundle)))
+    (testing "stored EXACTLY as handed over — the adapter transports, so any
+              difference here would be the adapter having opinions about content"
+      (is (identical? artifact (memory/served-artifact bundle "/probe"))))))
+
+;; ── the artifact is produced ABOVE the effect boundary ────────────────────
+
+(defn- read-source
+  [relative-path]
+  (.readFileSync node-fs (.join path (.cwd js/process) relative-path) "utf8"))
+
+(deftest ^:async the-artifact-is-produced-above-the-effect-boundary
+  (testing "the boundary cannot supply one, so it must come from above: a
+            :publish plan with no artifact is refused rather than rendered here"
+    (let [{:keys [store]} (memory/memory-store)
+          bundle (memory/memory-target)
+          receipt (await (effects/execute-plan!
+                          store (:target bundle) {} publish-plan nil))]
+      (is (= :publication/failed (:receipt/type receipt)))
+      (is (empty? (memory/public-routes bundle)))))
+
+  (testing "and two independent adapters handed the SAME artifact serve the
+            identical value. Produced BELOW the boundary each adapter would
+            render from the intent it was given, and two targets publishing the
+            same intent at the same revision could serve different bytes with
+            nothing in the receipt chain able to say which is right"
+    (let [first-bundle (memory/memory-target {:id :first/target})
+          second-bundle (memory/memory-target {:id :second/target})]
+      (await (effects/publish! (:target first-bundle) {} (op-with artifact)))
+      (await (effects/publish! (:target second-bundle) {} (op-with artifact)))
+      (is (= (memory/served-artifact first-bundle "/probe")
+             (memory/served-artifact second-bundle "/probe")))
+      (testing "identical?, not merely equal — an adapter that rendered its own
+                copy would satisfy = and still be the divergence this forbids"
+        (is (identical? artifact (memory/served-artifact first-bundle "/probe")))
+        (is (identical? artifact (memory/served-artifact second-bundle "/probe"))))))
+
+  (testing "no source at or below the boundary constructs artifact content"
+    (doseq [relative-path ["src/cljs/knoxx/backend/infra/publication_effects.cljs"
+                           "src/cljs/knoxx/backend/infra/publication_target_memory.cljs"]]
+      (testing relative-path
+        (is (not (str/includes? (read-source relative-path) ":artifact/content"))
+            "an adapter that writes this key is rendering, which is the one thing
+             the ownership decision forbids it from doing")))))

--- a/backend/test/cljs/knoxx/backend/law/publication_test.cljs
+++ b/backend/test/cljs/knoxx/backend/law/publication_test.cljs
@@ -214,3 +214,86 @@
                              first)
             legacy-backend-marker (str "open" "planner")]
         (is (not (str/includes? (str/lower-case law-require) legacy-backend-marker)))))))
+
+;; ── 11 the materialized artifact ──────────────────────────────────────────
+
+(def probe-artifact
+  {:artifact/content "<!doctype html><p>Sonda</p>"
+   :artifact/media-type "text/html"
+   :artifact/encoding "utf-8"
+   :artifact/locale :es
+   :artifact/revision "rev-7f3a91c"})
+
+(deftest publication-artifact-declares-content-media-type-encoding-locale-revision
+  (is (true? (m/validate pub/PublicationArtifact probe-artifact)))
+  (testing "bytes are content too — the difference from a string is only whether
+            the renderer already applied the declared encoding"
+    (is (true? (m/validate pub/PublicationArtifact
+                           (assoc probe-artifact :artifact/content
+                                  (.encode (js/TextEncoder.) "<p>Sonda</p>"))))))
+  (testing "every field is load-bearing: an adapter that has to guess one of them
+            is an adapter making a publication decision"
+    (doseq [field [:artifact/content :artifact/media-type :artifact/encoding
+                   :artifact/locale :artifact/revision]]
+      (is (false? (m/validate pub/PublicationArtifact (dissoc probe-artifact field)))
+          (str field " must be required"))))
+  (testing "extra keys are allowed — an artifact may carry renderer provenance"
+    (is (true? (m/validate pub/PublicationArtifact
+                           (assoc probe-artifact :render/engine :markdown))))))
+
+(deftest media-type-carries-no-charset-parameter
+  (testing "accepted"
+    (doseq [media-type ["text/html" "application/edn" "image/svg+xml" "text/plain"]]
+      (is (true? (pub/valid-media-type? media-type)) media-type)))
+  (testing "refused — a charset parameter duplicates :artifact/encoding, and two
+            places to declare one encoding is two places that can disagree"
+    (doseq [media-type ["text/html; charset=utf-8" "text/html charset=utf-8"
+                        "texthtml" "text/" "/html" "" "  "]]
+      (is (false? (pub/valid-media-type? media-type)) (pr-str media-type)))))
+
+(deftest character-encoding-is-declared-not-guessed
+  (doseq [encoding ["utf-8" "UTF-8" "iso-8859-1" "windows-1252"]]
+    (is (true? (pub/valid-character-encoding? encoding)) encoding))
+  (doseq [bad ["" "  " "utf 8" "utf-8; q=1"]]
+    (is (false? (pub/valid-character-encoding? bad)) (pr-str bad))))
+
+(deftest artifact-rejects-a-revision-selector-anywhere
+  (testing "the whole value is walked, keys included, so a selector cannot ride
+            along on a key the shape does not name"
+    (doseq [[label value] [["the revision itself" {:artifact/revision :source/current}]
+                           ["an extra key" {:render/from :source/current}]
+                           ["nested in a map" {:render/provenance {:from :source/current}}]
+                           ["nested in a vector" {:render/inputs [:source/current]}]
+                           ["a map key" {:render/by {:source/current true}}]
+                           ["a sibling nobody has invented yet"
+                            {:render/from :source/head}]]]
+      (is (false? (pub/free-of-revision-selectors? (merge probe-artifact value)))
+          label)
+      (is (false? (m/validate pub/PublicationArtifact (merge probe-artifact value)))
+          label)))
+  (testing "while a document's own :source key is not a selector — the namespace
+            is what marks one, not the word"
+    (is (true? (pub/free-of-revision-selectors?
+                (assoc probe-artifact :document/source {:path "docs/probe.md"}))))))
+
+(deftest artifact-revision-conflict-carries-both-revisions
+  (is (nil? (pub/artifact-revision-conflict probe-artifact "rev-7f3a91c"))
+      "agreement is not a conflict")
+  (let [conflict (pub/artifact-revision-conflict probe-artifact "rev-other")]
+    (is (= {:conflict/type :publication/artifact-revision-conflict
+            :conflict/artifact-revision "rev-7f3a91c"
+            :conflict/concrete-revision "rev-other"}
+           conflict))
+    (is (true? (pub/artifact-revision-conflict? conflict)))
+    (is (true? (m/validate pub/ArtifactRevisionConflict conflict))))
+  (testing "assert-artifact! returns the artifact on agreement and throws the
+            conflict otherwise, with both revisions in ex-data"
+    (is (= probe-artifact (pub/assert-artifact! probe-artifact "rev-7f3a91c")))
+    (is (thrown-with-msg? js/Error #"revision conflict"
+                          (pub/assert-artifact! probe-artifact "rev-other")))
+    (is (= {:conflict/type :publication/artifact-revision-conflict
+            :conflict/artifact-revision "rev-7f3a91c"
+            :conflict/concrete-revision "rev-other"}
+           (try (pub/assert-artifact! probe-artifact "rev-other")
+                nil
+                (catch :default err (ex-data err)))))))


### PR DESCRIPTION
## Card
knoxx-publication-artifact-contract

## Summary
- Declare the `PublicationArtifact` law shape.
- Validate artifacts with `assert-artifact!` at the publication effect boundary.
- Validate artifacts in the memory target before materialization.
- Preserve a typed artifact-revision conflict on failed receipts.

## Verification
`pnpm -C backend test` => "Ran 1058 tests containing 3834 assertions. 0 failures, 0 errors."

Adversarial verifier:
- `overall: sound`
- `matches_their_claim: true`

## Known follow-ups
- `:artifact/locale` is not cross-checked.
- `:route/artifact` namespacing diverges in the memory double.
- Stricter-than-contract refusals are not reflected in the note.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for publication artifacts, including content, media type, encoding, locale, and revision.
  * Supports publication content provided as text or bytes.
  * Added structured failure details when an artifact’s revision conflicts with the planned revision.
* **Bug Fixes**
  * Invalid, incomplete, or revision-selector-containing artifacts are rejected before publication effects occur.
  * Stale artifacts no longer create public routes or materialization records.
  * Valid artifacts are stored and served unchanged across publication targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->