### PR TITLE
docs(kanban): re-materialize remaining translated-publication cards

### DIFF
--- a/kanban/tasks/knoxx-publication-locale-catalog.md
+++ b/kanban/tasks/knoxx-publication-locale-catalog.md
@@ -1,0 +1,48 @@
+---
+category: "tasks"
+labels: ["tasks", "has-parent", "publication", "locales", "resources", "adapters", "wave-2"]
+write-id: "1787011200005-0.793154"
+points: "2"
+title: "Publication — target locale catalog"
+priority: "P2"
+status: "ready"
+uuid: "knoxx-publication-locale-catalog"
+created_at: "2026-08-22T00:00:00Z"
+---
+
+# Publication — target locale catalog
+
+> Parent epic: `knoxx-translated-publication-to-website`
+
+## Purpose
+
+Declare the locales each publication target accepts in resources and enforce the
+locale identity that reaches the static-site adapter. Without this guard, an
+artifact path derived from `:artifact/locale` can place wrong-language bytes
+behind a manifest route derived from `:publication/locale`.
+
+## Dependencies
+
+`knoxx-publication-artifact-contract`. It may land after that contract and must
+be wired before static-site publication is allowed to materialize locale routes.
+
+## Work
+
+- Extend target resource declarations with an explicit locale catalog or policy
+  that states the locales accepted by that target.
+- Validate `:publication/locale` against the selected target catalog during
+  admissibility and validate it equals `:artifact/locale` before adapter effects.
+- Define a clear error/receipt shape for unsupported and disagreeing locales so
+  reconciliation reports a blocker rather than a misleading materialization.
+- Keep default locale and route-prefix behavior owned by the website reader; this
+  card governs writer target admissibility only.
+
+## Definition of Done
+
+- A target resource declares its accepted locales and an accepted locale reaches
+  the adapter unchanged.
+- Unsupported publication locales are blocked before artifact or manifest writes.
+- Tests prove a disagreement between `:publication/locale` and
+  `:artifact/locale` cannot create a route or expose bytes.
+- Tests prove locale catalog validation does not change the website's reader-side
+  default-locale routing rules.

--- a/kanban/tasks/knoxx-publication-reconciler-runtime.md
+++ b/kanban/tasks/knoxx-publication-reconciler-runtime.md
@@ -1,0 +1,53 @@
+---
+category: "tasks"
+labels: ["tasks", "has-parent", "publication", "reconciliation", "runtime", "receipts", "wave-1"]
+write-id: "1787011200002-0.914627"
+points: "3"
+title: "Publication — reconciler runtime"
+priority: "P1"
+status: "ready"
+uuid: "knoxx-publication-reconciler-runtime"
+created_at: "2026-08-22T00:00:00Z"
+---
+
+# Publication — reconciler runtime
+
+> Parent epic: `knoxx-translated-publication-to-website`
+
+## Purpose
+
+Make the proven pure plan and replaceable adapter effects run on a real trigger.
+The runtime translates a trigger into plan → effects and records evidence of what
+actually happened; it does not turn operational receipt state into desired state.
+
+## Dependencies
+
+`knoxx-publication-target-registry`, `knoxx-publication-static-site-target`,
+`knoxx-translation-work-dispatch`, and `knoxx-translation-approval-surface`.
+
+## Work
+
+- Define the runtime entry point and trigger payload that load resources,
+  publication intent, relevant translation/review facts, and a concrete artifact
+  before invoking the existing pure reconciliation law.
+- Resolve the declared target through the registry, execute the resulting plan,
+  and preserve the planner's operation identities when effects are retried.
+- Persist or emit a validated receipt for every attempted effect, including
+  blocked, noop, materialized, removed, and failed outcomes, with enough
+  correlation data to trace the triggering publication identity and revision.
+- Ensure one failed target effect is observable and does not fabricate a
+  materialized receipt; desired resource state remains unchanged by runtime
+  observation.
+- Provide an explicit trigger integration (event, scheduled job, or authorized
+  runtime route) rather than a library function that no production path calls.
+
+## Definition of Done
+
+- An integration test triggers reconciliation and proves the runtime calls pure
+  planning before adapter effects.
+- A materialization, noop, blocker, removal, and adapter failure each produce a
+  receipt with the expected outcome and correlation identity.
+- A retry of the same operation preserves idempotency and yields no duplicate
+  publication.
+- Tests prove a receipt cannot mutate desired resource declarations or bypass a
+  translation/review blocker.

