### PR TITLE
feat(knoxx): publication locale catalog cross-checks artifact and intent locale

### DIFF
--- a/backend/src/cljs/knoxx/backend/domain/publication_migration.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/publication_migration.cljs
@@ -141,7 +141,17 @@
                  (and (string? value) (seq value)) (keyword value))]
     (if (and locale (m/validate law/Locale locale))
       {:ok locale}
-      (conflict :unknown-locale field value row))))
+       (conflict :unknown-locale field value row))))
+
+(defn decode-garden-locales
+  "Decode a legacy target's explicit locale catalog without inventing a default.
+   The website owns reader-side defaults; a migration may only write locales the
+   legacy target actually declared."
+  [row]
+  (let [locales (:locales row)]
+    (if (m/validate law/LocaleCatalog locales)
+      {:ok locales}
+      (conflict :invalid-garden-locales :locales locales row))))
 
 (defn decode-revision
   [row]
@@ -220,18 +230,22 @@
 (defn garden->decision
   [policy row]
   (let [status (decode-garden-status row)
+        locales (decode-garden-locales row)
         garden-id (ident/canonical-garden-id policy row)]
     (cond
       (conflict? status) status
+
+      (conflict? locales) locales
 
       (nil? garden-id)
       (conflict :unresolvable-garden-identity :garden-id (:garden-id row) row)
 
       :else
       {:migration/status :candidate
-       :resource {:garden/id garden-id
-                  :garden/title (or (:title row) "")
-                  :garden/status (:ok status)}})))
+        :resource {:garden/id garden-id
+                   :garden/title (or (:title row) "")
+                   :garden/status (:ok status)
+                   :garden/locales (:ok locales)}})))
 
 (defn- identity-conflict
   "First identity component that cannot be represented faithfully, or nil.

--- a/backend/src/cljs/knoxx/backend/domain/publication_plan.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/publication_plan.cljs
@@ -95,11 +95,17 @@
       ;; Neither a request to publish nor a recognized takedown: refuse both
       ;; effects. No evidence is gathered, because there is no trustworthy
       ;; intent to gather it about.
-      (not (law/publishes? intent))
-      {:op :blocked
-       :intent intent
-       :blockers [:publication-state-unrecognized]
-       :concrete-revision nil}
+       (not (law/publishes? intent))
+       {:op :blocked
+        :intent intent
+        :blockers [:publication-state-unrecognized]
+        :concrete-revision nil}
 
-      :else
-      (converge intent observed (gate/publication-evidence intent facts)))))
+       (law/publication-locale-blocker resource-index intent)
+       {:op :blocked
+        :intent intent
+        :blockers [(law/publication-locale-blocker resource-index intent)]
+        :concrete-revision nil}
+
+       :else
+       (converge intent observed (gate/publication-evidence intent facts)))))

--- a/backend/src/cljs/knoxx/backend/domain/publication_resolver.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/publication_resolver.cljs
@@ -43,7 +43,7 @@
   [:document/id :document/title :document/source-locale :document/source])
 
 (def garden-projection-keys
-  [:garden/id :garden/title :garden/status])
+  [:garden/id :garden/title :garden/status :garden/locales])
 
 (def publication-projection-keys
   [:publication/id :publication/document :publication/garden :publication/locale

--- a/backend/src/cljs/knoxx/backend/infra/publication_effects.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/publication_effects.cljs
@@ -161,7 +161,7 @@
   [store target ctx plan artifact]
   (let [intent (:intent plan)
         concrete-revision (:concrete-revision plan)
-        checked (law/assert-artifact! artifact concrete-revision)
+        checked (law/assert-artifact! artifact intent concrete-revision)
         idempotency-key (publish-idempotency-key (target-id target)
                                                  intent
                                                  concrete-revision)]
@@ -212,8 +212,9 @@
                                             (:concrete-revision plan))
                    (catch :default _ nil)))
 