--- a/kanban/tasks/knoxx-publication-static-site-target.md
+++ b/kanban/tasks/knoxx-publication-static-site-target.md
@@ -1,0 +1,75 @@
+---
+category: "tasks"
+labels: ["tasks", "has-parent", "publication", "adapters", "website", "static-site", "wave-1"]
+write-id: "1787011200001-0.642918"
+points: "8"
+title: "Publication — the static-site target adapter"
+priority: "P1"
+status: "ready"
+uuid: "knoxx-publication-static-site-target"
+created_at: "2026-08-22T00:00:00Z"
+---
+
+# Publication — the static-site target adapter
+
+> Parent epic: `knoxx-translated-publication-to-website`
+
+## Purpose
+
+The first `IPublicationTarget` that writes bytes a person can load in a browser.
+Everything above the effect boundary is already proven against a fake; this card
+is where the protocol finds out whether it was honest.
+
+## Dependencies
+
+`knoxx-publication-artifact-contract`, `knoxx-publication-target-registry`, and
+**`services-website-content-root`** — the transport this adapter uses is decided
+by whether Knoxx and the website share a host. Do not start before that answer.
+
+## Work
+
+- Call `law.publication-receipts/assert-artifact!` before every write and reject
+  an artifact whose concrete revision or selector identity violates the artifact
+  contract.
+- Write an artifact to a content root at a path derived from document × locale ×
+  concrete revision, and maintain a manifest that maps public paths to the
+  artifact currently serving them.
+- **The manifest is the published fact.** A file on disk that no manifest entry
+  names is not public, so a partially written artifact cannot be served. Write
+  the artifact first, then update the manifest as the commit point.
+- Update the manifest atomically — write beside and rename — so a reader never
+  observes a half-written manifest. A static file server has no read lock.
+- Set `:route/media-type` and `:route/encoding` from the validated
+  `:artifact/media-type` and `:artifact/encoding`; record `:route/artifact` as
+  the relative artifact **path**, never the artifact value held by the memory
+  target.
+- Implement `observe!` by reading the manifest, keyed on `:publication/id`, not
+  on the desired path. `publication-target-memory` documents exactly why: keying
+  on path means that after a path move the caller cannot see the route it is
+  replacing, `:previous` comes back nil, and both routes stay public.
+- Implement `remove!` so the route leaves the manifest and the publication id is
+  carried on the receipt — without it a publish-then-remove history still reports
+  the old route as materialized, and a later republish of the same revision reads
+  as `:noop` with nothing public.
+- Reclaim orphaned artifact files, or state in the namespace docstring that
+  content is retained deliberately and what bounds the growth.
+- Implement `IIdempotencyStore` against the same root with the same atomic
+  reservation contract: one operation claims the key, with no await between
+  reading it and claiming it. A separate check-then-write can publish twice and
+  the second publication is unrecoverable.
+- Concurrency is real here in a way it is not in the memory target: two
+  reconciler runs, or a run overlapping a deploy, touch the same directory.
+- An empty content root is a valid initial state, not an error.
+
+## Definition of Done
+
+- A published document is fetchable at its manifest path with the expected bytes.
+- The written manifest contains a relative `:route/artifact` path and route media
+  type and encoding equal to their validated artifact values.
+- Replay is a `:noop` and does not rewrite the artifact.
+- A path move leaves exactly one public route.
+- A removal makes the route stop serving and is visible to `observe!`.
+- A crash between artifact write and manifest update leaves nothing public and
+  the next run converges.
+- Interrupted mid-write, the manifest is either the old one or the new one.
+- The adapter contains no admissibility, gating, or planning logic.