-       (law/artifact-revision-conflict? evidence)
-       (assoc :failure/conflict evidence)))))
+        (or (law/artifact-revision-conflict? evidence)
+            (law/artifact-locale-conflict? evidence))
+        (assoc :failure/conflict evidence)))))
 
 (defn ^:async execute-plan!
   "Execute a validated plan and return a validated receipt.

--- a/backend/src/cljs/knoxx/backend/infra/publication_target_memory.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/publication_target_memory.cljs
@@ -70,7 +70,7 @@
    adapter that admitted more than the boundary would be the one place a
    contradiction could live."
   [op]
-  (law/assert-artifact! (:artifact op) (:concrete-revision op)))
+  (law/assert-artifact! (:artifact op) (:intent op) (:concrete-revision op)))
 
 (defn- record-route!
   "Materialize `op`, replacing the prior route rather than leaving it public

--- a/backend/src/cljs/knoxx/backend/law/publication.cljs
+++ b/backend/src/cljs/knoxx/backend/law/publication.cljs
@@ -10,22 +10,19 @@
   route, collection, or identifier is required to satisfy any schema in this
   namespace."
   (:require [clojure.string :as str]
-            [malli.core :as m]
-            [malli.error :as me]))
+             [malli.core :as m]
+             [malli.error :as me]
+             [knoxx.backend.law.publication-locale :as locale]))
 
 ;; ── Locale ─────────────────────────────────────────────────────────────────
 
-(defn locale-keyword?
-  "A bare language tag (`:en`) or dashed variant (`:en-US`), as a keyword.
-   Namespaced document/garden ids are validated separately via
-   `qualified-keyword?` — locales are never namespaced."
-  [value]
-  (and (keyword? value)
-       (nil? (namespace value))
-       (boolean (re-matches #"[A-Za-z]{2,3}(-[A-Za-z0-9]{1,8})*" (name value)))))
-
 (def Locale
-  [:and keyword? [:fn locale-keyword?]])
+  "Re-exported portable language tag contract."
+  locale/Locale)
+
+(def LocaleCatalog
+  "A target's explicit, non-empty, duplicate-free catalog of accepted locales."
+  locale/LocaleCatalog)
 
 ;; ── Publication path ───────────────────────────────────────────────────────
 
@@ -69,7 +66,8 @@
   [:map
    [:garden/id qualified-keyword?]
    [:garden/title string?]
-   [:garden/status [:enum :active :archived]]])
+   [:garden/status [:enum :active :archived]]
+   [:garden/locales LocaleCatalog]])
 
 (def PublicationRevision
   "A revision *selector*: either a concrete revision or the `:source/current`
@@ -227,10 +225,25 @@
   (boolean
    (and (contains? reconcilable-publication-states (:publication/state intent))
         (contains? (:documents resource-index) (:publication/document intent))
-        (contains? (:gardens resource-index) (:publication/garden intent))
-        (= :active
-           (:garden/status
-            (get-in resource-index [:gardens (:publication/garden intent)]))))))
+         (contains? (:gardens resource-index) (:publication/garden intent))
+         (= :active
+            (:garden/status
+             (get-in resource-index [:gardens (:publication/garden intent)])))
+         (contains? (set (:garden/locales
+                          (get-in resource-index [:gardens (:publication/garden intent)])))
+                    (:publication/locale intent)))))
+
+(defn publication-locale-blocker
+  "Return the explicit reconciliation blocker when `intent` asks a target for an
+   unsupported locale, otherwise nil. This names the failed relation rather than
+   returning a generic inadmissible result so reconciliation records why it
+   declined to materialize a route."
+  [resource-index intent]
+  (let [target (get-in resource-index [:gardens (:publication/garden intent)])]
+    (when (and target
+               (not (contains? (set (:garden/locales target))
+                               (:publication/locale intent))))
+      :publication-locale-unsupported)))
 
 ;; ── The materialized artifact ──────────────────────────────────────────────
 
@@ -314,14 +327,12 @@
    Pinned by `the-artifact-is-produced-above-the-effect-boundary`, not left as
    prose.
 
-   `:artifact/revision` is the one field cross-checked against the op, by
+    `:artifact/revision` is cross-checked against the op, by
    `artifact-revision-conflict` below: it is the axis `publish-idempotency-key`
    is built from, so a disagreement there is the difference between replay-safe
    and republishing other content under a key that already reports `done`.
-   `:artifact/locale` is declared so an adapter can address bytes by locale
-   without re-deriving it from intent, and is deliberately *not* cross-checked
-   here — which locales a target accepts at all is a separate question, owned by
-   the locale-catalog resource rather than by this shape."
+    `:artifact/locale` is cross-checked against intent at the effect boundary
+    before an adapter can derive an artifact path from it."
   [:and
    [:map
     [:artifact/content ArtifactContent]
@@ -341,6 +352,17 @@
    [:conflict/type [:= :publication/artifact-revision-conflict]]
    [:conflict/artifact-revision :any]
    [:conflict/concrete-revision :any]])
+
+(def artifact-locale-identity-decision
+  "The locale identity decision for publication adapters: cross-check the
+   renderer artifact against publication intent before effects. Adapters may use
+   `:artifact/locale` to address bytes only after this boundary has established
+   equality, preventing wrong-language bytes behind an intent-derived route."
+  :cross-check)
+
+(def ArtifactLocaleConflict
+  "Re-exported portable artifact-versus-intent locale conflict contract."
+  locale/ArtifactLocaleConflict)
 
 (defn artifact-revision-conflict
   "nil when the artifact and the op agree about what is being published;
@@ -364,18 +386,39 @@
   [value]
   (m/validate ArtifactRevisionConflict value))
 
+(defn artifact-locale-conflict
+  "nil when `artifact` and `intent` name the same locale; otherwise return the
+   typed conflict that preserves both values for a failed receipt."
+  [artifact intent]
+  (locale/artifact-locale-conflict artifact intent))
+
+(defn artifact-locale-conflict?
+  "True when `value` is the typed locale-identity conflict emitted at the
+   publication effect boundary."
+  [value]
+  (locale/artifact-locale-conflict? value))
+
 (defn assert-artifact!
   "Return the artifact when it is publishable at `concrete-revision`; otherwise
    throw.
 
    Shape first, then agreement — a malformed artifact has no revision worth
-   comparing. Called above any effect, so nothing is reserved, written, or
-   recorded on behalf of a publication that cannot lawfully happen."
-  [artifact concrete-revision]
-  (assert-valid! :publication/artifact PublicationArtifact artifact)
-  (when-let [conflict (artifact-revision-conflict artifact concrete-revision)]
-    (throw
-     (ex-info (str "Publication artifact revision conflict: the artifact was "
-                   "rendered from a different source state than the plan publishes")
-              conflict)))
-  artifact)
+   comparing. The three-argument form additionally cross-checks locale identity
+   before adapter effects. Called above any effect, so nothing is reserved,
+   written, or recorded on behalf of a publication that cannot lawfully happen."
+  ([artifact concrete-revision]
+   (assert-artifact! artifact nil concrete-revision))
+  ([artifact intent concrete-revision]
+   (assert-valid! :publication/artifact PublicationArtifact artifact)
+   (when-let [conflict (artifact-revision-conflict artifact concrete-revision)]
+     (throw
+      (ex-info (str "Publication artifact revision conflict: the artifact was "
+                    "rendered from a different source state than the plan publishes")
+               conflict)))
+   (when (some? intent)
+     (when-let [conflict (artifact-locale-conflict artifact intent)]
+       (throw
+        (ex-info (str "Publication artifact locale conflict: the artifact locale "
+                      "differs from the publication intent")
+                 conflict))))
+   artifact))