--- a/kanban/tasks/knoxx-publication-target-registry.md
+++ b/kanban/tasks/knoxx-publication-target-registry.md
@@ -1,0 +1,58 @@
+---
+category: "tasks"
+labels: ["tasks", "has-parent", "publication", "adapters", "resources", "wave-1"]
+write-id: "1787011200000-0.381743"
+points: "5"
+title: "Publication — target registry from resources"
+priority: "P1"
+status: "ready"
+uuid: "knoxx-publication-target-registry"
+created_at: "2026-08-22T00:00:00Z"
+---
+
+# Publication — target registry from resources
+
+> Parent epic: `knoxx-translated-publication-to-website`
+
+## Purpose
+
+Select a publication adapter from declared resources rather than constructing an
+adapter at a publication call site. Desired target identity stays in resources;
+the registry resolves that identity to a Knoxx-owned adapter without making the
+adapter, its mutable state, or its transport part of the domain plan.
+
+## Dependencies
+
+`knoxx-publication-artifact-contract` and the existing publication adapter
+effect/idempotency contract. `knoxx-publication-static-site-target` consumes
+this registry.
+
+## Work
+
+- Define a resource-shaped target declaration with a stable target id, target
+  kind, and adapter configuration sufficient for selection without embedding an
+  adapter instance in resource data.
+- Build a registry that resolves a declared target kind to its
+  `IPublicationTarget` implementation and rejects unknown, duplicate, malformed,
+  or disabled target declarations before effects run.
+- Keep selection separate from reconciliation: the pure plan names the desired
+  target; only runtime composition turns that name and validated configuration
+  into an adapter.
+- Pass validated publication context through the registry unchanged so the
+  adapter still receives the concrete revision, publication identity, and
+  idempotency operation identity established by existing laws.
+- State explicitly that locale admissibility is not inferred here. The verifier
+  found that `:artifact/locale` is not cross-checked with
+  `:publication/locale`; accepted target locales belong to
+  `knoxx-publication-locale-catalog`.
+
+## Definition of Done
+
+- A resource declaration selects the registered adapter without a call site
+  constructing that adapter directly.
+- Unknown, duplicate, disabled, and structurally invalid targets fail before
+  `publish!`, `remove!`, or `observe!` is invoked.
+- Tests prove target selection is deterministic and adapter configuration cannot
+  alter the pure reconciliation decision.
+- Tests prove locale mismatch remains unadmitted until the locale-catalog guard
+  is supplied; the registry does not silently treat any locale as accepted.

--- a/kanban/tasks/knoxx-translation-approval-surface.md
+++ b/kanban/tasks/knoxx-translation-approval-surface.md
@@ -1,0 +1,50 @@
+---
+category: "tasks"
+labels: ["tasks", "has-parent", "translation", "approval", "authorization", "publication", "wave-2"]
+write-id: "1787011200004-0.528396"
+points: "3"
+title: "Translation — revision-specific approval surface"
+priority: "P1"
+status: "ready"
+uuid: "knoxx-translation-approval-surface"
+created_at: "2026-08-22T00:00:00Z"
+---
+
+# Translation — revision-specific approval surface
+
+> Parent epic: `knoxx-translated-publication-to-website`
+
+## Purpose
+
+Give an authorized human a real route to record approval of one translated
+revision. Approval is evidence for the publication gate, not a mutable blanket
+permission for a document or locale.
+
+## Dependencies
+
+The existing translation receipt and publication gate contracts.
+`knoxx-publication-reconciler-runtime` consumes the approval evidence.
+
+## Work
+
+- Provide an authenticated, authorized API and/or UI action that records an
+  approval against translation identity, target locale, and concrete translated
+  revision.
+- Validate the requested approval against the corresponding completed
+  translation receipt before persisting it; reject selector revisions, unknown
+  translations, and revision or locale mismatches.
+- Attribute each approval to the acting principal and timestamp it as immutable
+  review evidence usable by the gate.
+- Return a validated approval receipt to the caller and ensure unauthorized and
+  malformed requests fail before review state changes.
+- Keep approval recording separate from publication effects: an approval may
+  make a plan admissible but must not itself materialize content.
+
+## Definition of Done
+
+- An authorized principal can approve one completed translation revision through
+  the supported route and receives a revision-specific receipt.
+- An unauthenticated or unauthorized request cannot create approval evidence.
+- Tests prove an approval for one revision, locale, or document cannot satisfy
+  the gate for another.
+- Tests prove approval alone invokes no publication adapter effect.