--- a/backend/src/cljs/knoxx/backend/law/publication_locale.cljc
+++ b/backend/src/cljs/knoxx/backend/law/publication_locale.cljc
@@ -1,0 +1,42 @@
+(ns knoxx.backend.law.publication-locale
+  "Portable locale contracts for publication resources and artifacts."
+  (:require [malli.core :as m]))
+
+(defn locale-keyword?
+  "True for an unqualified language tag keyword, optionally with a variant."
+  [value]
+  (and (keyword? value)
+       (nil? (namespace value))
+       (boolean (re-matches #"[A-Za-z]{2,3}(-[A-Za-z0-9]{1,8})*" (name value)))))
+
+(def Locale
+  "A single unqualified language tag keyword."
+  [:and keyword? [:fn locale-keyword?]])
+
+(def LocaleCatalog
+  "A target's explicit, non-empty, duplicate-free catalog of accepted locales."
+  [:and [:vector Locale]
+   [:fn {:error/message "a publication target must declare one or more distinct accepted locales"}
+    #(and (seq %) (= (count %) (count (distinct %))))]])
+
+(def ArtifactLocaleConflict
+  "The renderer artifact and publication intent disagree about the locale whose
+   bytes may be exposed. Values remain `:any` to preserve invalid refusal evidence."
+  [:map
+   [:conflict/type [:= :publication/artifact-locale-conflict]]
+   [:conflict/artifact-locale :any]
+   [:conflict/publication-locale :any]])
+
+(defn artifact-locale-conflict
+  "nil when `artifact` and `intent` name the same locale; otherwise return the
+   typed conflict that preserves both values for a failed receipt."
+  [artifact intent]
+  (when (not= (:artifact/locale artifact) (:publication/locale intent))
+    {:conflict/type :publication/artifact-locale-conflict
+     :conflict/artifact-locale (:artifact/locale artifact)
+     :conflict/publication-locale (:publication/locale intent)}))
+
+(defn artifact-locale-conflict?
+  "True when `value` is the typed locale-identity conflict."
+  [value]
+  (m/validate ArtifactLocaleConflict value))

--- a/backend/src/cljs/knoxx/backend/law/publication_receipts.cljs
+++ b/backend/src/cljs/knoxx/backend/law/publication_receipts.cljs
@@ -25,6 +25,15 @@
 (def ArtifactRevisionConflict
   publication/ArtifactRevisionConflict)
 
+(def ArtifactLocaleConflict
+  "Re-exported locale-identity conflict so the effect boundary carries all
+   publication artifact refusal evidence through one law namespace."
+  publication/ArtifactLocaleConflict)
+
+(def PublicationArtifactConflict
+  "Any typed conflict that can prevent an artifact from being materialized."
+  [:or ArtifactRevisionConflict ArtifactLocaleConflict])
+
 ;; ── Plans entering the effect layer ────────────────────────────────────────
 
 (def PlanOp
@@ -103,7 +112,7 @@
    [:failure/reason publication/NonBlankString]
    [:failure/drift? [:= true]]
    [:idempotency/key {:optional true} [:maybe :string]]
-   [:failure/conflict {:optional true} [:maybe ArtifactRevisionConflict]]])
+    [:failure/conflict {:optional true} [:maybe PublicationArtifactConflict]]])
 
 (def Receipt
   [:multi {:dispatch :receipt/type}
@@ -130,8 +139,10 @@
    Called before the idempotency key is derived and before the store is touched,
    so a publication that cannot lawfully happen leaves no reservation behind for
    a later attempt to reconcile."
-  [artifact concrete-revision]
-  (publication/assert-artifact! artifact concrete-revision))
+  ([artifact concrete-revision]
+   (publication/assert-artifact! artifact concrete-revision))
+  ([artifact intent concrete-revision]
+   (publication/assert-artifact! artifact intent concrete-revision)))
 
 (defn artifact-revision-conflict?
   "True when a thrown `ex-data` is the typed artifact-revision conflict, so the
@@ -139,3 +150,9 @@
    inside a message string."
   [value]
   (publication/artifact-revision-conflict? value))
+
+(defn artifact-locale-conflict?
+  "True when a thrown `ex-data` is the typed artifact-locale conflict, so the
+   boundary preserves both locale values on the failed receipt."
+  [value]
+  (publication/artifact-locale-conflict? value))

--- a/backend/test/cljs/knoxx/backend/domain/publication_boundary_test.cljs
+++ b/backend/test/cljs/knoxx/backend/domain/publication_boundary_test.cljs
@@ -35,10 +35,12 @@
    :artifact/revision "abc123"})
 
 (def resource-index
-  {:gardens {:knoxx.docs/promethean {:garden/id :knoxx.docs/promethean
-                                     :garden/status :active}
-             :knoxx.docs/legacy {:garden/id :knoxx.docs/legacy
-                                 :garden/status :archived}}})
+   {:gardens {:knoxx.docs/promethean {:garden/id :knoxx.docs/promethean
+                                      :garden/status :active
+                                      :garden/locales [:en :es]}
+              :knoxx.docs/legacy {:garden/id :knoxx.docs/legacy
+                                  :garden/status :archived
+                                  :garden/locales [:en]}}})
 
 (defn- facts
   "Clean evidence, with observation read live from the target so the planner sees
@@ -220,4 +222,3 @@
       (testing "the contract refuses an unattributable removal outright"
         (is (thrown? js/Error
                      (law/assert-receipt! (dissoc removal-receipt :publication/id))))))))