--- a/kanban/tasks/knoxx-translation-work-dispatch.md
+++ b/kanban/tasks/knoxx-translation-work-dispatch.md
@@ -1,0 +1,52 @@
+---
+category: "tasks"
+labels: ["tasks", "has-parent", "translation", "publication", "ingestion", "receipts", "wave-2"]
+write-id: "1787011200003-0.176845"
+points: "5"
+title: "Translation — dispatch gated work to ingestion"
+priority: "P1"
+status: "ready"
+uuid: "knoxx-translation-work-dispatch"
+created_at: "2026-08-22T00:00:00Z"
+---
+
+# Translation — dispatch gated work to ingestion
+
+> Parent epic: `knoxx-translated-publication-to-website`
+
+## Purpose
+
+Connect the publication gate's derived translation work to the ingestion worker
+and return its result as evidence. A derived work item must be dispatchable,
+revision-specific, and receipt-backed instead of being a plan that remains only
+in memory.
+
+## Dependencies
+
+The existing translation/publication gate and translation ingestion worker.
+`knoxx-publication-reconciler-runtime` consumes the resulting translation facts.
+
+## Work
+
+- Map each admissible derived translation work item into the ingestion worker's
+  input contract, carrying document identity, source and target locale, concrete
+  source revision, and a stable dispatch/idempotency identity.
+- Dispatch through the established worker boundary; do not reimplement
+  translation or make a Knoxx publication adapter call a provider directly.
+- Decode and validate the worker result into a translation receipt tied to the
+  exact derived-work and source revision that produced it.
+- Record failed, rejected, duplicate, and completed dispatches distinctly so the
+  gate can distinguish missing work from an attempted-but-unsuccessful run.
+- Reject selector revisions and stale or mismatched worker responses rather than
+  allowing them to satisfy a publication gate for a moving source.
+
+## Definition of Done
+
+- A gated translation work item reaches the ingestion worker with a concrete
+  revision and expected locale pair.
+- A successful worker result returns a validated, revision-specific receipt that
+  the publication gate recognizes.
+- Duplicate dispatch reuses its idempotency identity and does not enqueue or
+  translate twice.
+- Tests prove failed, stale, selector, and mismatched-revision results cannot
+  satisfy the gate or cause publication.

--- a/kanban/tasks/knoxx-website-publication-live-verification.md
+++ b/kanban/tasks/knoxx-website-publication-live-verification.md
@@ -1,0 +1,58 @@
+---
+category: "tasks"
+labels: ["tasks", "has-parent", "publication", "website", "verification", "https", "wave-4"]
+write-id: "1787011200006-0.249681"
+points: "2"
+title: "Website publication — live verification"
+priority: "P2"
+status: "ready"
+uuid: "knoxx-website-publication-live-verification"
+created_at: "2026-08-22T00:00:00Z"
+---
+
+# Website publication — live verification
+
+> Parent epic: `knoxx-translated-publication-to-website`
+
+## Purpose
+
+Prove the full seam once against deployed services: publication intent becomes a
+translation, an authorized revision approval, a materialized artifact and
+manifest entry, and a document fetched from the website over HTTPS.
+
+## Dependencies
+
+`knoxx-publication-reconciler-runtime`, `knoxx-translation-work-dispatch`,
+`knoxx-translation-approval-surface`, `knoxx-publication-locale-catalog`,
+`services-website-as-gated-service`, `website-published-content-source`, and
+`website-manifest-contract-tests`.
+
+## Work
+
+- Add a repeatable, environment-safe live verification procedure that seeds a
+  unique publication intent, waits for the translation receipt, records an
+  authorized revision-specific approval, triggers reconciliation, and cleans up
+  its test data when possible.
+- Fetch the resulting website route and `manifest.edn` over HTTPS, asserting the
+  route's locale, revision, bytes, media type, and manifest artifact path agree
+  with the materialization receipt.
+- Verify the cross-repo contract's reader rules in the live environment: an
+  absent or empty manifest serves the site, while malformed required fields and
+  unsupported versions fail loudly.
+- Explicitly verify or file completion follow-ups for the website verifier's
+  known findings: artifact insertion via `innerHTML` can lose `<head>` content,
+  and the missing-manifest response has Content-Type asymmetry.
+- Record URLs, non-secret correlation identities, observed receipts, and any
+  environment preconditions so a reviewer can reproduce the run.
+
+## Definition of Done
+
+- One recorded live run proves intent → translation → authorized approval →
+  materialization → HTTPS fetch for a non-default locale.
+- The fetched route's bytes and locale agree with the manifest and materialized
+  artifact receipt; it never exposes an artifact with a disagreeing locale.
+- The verification output proves the website made no request to a Knoxx origin.
+- The `innerHTML` head-content and missing-manifest Content-Type findings are
+  each verified as fixed/acceptable or linked to an explicit follow-up card.
+- The procedure fails non-zero on a missing receipt, failed authorization,
+  malformed manifest, incorrect HTTPS response, or leftover seeded public route.


### PR DESCRIPTION
Re-materializes the seven remaining cards for `knoxx-translated-publication-to-website` from the epic summary, cross-repo manifest contract, preserved static-site card, and verifier follow-ups.

- W1 / 5sp — `knoxx-publication-target-registry`
- W1 / 8sp — `knoxx-publication-static-site-target`
- W1 / 3sp — `knoxx-publication-reconciler-runtime`
- W2 / 5sp — `knoxx-translation-work-dispatch`
- W2 / 3sp — `knoxx-translation-approval-surface`
- W2 / 2sp — `knoxx-publication-locale-catalog`
- W4 / 2sp — `knoxx-website-publication-live-verification`