-

--- a/backend/test/cljs/knoxx/backend/domain/publication_migration_test.cljs
+++ b/backend/test/cljs/knoxx/backend/domain/publication_migration_test.cljs
@@ -442,7 +442,8 @@
 ;; ── Fold phases ───────────────────────────────────────────────────────────
 
 (deftest ^:async fold-migrates-documents-and-gardens-too
-  (let [garden-row {:garden-id "garden-a" :title "Garden A" :status "active"}
+  (let [garden-row {:garden-id "garden-a" :title "Garden A" :status "active"
+                    :locales [:en]}
         row (membership-row legacy-document)
         {:keys [ctx]} (fake-ctx {:documents [legacy-document]
                                  :gardens [garden-row]

--- a/backend/test/cljs/knoxx/backend/domain/publication_plan_test.cljs
+++ b/backend/test/cljs/knoxx/backend/domain/publication_plan_test.cljs
@@ -6,10 +6,12 @@
 ;; ── Fixtures ───────────────────────────────────────────────────────────────
 
 (def active-garden
-  {:garden/id :knoxx.docs/promethean :garden/title "Promethean" :garden/status :active})
+  {:garden/id :knoxx.docs/promethean :garden/title "Promethean" :garden/status :active
+   :garden/locales [:en :es]})
 
 (def archived-garden
-  {:garden/id :knoxx.docs/legacy :garden/title "Legacy" :garden/status :archived})
+  {:garden/id :knoxx.docs/legacy :garden/title "Legacy" :garden/status :archived
+   :garden/locales [:en]})
 
 (def resource-index
   {:gardens {:knoxx.docs/promethean active-garden
@@ -159,7 +161,14 @@
     (is (= [:publication-revision-unresolved] (:blockers result)))
     (is (nil? (:concrete-revision result)))
     (testing "no publish plan is emitted"
-      (is (not= :publish (:op result))))))
+    (is (not= :publish (:op result))))))
+
+(deftest unsupported-locale-is-blocked-before-evidence-or-materialization
+  (let [result (plan-for {:publication/locale :de} {})]
+    (is (= :blocked (:op result)))
+    (is (= [:publication-locale-unsupported] (:blockers result)))
+    (is (nil? (:concrete-revision result)))
+    (is (nil? (:desired result)))))
 
 ;; ── 10 no publish plan carries a nil revision ─────────────────────────────
 
@@ -245,4 +254,3 @@
                                   {:observed converged-observation}))))
     (is (= :noop (:op (plan-for {:publication/state :withheld} {}))))
     (is (= :noop (:op (plan-for {:publication/state :archived} {}))))))
-

--- a/backend/test/cljs/knoxx/backend/domain/publication_resolver_test.cljs
+++ b/backend/test/cljs/knoxx/backend/domain/publication_resolver_test.cljs
@@ -27,7 +27,8 @@
   {:namespace :knoxx.docs
    :garden/id :promethean
    :garden/title "Promethean"
-   :garden/status :active})
+   :garden/status :active
+   :garden/locales [:en :es]})
 
 (def qualified-garden
   (assoc local-garden :garden/id :knoxx.docs/promethean))

--- a/backend/test/cljs/knoxx/backend/e2e/contract_publication_test.cljs
+++ b/backend/test/cljs/knoxx/backend/e2e/contract_publication_test.cljs
@@ -82,7 +82,8 @@
   {:namespace :knoxx.docs
    :garden/id :promethean
    :garden/title "Promethean"
-   :garden/status :active})
+   :garden/status :active
+   :garden/locales [:en :es]})
 
 (def intent-resource
   {:namespace :knoxx.docs

--- a/backend/test/cljs/knoxx/backend/infra/cms_publication_facade_test.cljs
+++ b/backend/test/cljs/knoxx/backend/infra/cms_publication_facade_test.cljs
@@ -30,7 +30,8 @@
    :document/source-locale :en})
 
 (def garden
-  {:garden/id :knoxx.docs/promethean :garden/title "Promethean" :garden/status :active})
+  {:garden/id :knoxx.docs/promethean :garden/title "Promethean" :garden/status :active
+   :garden/locales [:en :es]})
 
 (def no-evidence {:receipts {} :blockers {}})
 

--- a/backend/test/cljs/knoxx/backend/infra/publication_effects_test.cljs
+++ b/backend/test/cljs/knoxx/backend/infra/publication_effects_test.cljs
@@ -442,7 +442,22 @@
         (is (true? (law/artifact-revision-conflict? (:failure/conflict receipt)))))
       (is (empty? @calls) "nothing was published")
       (is (empty? @routes))
-      (is (empty? @state) "and nothing was claimed"))))
+       (is (empty? @state) "and nothing was claimed"))))
+
+(deftest ^:async an-artifact-locale-conflict-never-exposes-a-route
+  (let [{:keys [store state]} (fake-store)
+        {:keys [target calls routes]} (fake-target {})
+        receipt (await (effects/execute-plan!
+                        store target {} publish-plan
+                        (assoc artifact :artifact/locale :fr)))]
+    (is (= :publication/failed (:receipt/type receipt)))
+    (is (= {:conflict/type :publication/artifact-locale-conflict
+            :conflict/artifact-locale :fr
+            :conflict/publication-locale :es}
+           (:failure/conflict receipt)))
+    (is (empty? @calls) "no adapter effect may run")
+    (is (empty? @routes) "no correct-looking route may expose wrong-language bytes")
+    (is (empty? @state) "a refused locale must not reserve an idempotency key")))
 
 (deftest ^:async an-agreeing-artifact-publishes-as-bytes-or-as-a-string
   (testing "bytes and a string are both content; the difference is only whether

--- a/backend/test/cljs/knoxx/backend/infra/publications_facade_test.cljs
+++ b/backend/test/cljs/knoxx/backend/infra/publications_facade_test.cljs
@@ -29,7 +29,8 @@
   {:namespace :knoxx.docs
    :garden/id :knoxx.docs/promethean
    :garden/title "Promethean"
-   :garden/status :active})
+   :garden/status :active
+   :garden/locales [:en :es]})
 
 (defn- expanded-records
   "What the loader actually hands the facade for a composite entry: one record

--- a/backend/test/cljs/knoxx/backend/law/publication_test.cljs
+++ b/backend/test/cljs/knoxx/backend/law/publication_test.cljs
@@ -35,12 +35,14 @@
 (def promethean-garden
   {:garden/id :gardens/promethean
    :garden/title "Promethean"
-   :garden/status :active})
+   :garden/status :active
+   :garden/locales [:en :es :fr]})
 
 (def legacy-garden
   {:garden/id :gardens/legacy
    :garden/title "Legacy"
-   :garden/status :archived})
+   :garden/status :archived
+   :garden/locales [:en]})
 
 (def style-guide-fr-intent
   {:publication/id :knoxx.docs/translation-pipeline-fr
@@ -104,6 +106,12 @@
   (is (false? (m/validate pub/Garden (assoc promethean-garden :garden/status "active"))))
   (is (false? (m/validate pub/Garden (assoc promethean-garden :garden/status :deleted)))))
 
+(deftest garden-locale-catalog-is-explicit-and-distinct
+  (is (true? (m/validate pub/Garden promethean-garden)))
+  (doseq [locales [nil [] [:en :en] [:locale/en]]]
+    (is (false? (m/validate pub/Garden (assoc promethean-garden :garden/locales locales)))
+        (pr-str locales))))
+
 ;; ── 5 PublicationIntentResource ──────────────────────────────────────────
 
 (deftest publication-intent-resource-validates-relation
@@ -156,8 +164,19 @@
                  resource-index
                  (assoc example-manifest-intent :publication/document :knoxx.docs/unknown))))
     (is (false? (pub/admissible-publication?
+                  resource-index
+                  (assoc example-manifest-intent :publication/garden :gardens/unknown))))))
+
+(deftest admissible-publication?-requires-a-target-accepted-locale
+  (let [resource-index (pub/index-resources [translation-pipeline-document promethean-garden])]
+    (is (true? (pub/admissible-publication? resource-index example-manifest-intent)))
+    (is (false? (pub/admissible-publication?
                  resource-index
-                 (assoc example-manifest-intent :publication/garden :gardens/unknown))))))
+                 (assoc example-manifest-intent :publication/locale :de))))
+    (is (= :publication-locale-unsupported
+           (pub/publication-locale-blocker
+            resource-index
+            (assoc example-manifest-intent :publication/locale :de))))))
 
 (deftest admissible-publication?-rejects-archived-intent-state-with-an-active-garden
   (let [resource-index (pub/index-resources [translation-pipeline-document promethean-garden])]
@@ -294,6 +313,20 @@
     (is (= {:conflict/type :publication/artifact-revision-conflict
             :conflict/artifact-revision "rev-7f3a91c"
             :conflict/concrete-revision "rev-other"}
-           (try (pub/assert-artifact! probe-artifact "rev-other")
-                nil
-                (catch :default err (ex-data err)))))))
+            (try (pub/assert-artifact! probe-artifact "rev-other")
+                 nil
+                 (catch :default err (ex-data err)))))))
+
+(deftest artifact-locale-conflict-carries-both-locales
+  (let [intent (assoc example-manifest-intent :publication/locale :es)
+        conflict (pub/artifact-locale-conflict (assoc probe-artifact :artifact/locale :fr) intent)]
+    (is (= :cross-check pub/artifact-locale-identity-decision))
+    (is (= {:conflict/type :publication/artifact-locale-conflict
+            :conflict/artifact-locale :fr
+            :conflict/publication-locale :es}
+           conflict))
+    (is (true? (pub/artifact-locale-conflict? conflict)))
+    (is (thrown-with-msg? js/Error #"locale conflict"
+                          (pub/assert-artifact! (assoc probe-artifact :artifact/locale :fr)
+                                                intent
+                                                "rev-7f3a91c")))))


### PR DESCRIPTION
## Card

- `knoxx-publication-locale-catalog`

## Verification

- Ran 1063 tests containing 3856 assertions. 0 failures, 0 errors.

## Decision

- Cross-check chosen: `:artifact/locale` must equal `:publication/locale` at the effect boundary. Conflicts produce a typed `:publication/artifact-locale-conflict` receipt.

## Notes

- The 3 pre-existing clj-kondo warnings in touched files are not new.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Gardens now declare the languages they support.
  - Publications validate that their selected language is supported by the target garden.
  - Publication artifacts are checked for language consistency with the publication request.

- **Bug Fixes**
  - Unsupported or conflicting languages now produce clear publication blockers and typed failure details.
  - Legacy garden data is validated during migration, with invalid language catalogs reported as conflicts.
  - Invalid publications are stopped before any publishing actions occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->