### PR TITLE
feat(knoxx): static-site publication target adapter with atomic manifest

### DIFF
--- a/backend/src/cljs/knoxx/backend/domain/node/fs.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/node/fs.cljs
@@ -110,3 +110,81 @@
     (catch :default err
       (when-not (= "ENOENT" (.-code err))
         (throw err)))))
+
+;; ── Publication-target additions ──────────────────────────────────────────
+;; Atomic create/rename and synchronous variants, added for the static-site
+;; publication target. Same boundary: node objects never leave this file.
+
+(defn join
+  "Join path segments with the platform separator, normalizing the result."
+  [& parts]
+  (.apply (.-join path) path (into-array (map str parts))))
+
+(defn parent
+  "The parent directory of path `p`."
+  [p]
+  (.dirname path (str p)))
+
+(defn ^:async rename!
+  "Promise<nil>. Atomically rename `from` to `to` (same filesystem)."
+  [from to]
+  (.rename fs (str from) (str to)))
+
+(defn ^:async read-file-or-nil!
+  "Promise<string|nil>. UTF-8 file contents, or nil when the file is absent."
+  [p]
+  (try
+    (await (.readFile fs (str p) "utf8"))
+    (catch :default err
+      (when-not (= "ENOENT" (.-code err))
+        (throw err))
+      nil)))
+
+(defn write-file-encoded!
+  "Promise<nil>. Write `text` to `p` using the named character encoding
+   (e.g. \"utf-8\"). Dirs must already exist."
+  [p text encoding]
+  (.writeFile fs (str p) (str text) (str encoding)))
+
+(defn write-bytes!
+  "Promise<nil>. Write a Uint8Array to `p` verbatim. Dirs must already exist."
+  [p bytes]
+  (.writeFile fs (str p) bytes))
+
+(defn write-file-exclusive-sync!
+  "Atomically create `p` with `content`, failing if it exists. Returns true
+   when this call created the file, false when it already existed; any other
+   error is thrown. One `open(2)` with O_EXCL — there is no separate
+   check-then-create for a concurrent caller to slip between."
+  [p content]
+  (try
+    (.writeFileSync node-fs (str p) (str content) #js {:flag "wx"})
+    true
+    (catch :default err
+      (if (= "EEXIST" (.-code err))
+        false
+        (throw err)))))
+
+(defn write-file-sync!
+  "Synchronously write `content` to `p` as UTF-8, creating or overwriting."
+  [p content]
+  (.writeFileSync node-fs (str p) (str content) "utf8"))
+
+(defn rename-sync!
+  "Synchronously and atomically rename `from` to `to` (same filesystem)."
+  [from to]
+  (.renameSync node-fs (str from) (str to)))
+
+(defn unlink-sync!
+  "Synchronously delete `p`. Never throws on an already-absent file."
+  [p]
+  (try
+    (.unlinkSync node-fs (str p))
+    (catch :default err
+      (when-not (= "ENOENT" (.-code err))
+        (throw err)))))
+
+(defn mkdir-sync!
+  "Synchronously create `p` and all parents. Safe to call if it exists."
+  [p]
+  (.mkdirSync node-fs (str p) #js {:recursive true}))

--- a/backend/src/cljs/knoxx/backend/infra/publication_target_static_site.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/publication_target_static_site.cljs
@@ -1,0 +1,357 @@
+(ns knoxx.backend.infra.publication-target-static-site
+  "The static-site `IPublicationTarget`: bytes on a filesystem content root,
+   committed by an atomically replaced EDN manifest.
+
+   THE MANIFEST IS THE PUBLISHED FACT. A file on disk that no manifest entry
+   names is not public, so every publish writes the artifact first and updates
+   `manifest.edn` as the commit point. Both artifact and manifest writes are
+   write-beside-then-rename, so a reader — a static file server has no read
+   lock — observes either the whole old file or the whole new one, never a
+   half-written one.
+
+   Concurrency is real here in a way it is not in the memory target: two
+   reconciler runs, or a run overlapping a deploy, touch the same directory.
+   Manifest read-modify-write is serialized by a lock file created with
+   O_EXCL (`domain.node.fs/write-file-exclusive-sync!` — the create IS the
+   check; there is no await between reading and claiming). A holder that
+   crashes leaves its lock behind, so a lock older than `lock-stale-ms` is
+   unlinked and retried; the post-acquire token check keeps a takeover from
+   letting two holders believe they hold it. Temp files are unique per write
+   (`*.tmp-<random>`), so overlapping writers never share a temp name.
+
+   ORPHANS AND GROWTH. Publishing a new revision reclaims the superseded
+   revision's artifact file after the manifest commit, and removal reclaims
+   the removed route's file — so live content is bounded by one file per
+   (document, locale, revision) actually referenced by the manifest. What is
+   deliberately retained: crash-orphaned `*.tmp-*` files, bounded by crash
+   frequency and sweepable by age, and artifact files whose manifest entries
+   were removed by an editor other than this adapter. Neither is public —
+   the manifest names everything that serves.
+
+   This adapter TRANSPORTS. It contains no admissibility, gating, or planning
+   logic: it validates the artifact it is handed (an adapter is reachable
+   without the effect boundary, so the boundary's check is not this adapter's
+   check), and every other decision — what may publish, where it converges,
+   whether a locale is admitted — was made above it."
+  (:require [clojure.edn :as edn]
+            [knoxx.backend.domain.node.crypto :as crypto]
+            [knoxx.backend.domain.node.fs :as fs]
+            [knoxx.backend.infra.publication-effects :as effects]
+            [knoxx.backend.law.publication-manifest :as manifest-law]
+            [knoxx.backend.law.publication-receipts :as law]))
+
+(def kind
+  "The target-registry kind this adapter answers to."
+  :publication-target/static-site)
+
+(def ^:private manifest-filename "manifest.edn")
+(def ^:private lock-filename "manifest.lock")
+(def ^:private idempotency-dirname ".idempotency")
+
+(def ^:private lock-stale-ms
+  "Age at which a held lock is presumed abandoned by a crashed writer."
+  30000)
+(def ^:private lock-wait-ms
+  "How long a writer waits for a live lock before failing the effect. A
+   failure surfaces as drift on the receipt, so a slow peer degrades to a
+   retriable miss, never a corrupted manifest."
+  5000)
+(def ^:private lock-poll-ms 10)
+
+;; ── Manifest lock ──────────────────────────────────────────────────────────
+
+(defn- sleep!
+  "Promise<nil> resolving after `ms`. Polling the lock must yield the event
+   loop, or a contended in-process peer could never finish its critical
+   section."
+  [ms]
+  (js/Promise. (fn [resolve] (js/setTimeout resolve ms))))
+
+(defn- ^:async acquire-lock!
+  "Take the manifest lock, returning this holder's token.
+
+   The lock file's content is a random token: after a stale takeover unlinks
+   and recreates the file, the previous would-be holder's post-acquire read
+   no longer matches its token and it keeps waiting instead of entering the
+   critical section it does not hold."
+  [root]
+  (let [lock-path (fs/join root lock-filename)
+        token (crypto/random-hex 8)
+        deadline (+ (js/Date.now) lock-wait-ms)]
+    (loop []
+      (if (fs/write-file-exclusive-sync! lock-path token)
+        (if (= token (fs/read-file-sync lock-path))
+          token
+          (do (await (sleep! lock-poll-ms))
+              (recur)))
+        (do (when-let [stat (await (fs/stat-or-nil! lock-path))]
+              (when (< (:mtime-ms stat) (- (js/Date.now) lock-stale-ms))
+                (fs/unlink-sync! lock-path)))
+            (when (<= deadline (js/Date.now))
+              (throw (ex-info "publication manifest lock unavailable"
+                              {:content-root root})))
+            (await (sleep! lock-poll-ms))
+            (recur))))))
+
+(defn- release-lock!
+  "Release the manifest lock, but only if this holder's token is still the
+   one on disk — after a stale takeover the file belongs to someone else."
+  [root token]
+  (let [lock-path (fs/join root lock-filename)]
+    (when (= token (fs/read-file-sync lock-path))
+      (fs/unlink-sync! lock-path))))
+
+(defn- ^:async with-manifest-lock!
+  "Run zero-argument async `f` holding the manifest lock."
+  [root f]
+  (let [token (await (acquire-lock! root))]
+    (try
+      (await (f))
+      (finally
+        (release-lock! root token)))))
+
+;; ── Manifest and artifact I/O ──────────────────────────────────────────────
+
+(defn- ^:async read-manifest!
+  "The current manifest, or nil when absent. Absent is the normal state of
+   every content root before the first publication — never an error. A
+   manifest that EXISTS but does not parse or validate throws: that is a
+   writer defect, and reading it as empty would publish over routes nobody
+   can account for."
+  [root]
+  (when-let [edn-string (await (fs/read-file-or-nil!
+                                (fs/join root manifest-filename)))]
+    (manifest-law/edn->manifest edn-string)))
+
+(defn- ^:async write-manifest-atomic!
+  "The commit point. Write beside and rename, so a reader observes either the
+   whole old manifest or the whole new one."
+  [root manifest]
+  (let [final-path (fs/join root manifest-filename)
+        temp-path (str final-path ".tmp-" (crypto/random-hex 8))]
+    (await (fs/write-file-encoded! temp-path
+                                   (manifest-law/manifest->edn manifest)
+                                   "utf-8"))
+    (await (fs/rename! temp-path final-path))))
+
+(defn- ^:async write-artifact-atomic!
+  "Write the artifact bytes beside their final name and rename into place.
+   A string is written under the artifact's declared `:artifact/encoding`;
+   bytes are written verbatim. Nothing is re-encoded or re-decided."
+  [root relative-path artifact]
+  (let [final-path (fs/join root relative-path)
+        temp-path (str final-path ".tmp-" (crypto/random-hex 8))]
+    (await (fs/mkdir! (fs/parent final-path)))
+    (if (string? (:artifact/content artifact))
+      (await (fs/write-file-encoded! temp-path
+                                     (:artifact/content artifact)
+                                     (:artifact/encoding artifact)))
+      (await (fs/write-bytes! temp-path (:artifact/content artifact))))
+    (await (fs/rename! temp-path final-path))))
+
+(defn- ^:async reclaim-artifact!
+  "Best-effort unlink of a superseded or removed route's artifact file.
+
+   Runs AFTER the manifest commit, so its failure can never retract a
+   committed publication: the route is already gone (or already replaced)
+   and the file is already unreferenced. A failure leaves an orphan, which
+   the namespace docstring bounds — it must not leave a failed receipt for
+   a publication that succeeded."
+  [root relative-path]
+  (when relative-path
+    (try
+      (await (fs/unlink! (fs/join root relative-path)))
+      (catch :default err
+        (js/console.warn "[publication-static-site] could not reclaim artifact"
+                         relative-path (ex-message err))))))
+
+;; ── Receipts ───────────────────────────────────────────────────────────────
+
+(defn- materialized-receipt
+  "Evidence of the materialization the op requested. Same shape the memory
+   target returns, so adapters stay interchangeable upward."
+  [adapter-id op]
+  (let [intent (:intent op)
+        revision (:concrete-revision op)
+        path (:publication/path intent)]
+    {:receipt/type :publication/materialized
+     :publication/id (:publication/id intent)
+     :adapter/id adapter-id
+     :idempotency/key (:idempotency/key op)
+     :document/id (:publication/document intent)
+     :target (:publication/garden intent)
+     :locale (:publication/locale intent)
+     :revision revision
+     :path path
+     :materialized/revision revision
+     :materialized/path path}))
+
+;; ── Protocol methods ───────────────────────────────────────────────────────
+
+(defn- ^:async commit-route!
+  "The critical section of a publish, run holding the manifest lock: write
+   the artifact bytes, commit the manifest route, then reclaim the displaced
+   route's bytes. Replay — manifest route identical AND artifact file
+   present — rewrites nothing: the bytes on disk are already exactly what
+   this op was asked to serve."
+  [root route artifact]
+  (let [manifest (or (await (read-manifest! root))
+                     (manifest-law/empty-manifest))
+        existing (manifest-law/find-route manifest (:publication/id route))
+        artifact-path (:route/artifact route)
+        unchanged? (and (= existing route)
+                        (fs/exists? (fs/join root artifact-path)))]
+    (when-not unchanged?
+      (await (write-artifact-atomic! root artifact-path artifact))
+      (await (write-manifest-atomic! root
+                                     (-> manifest
+                                         (manifest-law/upsert-route route)
+                                         (manifest-law/touch))))
+      (let [previous-path (:route/artifact existing)]
+        (when (and previous-path (not= previous-path artifact-path))
+          (await (reclaim-artifact! root previous-path)))))))
+
+(defn- ^:async publish-artifact!
+  "Materialize `op`: validate the artifact, write its bytes, then commit the
+   manifest route."
+  [root adapter-id op]
+  (let [intent (:intent op)
+        artifact (law/assert-artifact! (:artifact op) intent (:concrete-revision op))
+        route (manifest-law/route-for-artifact intent artifact)]
+    (await (with-manifest-lock! root
+                                (^:async fn []
+                                  (await (commit-route! root route artifact)))))
+    (materialized-receipt adapter-id op)))
+
+(defn- ^:async remove-publication!
+  "Take the publication's route out of the manifest (the commit), then
+   reclaim its artifact file. Keyed on `:publication/id`, so a removal finds
+   the route wherever a path move left it. Idempotent: nothing manifested
+   is nothing to remove, and the receipt is the same either way."
+  [root intent observed]
+  (await (with-manifest-lock!
+          root
+          (^:async fn []
+            (when-let [manifest (await (read-manifest! root))]
+              (when-let [route (manifest-law/find-route manifest
+                                                        (:publication/id intent))]
+                (await (write-manifest-atomic!
+                        root
+                        (-> manifest
+                            (manifest-law/remove-route (:publication/id intent))
+                            (manifest-law/touch))))
+                (await (reclaim-artifact! root (:route/artifact route))))))))
+  {:receipt/type :publication/removed
+   :publication/id (:publication/id intent)
+   :removed/path (:materialized/path observed)})
+
+(defn- ^:async observe-publication!
+  "The observed materialization for `intent`, or nil.
+
+   Read from the manifest and keyed on `:publication/id`, never on the
+   desired path — keying on path is what makes a path move leave both routes
+   public, because the route being replaced is invisible at its old address.
+
+   The manifest is the published fact, but a route only SERVES when its
+   bytes exist. A deploy overlap or external deletion can remove the file
+   without touching the manifest; reporting that route as materialized would
+   block convergence, so an absent artifact reads as not published and the
+   planner republishes."
+  [root intent]
+  (when-let [manifest (await (read-manifest! root))]
+    (when-let [route (manifest-law/find-route manifest (:publication/id intent))]
+      (when (fs/exists? (fs/join root (:route/artifact route)))
+        {:materialized/revision (:route/revision route)
+         :materialized/path (:route/path route)
+         :publication/id (:publication/id route)
+         :locale (:route/locale route)
+         :route/artifact (:route/artifact route)}))))
+
+;; ── Construction ───────────────────────────────────────────────────────────
+
+(defn static-site-target
+  "An `IPublicationTarget` persisting under the content root named by the
+   declaration's `:publication-target/config` `:content-root`.
+
+   Takes the whole validated declaration so the registry can use this
+   function directly as a kind factory; the adapter's identity IS the
+   declared target id, which is what keeps idempotency keys resource-owned."
+  [declaration]
+  (let [target-id (:publication-target/id declaration)
+        content-root (get-in declaration
+                             [:publication-target/config :content-root])]
+    (when-not (and (string? content-root) (seq content-root))
+      (throw (ex-info "static-site publication target requires a :content-root"
+                      {:publication-target/id target-id})))
+    (reify effects/IPublicationTarget
+      (target-id [_] target-id)
+      (publish! [_ _ctx op]
+        (publish-artifact! content-root target-id op))
+      (remove! [_ _ctx intent observed]
+        (remove-publication! content-root intent observed))
+      (observe! [_ _ctx intent]
+        (observe-publication! content-root intent)))))
+
+;; ── Idempotency store ──────────────────────────────────────────────────────
+
+(defn- read-edn-safe
+  "Parse `edn-string`, nil on any failure. A reservation file whose content
+   cannot be read is a claim whose outcome is unknown, which is exactly what
+   `:in-flight` means — never a reason to throw past the store."
+  [edn-string]
+  (try
+    (edn/read-string edn-string)
+    (catch :default _ nil)))
+
+(defn- reserve-key!
+  "Atomically claim the reservation file for `key`, or report what the
+   existing claim knows. The O_EXCL create IS the check: no await and no
+   separate existence test for a concurrent caller or a crash to slip
+   between."
+  [key-file key]
+  (let [file (key-file key)]
+    (if (fs/write-file-exclusive-sync!
+         file (pr-str {:idempotency/status :in-flight}))
+      {:reservation/status :reserved}
+      (let [entry (read-edn-safe (fs/read-file-sync file))]
+        (if (:receipt entry)
+          {:reservation/status :done :receipt (:receipt entry)}
+          {:reservation/status :in-flight})))))
+
+(defn- complete-key!
+  "Record `receipt` for a claimed key, written beside the claim and renamed
+   over it, so a concurrent `reserve!` reads either the in-flight marker or
+   the whole receipt, never a torn write."
+  [key-file key receipt]
+  (let [file (key-file key)
+        temp-path (str file ".tmp-" (crypto/random-hex 8))]
+    (fs/write-file-sync! temp-path (pr-str {:receipt receipt}))
+    (fs/rename-sync! temp-path file))
+  nil)
+
+(defn static-site-store
+  "An `IIdempotencyStore` persisted under `<content-root>/.idempotency/`,
+   one file per key, named by the key's SHA-256 so any key content and length
+   maps to a safe, deterministic filename.
+
+   All three methods are synchronous: `publish-once!` reads the reservation
+   map directly off the call, and a promise here would fall through its
+   `case` as an unrecognized status."
+  [content-root]
+  (let [dir (fs/join content-root idempotency-dirname)
+        ensured? (atom false)
+        ensure-dir! (fn []
+                      (when-not @ensured?
+                        (fs/mkdir-sync! dir)
+                        (reset! ensured? true)))
+        key-file (fn [key] (fs/join dir (str (crypto/sha256-hex key) ".edn")))]
+    (reify effects/IIdempotencyStore
+      (reserve! [_ key]
+        (ensure-dir!)
+        (reserve-key! key-file key))
+      (complete! [_ key receipt]
+        (ensure-dir!)
+        (complete-key! key-file key receipt))
+      (release! [_ key]
+        (fs/unlink-sync! (key-file key))
+        nil))))

--- a/backend/src/cljs/knoxx/backend/law/publication_manifest.cljc
+++ b/backend/src/cljs/knoxx/backend/law/publication_manifest.cljc
@@ -1,0 +1,252 @@
+(ns knoxx.backend.law.publication-manifest
+  "Contracts and pure transforms for the published-content manifest.
+
+   The manifest is the published fact: a file on disk that no manifest entry
+   names is not public. This namespace owns the manifest's SHAPE and every
+   pure decision about it — route derivation, upsert/removal keyed by
+   `:publication/id`, EDN round-trip — so the filesystem adapter only
+   transports. No I/O lives here.
+
+   The cross-repo contract this declares the writer side of is
+   `docs/notes/published-content-manifest-cross-repo-contract.md` in Foresight:
+   EDN with namespaced keys, `manifest.edn` at the content root, artifacts
+   under `artifacts/<document>/<locale>/<revision>.<ext>`, and an absent
+   manifest meaning an empty published set rather than an error."
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]
+            [knoxx.backend.law.publication-locale :as locale]
+            [malli.core :as m]
+            [malli.error :as me]))
+
+;; ── Route and manifest contracts ────────────────────────────────────────────
+
+(defn nonblank-string?
+  "True for a string carrying at least one non-whitespace character."
+  [value]
+  (and (string? value) (seq (str/trim value))))
+
+(defn valid-route-path?
+  "A public route path: absolute, no query or fragment. Mirrors
+    `law.publication/valid-publication-path?`; restated here because that
+    namespace is `.cljs` (its bytes predicate has no portable spelling) and
+    this contract must stay portable."
+  [value]
+  (boolean
+   (and (nonblank-string? value)
+        (str/starts-with? value "/")
+        (not (str/includes? value "?"))
+        (not (str/includes? value "#"))
+        (not (str/includes? value "\u0000")))))
+
+(defn valid-artifact-path?
+  "A manifest-relative artifact path: relative, no traversal, no query or
+    fragment. What makes a route servable is that this path resolves inside
+    the content root, so anything that could escape it is refused at the
+    contract rather than at the filesystem."
+  [value]
+  (boolean
+   (and (nonblank-string? value)
+        (not (str/starts-with? value "/"))
+        (not (str/includes? value ".."))
+        (not (str/includes? value "\\"))
+        (not (str/includes? value "?"))
+        (not (str/includes? value "#"))
+        (not (str/includes? value "\u0000")))))
+
+(defn valid-media-type?
+  "`type/subtype` with no parameters. Mirrors
+    `law.publication/valid-media-type?` — the media type on a route IS the
+    artifact's media type, carried verbatim, so the two predicates must accept
+    exactly the same values."
+  [value]
+  (boolean
+   (and (string? value)
+        (re-matches #"[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*"
+                    value))))
+
+(def ManifestRoute
+  "One published route. The required set is what the cross-repo contract makes
+    a reader fail loudly without (`:route/path`, `:route/locale`,
+    `:route/artifact`, `:route/media-type`) plus what THIS writer always emits
+    and its own `observe!` depends on: `:route/revision`, `:route/encoding`,
+    and `:publication/id`. `:route/artifact` is a PATH, never the artifact
+    value — the manifest names where bytes live; it never holds them."
+  [:map
+   [:route/path [:and string? [:fn valid-route-path?]]]
+   [:route/locale locale/Locale]
+   [:route/artifact [:and string? [:fn valid-artifact-path?]]]
+   [:route/media-type [:and string? [:fn valid-media-type?]]]
+   [:route/encoding [:fn nonblank-string?]]
+   [:route/revision [:fn nonblank-string?]]
+   [:publication/id [:fn qualified-keyword?]]
+   [:route/document {:optional true} [:fn nonblank-string?]]
+   [:route/title {:optional true} string?]])
+
+(def Manifest
+  "The published fact. `:manifest/version` lets a reader reject a shape it
+    does not understand rather than rendering a blank page."
+  [:map
+   [:manifest/version [:= 1]]
+   [:manifest/generated-at [:fn nonblank-string?]]
+   [:manifest/routes [:vector ManifestRoute]]])
+
+(defn assert-manifest!
+  "Return `manifest` when it satisfies the contract; otherwise throw. Called
+    on every write and on every read-back: a malformed manifest is a writer
+    defect, and continuing past it would publish routes nobody can account
+    for."
+  [manifest]
+  (if (m/validate Manifest manifest)
+    manifest
+    (throw
+     (ex-info "Published content manifest contract violation"
+              {:contract :publication/manifest
+               :errors (me/humanize (m/explain Manifest manifest))}))))
+
+;; ── Lifecycle ───────────────────────────────────────────────────────────────
+
+(defn- now-iso
+  "The current instant as an ISO-8601 string."
+  []
+  #?(:cljs (.toISOString (js/Date.))
+     :clj (str (java.time.Instant/now))))
+
+(defn empty-manifest
+  "A manifest with no routes. An empty content root is a valid initial state,
+    and this is its manifest: not an error, not a missing file the reader must
+    special-case beyond \"nothing published yet\"."
+  []
+  {:manifest/version 1
+   :manifest/generated-at (now-iso)
+   :manifest/routes []})
+
+(defn touch
+  "Return `manifest` with `:manifest/generated-at` set to now. The timestamp
+    is diagnostic, never load-bearing: no convergence decision reads it."
+  [manifest]
+  (assoc manifest :manifest/generated-at (now-iso)))
+
+;; ── Path derivation ─────────────────────────────────────────────────────────
+
+(defn sanitize-segment
+  "Map an arbitrary string to one safe filesystem path segment.
+
+    Every character outside `[A-Za-z0-9._-]` becomes `-`, leading dots are
+    stripped (dotfiles and traversal), and an empty result falls back to
+    `\"-\"`. Inputs here are contract-checked upstream — a concrete revision is
+    a non-blank string, a locale a language-tag keyword — but the segment is
+    what touches a filesystem, so the check is repeated at the derivation
+    rather than trusted."
+  [value]
+  (let [cleaned (-> (str value)
+                    (str/replace #"[^A-Za-z0-9._-]+" "-")
+                    (str/replace #"^\.+" ""))]
+    (if (seq cleaned) cleaned "-")))
+
+(defn document-path-segment
+  "The document's manifest path segment(s): `namespace/name` for a qualified
+    keyword, `name` otherwise, each side sanitized."
+  [document-id]
+  (if (namespace document-id)
+    (str (sanitize-segment (namespace document-id))
+         "/"
+         (sanitize-segment (name document-id)))
+    (sanitize-segment (name document-id))))
+
+(def ^:private media-type-extension-aliases
+  "Conventional extensions where the bare subtype is not the name a person
+   browsing the content root expects. Naming only — `:route/media-type` is
+   the serving truth and is never derived from the extension."
+  {"text/plain" "txt"
+   "text/markdown" "md"
+   "image/jpeg" "jpg"})
+
+(defn media-type-extension
+  "The file extension for a media type: a conventional alias when one exists,
+    else the subtype up to any `+` suffix, sanitized. `text/html` -> `html`,
+    `image/svg+xml` -> `svg`. This is a NAMING convenience only."
+  [media-type]
+  (or (get media-type-extension-aliases media-type)
+      (-> (subs media-type (inc (str/index-of media-type "/")))
+          (str/replace #"\+.*$" "")
+          sanitize-segment)))
+
+(defn artifact-relative-path
+  "Where the bytes live, relative to the content root:
+    `artifacts/<document>/<locale>/<revision>.<ext>`.
+
+    Derived from the OP'S INTENT (document and locale) and the validated
+    artifact (revision and media type) — deliberately not from
+    `:artifact/locale`. The effect boundary has already established that
+    intent and artifact agree before an adapter runs, so the two are equal
+    here; deriving from intent keeps the route's file layout owned by the
+    publication that asked for it."
+  [intent artifact]
+  (str "artifacts/"
+       (document-path-segment (:publication/document intent)) "/"
+       (sanitize-segment (name (:publication/locale intent))) "/"
+       (sanitize-segment (:artifact/revision artifact)) "."
+       (media-type-extension (:artifact/media-type artifact))))
+
+;; ── Route construction and transforms ───────────────────────────────────────
+
+(defn route-for-artifact
+  "The manifest route for publishing `artifact` at `intent`.
+
+    `:route/media-type` and `:route/encoding` are copied VERBATIM from the
+    validated artifact — no derivation, no defaulting. `:route/artifact` is
+    the relative artifact PATH, never the artifact value."
+  [intent artifact]
+  {:route/path (:publication/path intent)
+   :route/locale (:publication/locale intent)
+   :route/document (document-path-segment (:publication/document intent))
+   :route/revision (:artifact/revision artifact)
+   :route/artifact (artifact-relative-path intent artifact)
+   :route/media-type (:artifact/media-type artifact)
+   :route/encoding (:artifact/encoding artifact)
+   :publication/id (:publication/id intent)})
+
+(defn find-route
+  "The route materialized for `publication-id`, or nil. Keyed on publication
+    IDENTITY, not path: after a path move the desired path names nothing yet,
+    and the route being replaced is only findable by who published it."
+  [manifest publication-id]
+  (->> (:manifest/routes manifest)
+       (filter #(= publication-id (:publication/id %)))
+       first))
+
+(defn upsert-route
+  "Return `manifest` with `route` as the one route for its `:publication/id`.
+
+    Replacement, not addition: a path move must leave exactly one public
+    route, so any prior route carrying the same publication id is displaced
+    wherever its path points."
+  [manifest route]
+  (update manifest :manifest/routes
+          (fn [routes]
+            (conj (vec (remove #(= (:publication/id route) (:publication/id %))
+                               routes))
+                  route))))
+
+(defn remove-route
+  "Return `manifest` with no route for `publication-id`. Idempotent: removing
+    what was never there is the same manifest."
+  [manifest publication-id]
+  (update manifest :manifest/routes
+          (fn [routes]
+            (vec (remove #(= publication-id (:publication/id %)) routes)))))
+
+;; ── EDN round-trip ──────────────────────────────────────────────────────────
+
+(defn manifest->edn
+  "Serialize a manifest to EDN. Namespaced keys survive the round-trip, which
+    is the reason the cross-repo contract chose EDN over JSON."
+  [manifest]
+  (pr-str (assert-manifest! manifest)))
+
+(defn edn->manifest
+  "Parse and validate a manifest from EDN. Throws on malformed input — a
+    corrupt manifest is a writer defect and must fail loudly, never read as
+    an empty published set."
+  [edn-string]
+  (assert-manifest! (edn/read-string edn-string)))

--- a/backend/test/cljs/knoxx/backend/infra/publication_target_registry_test.cljs
+++ b/backend/test/cljs/knoxx/backend/infra/publication_target_registry_test.cljs
@@ -112,7 +112,15 @@
     (is (identical? context @seen-context))))
 
 (deftest target-configuration-cannot-change-the-pure-plan
-  (let [resource-index {:gardens {:knoxx.docs/promethean {:garden/status :active}}}
+  (let [resource-index {:gardens {:knoxx.docs/promethean
+                                  {:garden/status :active
+                                   ;; The locale-catalog cross-check (#250)
+                                   ;; merged after this fixture: a garden
+                                   ;; without locales now blocks every
+                                   ;; publish, so the fixture must declare
+                                   ;; the intent's locale to keep testing
+                                   ;; what it names.
+                                   :garden/locales [:en :es]}}}
         facts {:current-source-revision (constantly "rev-1")
                :translated-revision? (constantly true)
                :approved? (constantly true)

--- a/backend/test/cljs/knoxx/backend/infra/publication_target_static_site_test.cljs
+++ b/backend/test/cljs/knoxx/backend/infra/publication_target_static_site_test.cljs
@@ -1,0 +1,510 @@
+(ns knoxx.backend.infra.publication-target-static-site-test
+  "The static-site target against a real filesystem: every DoD line of
+   knoxx-publication-static-site-target, exercised through the same effect
+   boundary production uses."
+  (:require [cljs.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [knoxx.backend.infra.publication-effects :as effects]
+            [knoxx.backend.infra.publication-target-registry :as registry]
+            [knoxx.backend.infra.publication-target-static-site :as static-site]
+            [knoxx.backend.law.publication-manifest :as manifest-law]
+            ["node:fs" :as node-fs]
+            ["node:os" :as os]
+            ["node:path" :as path]))
+
+;; ── Fixtures ───────────────────────────────────────────────────────────────
+
+(def ^:private intent
+  {:publication/id :knoxx.docs/probe-es
+   :publication/document :knoxx.docs/probe
+   :publication/garden :knoxx.docs/promethean
+   :publication/target :knoxx.publication/static-site
+   :publication/locale :es
+   :publication/revision :source/current
+   :publication/state :published
+   :publication/path "/probe"
+   :translation/review :required
+   :document/source-locale :en})
+
+(def ^:private artifact
+  {:artifact/content "<!doctype html><p>Sonda — contenido traducido</p>"
+   :artifact/media-type "text/html"
+   :artifact/encoding "utf-8"
+   :artifact/locale :es
+   :artifact/revision "probe-revision"})
+
+(def ^:private publish-plan
+  {:op :publish
+   :intent intent
+   :desired {:materialized/revision "probe-revision" :materialized/path "/probe"}
+   :previous nil
+   :concrete-revision "probe-revision"})
+
+(def ^:private artifact-path
+  "The path derivation is pinned in the law test; here it is only how the
+   adapter's writes are found on disk."
+  "artifacts/knoxx.docs/probe/es/probe-revision.html")
+
+;; ── Filesystem helpers ─────────────────────────────────────────────────────
+
+(defn- temp-root!
+  "A fresh, empty content root. The caller removes it."
+  []
+  (.mkdtempSync node-fs (.join path (.tmpdir os) "knoxx-static-site-")))
+
+(defn- remove-root!
+  "Delete a content root and everything under it."
+  [root]
+  (.rmSync node-fs root #js {:recursive true :force true}))
+
+(defn- ^:async with-root!
+  "Run async `f` with a fresh empty content root, removing the root
+   afterwards even when `f` throws."
+  [f]
+  (let [root (temp-root!)]
+    (try
+      (await (f root))
+      (finally
+        (remove-root! root)))))
+
+(defn- with-root-sync!
+  "The synchronous `with-root!`: run `f` with a fresh content root and
+   always remove it."
+  [f]
+  (let [root (temp-root!)]
+    (try
+      (f root)
+      (finally
+        (remove-root! root)))))
+
+(defn- target-in
+  "The adapter over `root`, declared exactly as a resource would declare it."
+  [root]
+  (static-site/static-site-target
+   {:publication-target/id :knoxx.publication/static-site
+    :publication-target/kind static-site/kind
+    :publication-target/config {:content-root root}
+    :publication-target/enabled? true}))
+
+(defn- read-manifest
+  "Parse the manifest under `root`."
+  [root]
+  (manifest-law/edn->manifest
+   (.readFileSync node-fs (.join path root "manifest.edn") "utf8")))
+
+(defn- read-artifact
+  "The probe artifact's bytes as a UTF-8 string."
+  [root]
+  (.readFileSync node-fs (.join path root artifact-path) "utf8"))
+
+(defn- artifact-exists?
+  "True when the probe artifact file exists."
+  [root]
+  (.existsSync node-fs (.join path root artifact-path)))
+
+(defn- manifest-exists?
+  "True when a manifest exists under `root`."
+  [root]
+  (.existsSync node-fs (.join path root "manifest.edn")))
+
+(defn- age-artifact!
+  "Set the artifact's mtime far into the past, so a later rewrite is
+   distinguishable from a replay that touched nothing. mtime granularity
+   alone cannot tell \"rewritten just now\" from \"written just now\"."
+  [root]
+  (let [long-ago (js/Date. 946684800000)]
+    (.utimesSync node-fs (.join path root artifact-path) long-ago long-ago)))
+
+(defn- artifact-aged?
+  "True when the artifact's mtime is still the one `age-artifact!` set."
+  [root]
+  (< (.getTime (.-mtime (.statSync node-fs (.join path root artifact-path))))
+     950000000000))
+
+;; ── DoD: a published document is fetchable at its manifest path ───────────
+
+(deftest ^:async a-published-document-is-fetchable-with-the-expected-bytes
+  (await
+   (with-root!
+    (^:async fn [root]
+      (let [store (static-site/static-site-store root)
+            target (target-in root)
+            receipt (await (effects/execute-plan!
+                            store target {} publish-plan artifact))]
+        (is (= :publication/materialized (:receipt/type receipt)))
+        (is (= "probe-revision" (:materialized/revision receipt)))
+        (is (= "/probe" (:materialized/path receipt)))
+        (testing "the manifest names the route and the artifact PATH, and the
+                  bytes at that path are exactly what the renderer produced"
+          (let [route (first (:manifest/routes (read-manifest root)))]
+            (is (= "/probe" (:route/path route)))
+            (is (= :es (:route/locale route)))
+            (is (= artifact-path (:route/artifact route)))
+            (is (= "probe-revision" (:route/revision route)))
+            (is (= :knoxx.docs/probe-es (:publication/id route)))
+            (testing "media type and encoding come STRAIGHT off the artifact —
+                      no derivation, no defaulting"
+              (is (= "text/html" (:route/media-type route)))
+              (is (= "utf-8" (:route/encoding route))))
+            (is (= (:artifact/content artifact) (read-artifact root))))))))))
+
+(deftest ^:async byte-artifacts-are-written-verbatim
+  (await
+   (with-root!
+    (^:async fn [root]
+      (let [store (static-site/static-site-store root)
+            target (target-in root)
+            bytes (.encode (js/TextEncoder.) "binäre bytes — ünïcode")
+            receipt (await (effects/execute-plan!
+                            store target {} publish-plan
+                            (assoc artifact :artifact/content bytes)))]
+        (is (= :publication/materialized (:receipt/type receipt)))
+        (let [on-disk (.readFileSync node-fs (.join path root artifact-path))]
+          (is (= (vec bytes) (vec (js/Uint8Array. on-disk)))
+              "the adapter transports; it does not re-encode")))))))
+
+(deftest ^:async media-type-and-encoding-are-never-derived-or-defaulted
+  (await
+   (with-root!
+    (^:async fn [root]
+      (let [store (static-site/static-site-store root)
+            target (target-in root)
+            plain (assoc artifact
+                         :artifact/content "plain text, sin adornos"
+                         :artifact/media-type "text/plain")
+            receipt (await (effects/execute-plan!
+                            store target {} publish-plan plain))]
+        (is (= :publication/materialized (:receipt/type receipt)))
+        (let [route (first (:manifest/routes (read-manifest root)))]
+          (is (= "text/plain" (:route/media-type route)))
+          (is (= "utf-8" (:route/encoding route)))
+          (is (= "artifacts/knoxx.docs/probe/es/probe-revision.txt"
+                 (:route/artifact route)))))))))
+
+;; ── DoD: replay is a noop and does not rewrite the artifact ───────────────
+
+(deftest ^:async replay-does-not-rewrite-the-artifact
+  (await
+   (with-root!
+    (^:async fn [root]
+      (let [store (static-site/static-site-store root)
+            target (target-in root)
+            first-receipt (await (effects/execute-plan!
+                                  store target {} publish-plan artifact))]
+        (age-artifact! root)
+        (let [second-receipt (await (effects/execute-plan!
+                                     store target {} publish-plan artifact))]
+          (is (= first-receipt second-receipt)
+              "the reservation answers :done with the recorded receipt")
+          (is (artifact-aged? root)
+              "the artifact file was NOT rewritten — its mtime is still the
+               one the first write left behind")
+          (testing "and even with the reservation released, the adapter itself
+                    short-circuits an identical route rather than rewriting"
+            (effects/release! store (effects/publish-idempotency-key
+                                     :knoxx.publication/static-site
+                                     intent "probe-revision"))
+            (let [receipt (await (effects/publish! target {}
+                                                   {:intent intent
+                                                    :artifact artifact
+                                                    :previous nil
+                                                    :concrete-revision "probe-revision"
+                                                    :idempotency/key "direct-replay"}))]
+              (is (= :publication/materialized (:receipt/type receipt)))
+              (is (artifact-aged? root)
+                  "identical manifest route + present bytes = no write")))))))))
+
+;; ── DoD: a path move leaves exactly one public route ──────────────────────
+
+(deftest ^:async a-path-move-leaves-exactly-one-public-route
+  (await
+   (with-root!
+    (^:async fn [root]
+      (let [store (static-site/static-site-store root)
+            target (target-in root)
+            _ (await (effects/execute-plan! store target {} publish-plan artifact))
+            moved-intent (assoc intent :publication/path "/moved")
+            moved-plan {:op :publish
+                        :intent moved-intent
+                        :desired {:materialized/revision "probe-revision"
+                                  :materialized/path "/moved"}
+                        :previous {:materialized/revision "probe-revision"
+                                   :materialized/path "/probe"}
+                        :concrete-revision "probe-revision"}
+            receipt (await (effects/execute-plan!
+                            store target {} moved-plan artifact))]
+        (is (= :publication/materialized (:receipt/type receipt)))
+        (let [routes (:manifest/routes (read-manifest root))]
+          (is (= 1 (count routes)) "exactly one public route for the publication")
+          (is (= "/moved" (:route/path (first routes)))))
+        (testing "observe! is keyed on publication identity, so it sees the
+                  route at its NEW path even when asked with the stale intent"
+          (let [observed (await (effects/observe! target {} intent))]
+            (is (= "/moved" (:materialized/path observed)))
+            (is (= "probe-revision" (:materialized/revision observed))))))))))
+
+;; ── DoD: a removal stops serving and is visible to observe! ───────────────
+
+(deftest ^:async a-removal-stops-serving-and-is-observable
+  (await
+   (with-root!
+    (^:async fn [root]
+      (let [store (static-site/static-site-store root)
+            target (target-in root)]
+        (await (effects/execute-plan! store target {} publish-plan artifact))
+        (let [observed (await (effects/observe! target {} intent))]
+          (is (some? observed) "materialized before removal")
+          (let [receipt (await (effects/execute-plan!
+                                store target {}
+                                {:op :remove :intent intent :observed observed}
+                                nil))]
+            (is (= :publication/removed (:receipt/type receipt)))
+            (testing "the publication id is carried on the receipt — without it
+                      the projection drops the removal and a republish of the
+                      same revision reads as :noop with nothing public"
+              (is (= :knoxx.docs/probe-es (:publication/id receipt)))
+              (is (= "/probe" (:removed/path receipt))))
+            (is (empty? (:manifest/routes (read-manifest root)))
+                "the route left the manifest, so it stops serving")
+            (is (not (artifact-exists? root))
+                "and its bytes were reclaimed after the commit")
+            (is (nil? (await (effects/observe! target {} intent)))
+                "observe! sees the removal"))))))))
+
+(deftest ^:async removal-is-idempotent-and-an-empty-root-is-valid
+  (await
+   (with-root!
+    (^:async fn [root]
+      (let [target (target-in root)]
+        (testing "an empty content root is a valid initial state, not an error"
+          (is (nil? (await (effects/observe! target {} intent)))))
+        (let [observed {:materialized/revision "probe-revision"
+                        :materialized/path "/probe"}
+              first-receipt (await (effects/remove! target {} intent observed))
+              second-receipt (await (effects/remove! target {} intent observed))]
+          (is (= :publication/removed (:receipt/type first-receipt)))
+          (is (= first-receipt second-receipt)
+              "removing what was never published is the same receipt"))
+        (testing "and a root that does not exist yet at all is equally valid"
+          (let [unborn (.join path root "never-created")
+                unborn-target (target-in unborn)]
+            (is (nil? (await (effects/observe! unborn-target {} intent)))))))))))
+
+;; ── DoD: crashes leave nothing public and the next run converges ───────────
+
+(deftest ^:async a-crash-between-artifact-and-manifest-leaves-nothing-public
+  (await
+   (with-root!
+    (^:async fn [root]
+      (testing "an artifact file no manifest entry names is not public"
+        (.mkdirSync node-fs (.dirname path (.join path root artifact-path))
+                    #js {:recursive true})
+        (.writeFileSync node-fs (.join path root artifact-path)
+                        (:artifact/content artifact) "utf8")
+        (let [store (static-site/static-site-store root)
+              target (target-in root)]
+          (is (nil? (await (effects/observe! target {} intent)))
+              "orphaned bytes are not a materialization")
+          (testing "the next run converges: the same plan now publishes and
+                    serves the expected bytes"
+            (let [receipt (await (effects/execute-plan!
+                                  store target {} publish-plan artifact))]
+              (is (= :publication/materialized (:receipt/type receipt)))
+              (is (= (:artifact/content artifact) (read-artifact root)))
+              (is (some? (await (effects/observe! target {} intent))))))))))))
+
+(deftest ^:async a-crash-after-reservation-reconciles-by-observation
+  (await
+   (with-root!
+    (^:async fn [root]
+      (let [store (static-site/static-site-store root)
+            target (target-in root)
+            key (effects/publish-idempotency-key
+                 :knoxx.publication/static-site intent "probe-revision")
+            reservation (effects/reserve! store key)]
+        (is (= :reserved (:reservation/status reservation))
+            "claimed, then the process 'died' before publishing")
+        (let [receipt (await (effects/execute-plan!
+                              store target {} publish-plan artifact))]
+          (is (= :publication/materialized (:receipt/type receipt)))
+          (is (= (:artifact/content artifact) (read-artifact root))))
+        (testing "the retained claim now reports the recorded receipt"
+          (is (= :done (:reservation/status (effects/reserve! store key))))))))))
+
+(deftest ^:async an-interrupted-manifest-write-is-old-or-new-never-torn
+  (await
+   (with-root!
+    (^:async fn [root]
+      (let [store (static-site/static-site-store root)
+            target (target-in root)]
+        (await (effects/execute-plan! store target {} publish-plan artifact))
+        (testing "a dead writer's temp file beside the manifest is never
+                  mistaken for the manifest — the live manifest still parses
+                  as wholly the old one"
+          (.writeFileSync node-fs
+                          (.join path root "manifest.edn.tmp-deadbeef")
+                          "{:manifest/version 1 :manifest/routes [{")
+          (let [manifest (read-manifest root)]
+            (is (= 1 (count (:manifest/routes manifest))))
+            (is (= "/probe" (:route/path (first (:manifest/routes manifest)))))))
+        (testing "and the next write replaces it wholly"
+          (let [new-plan (assoc publish-plan :concrete-revision "revision-two")
+                new-artifact (assoc artifact
+                                    :artifact/content "<!doctype html><p>Segunda</p>"
+                                    :artifact/revision "revision-two")
+                receipt (await (effects/execute-plan!
+                                store target {} new-plan new-artifact))]
+            (is (= :publication/materialized (:receipt/type receipt)))
+            (let [manifest (read-manifest root)
+                  routes (:manifest/routes manifest)]
+              (is (= 1 (count routes)))
+              (is (= "revision-two" (:route/revision (first routes))))
+              (is (= "artifacts/knoxx.docs/probe/es/revision-two.html"
+                     (:route/artifact (first routes)))))
+            (testing "the superseded revision's bytes were reclaimed"
+              (is (not (artifact-exists? root)))))))))))
+
+;; ── Concurrency: two reconciler runs touching one root ────────────────────
+
+(deftest ^:async concurrent-runs-converge-on-one-consistent-manifest
+  (await
+   (with-root!
+    (^:async fn [root]
+      (let [store (static-site/static-site-store root)
+            target (target-in root)
+            other-intent (-> intent
+                             (assoc :publication/id :knoxx.docs/otra-es)
+                             (assoc :publication/document :knoxx.docs/otra)
+                             (assoc :publication/path "/otra"))
+            plan-for (fn [an-intent]
+                       {:op :publish
+                        :intent an-intent
+                        :desired {:materialized/revision "probe-revision"
+                                  :materialized/path (:publication/path an-intent)}
+                        :concrete-revision "probe-revision"})
+            other-artifact (assoc artifact
+                                  :artifact/content "<!doctype html><p>Otra</p>")
+            receipts (await (js/Promise.all
+                             #js [(effects/execute-plan!
+                                   store target {} (plan-for intent) artifact)
+                                  (effects/execute-plan!
+                                   store target {} (plan-for other-intent)
+                                   other-artifact)]))]
+        (is (= [:publication/materialized :publication/materialized]
+               (mapv :receipt/type receipts)))
+        (let [manifest (read-manifest root)
+              routes (:manifest/routes manifest)]
+          (is (= 2 (count routes)) "both runs committed, neither update lost")
+          (is (= #{"/probe" "/otra"} (set (map :route/path routes)))))
+        (is (= (:artifact/content artifact) (read-artifact root)))
+        (is (= (:artifact/content other-artifact)
+               (.readFileSync node-fs
+                              (.join path root
+                                     "artifacts/knoxx.docs/otra/es/probe-revision.html")
+                              "utf8"))))))))
+
+;; ── The adapter validates what it is handed ────────────────────────────────
+
+(deftest ^:async the-adapter-refuses-an-unlawful-artifact-before-writing
+  (await
+   (with-root!
+    (^:async fn [root]
+      (let [target (target-in root)
+            stale (assoc artifact :artifact/revision "an-older-revision")
+            outcome (try
+                      (await (effects/publish! target {}
+                                               {:intent intent
+                                                :artifact stale
+                                                :previous nil
+                                                :concrete-revision "probe-revision"
+                                                :idempotency/key "refused"}))
+                      :published
+                      (catch :default err
+                        (if (some? (ex-data err)) :refused :threw-untyped)))]
+        (is (= :refused outcome)
+            "a revision-conflicting artifact must not publish")
+        (is (not (manifest-exists? root)) "no commit for a refused artifact")
+        (is (not (artifact-exists? root)) "and no bytes either"))))))
+
+;; ── The adapter contains no policy ─────────────────────────────────────────
+
+(deftest the-adapter-contains-no-admissibility-gating-or-planning-logic
+  (let [source (.readFileSync
+                node-fs
+                (.join path (.cwd js/process)
+                       "src/cljs/knoxx/backend/infra/publication_target_static_site.cljs")
+                "utf8")]
+    (testing "it validates what it is handed — the one check an adapter owns"
+      (is (str/includes? source "assert-artifact!")))
+    (doseq [policy ["publication-gate" "admissible-publication" "reconcile-plan"
+                    "publication-plan" "publishes?"]]
+      (testing (str "no reference to " policy)
+        (is (not (str/includes? source policy)))))))
+
+;; ── Registry wiring ────────────────────────────────────────────────────────
+
+(deftest the-target-resolves-through-the-registry-as-its-kind
+  (with-root-sync!
+   (fn [root]
+     (let [declaration {:publication-target/id :knoxx.publication/static-site
+                        :publication-target/kind static-site/kind
+                        :publication-target/config {:content-root root}
+                        :publication-target/enabled? true}
+           target-registry (registry/make-registry
+                            [declaration]
+                            {static-site/kind static-site/static-site-target})
+           target (registry/resolve-target! target-registry
+                                            :knoxx.publication/static-site)]
+       (is (= :knoxx.publication/static-site (effects/target-id target)))))))
+
+;; ── Idempotency store ──────────────────────────────────────────────────────
+
+(deftest the-store-claims-atomically-and-remembers-completions
+  (with-root-sync!
+   (fn [root]
+     (let [store (static-site/static-site-store root)
+           receipt {:receipt/type :publication/materialized
+                    :materialized/revision "probe-revision"
+                    :materialized/path "/probe"
+                    :idempotency/key "key-one"}]
+       (is (= :reserved (:reservation/status (effects/reserve! store "key-one")))
+           "one operation claims the key — the O_EXCL create IS the check")
+       (is (= :in-flight (:reservation/status (effects/reserve! store "key-one")))
+           "a second claim sees the first, with no window between read and claim")
+       (effects/complete! store "key-one" receipt)
+       (let [done (effects/reserve! store "key-one")]
+         (is (= :done (:reservation/status done)))
+         (is (= receipt (:receipt done))
+             "the receipt round-trips through EDN with namespaced keys intact"))
+       (effects/release! store "key-one")
+       (is (= :reserved (:reservation/status (effects/reserve! store "key-one")))
+           "a released claim may be taken again")
+       (testing "an absurdly long or separator-laden key still maps to a safe,
+                 deterministic filename"
+         (let [ugly (apply str "k|\"|/" (repeat 512 "x"))]
+           (is (= :reserved (:reservation/status (effects/reserve! store ugly))))
+           (let [fresh-store (static-site/static-site-store root)]
+             (is (= :in-flight (:reservation/status (effects/reserve! fresh-store ugly)))
+                 "a second store instance lands on the SAME file — the mapping is deterministic")
+             (effects/release! fresh-store ugly)
+             (is (= :reserved (:reservation/status (effects/reserve! store ugly)))
+                  "and releasing through it frees the key for the first"))))))))
+
+(deftest ^:async a-stale-lock-does-not-wedge-the-next-run
+  (await
+   (with-root!
+    (^:async fn [root]
+      (testing "a lock abandoned by a crashed writer is taken over rather than
+                failing every subsequent publication forever"
+        (let [lock-path (.join path root "manifest.lock")]
+          (.writeFileSync node-fs lock-path "dead-writer-token")
+          (let [long-ago (js/Date. 946684800000)]
+            (.utimesSync node-fs lock-path long-ago long-ago))
+          (let [store (static-site/static-site-store root)
+                target (target-in root)
+                receipt (await (effects/execute-plan!
+                                store target {} publish-plan artifact))]
+            (is (= :publication/materialized (:receipt/type receipt)))
+            (is (= (:artifact/content artifact) (read-artifact root)))
+            (is (not (.existsSync node-fs lock-path))
+                "and the lock was released behind it"))))))))

--- a/backend/test/cljs/knoxx/backend/law/publication_manifest_test.cljs
+++ b/backend/test/cljs/knoxx/backend/law/publication_manifest_test.cljs
@@ -1,0 +1,172 @@
+(ns knoxx.backend.law.publication-manifest-test
+  "The pure half of the static-site target: manifest shape, path derivation,
+   and the route transforms the filesystem adapter commits."
+  (:require [cljs.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [knoxx.backend.law.publication-manifest :as manifest]))
+
+(def ^:private intent
+  {:publication/id :knoxx.docs/probe-es
+   :publication/document :knoxx.docs/probe
+   :publication/garden :knoxx.docs/promethean
+   :publication/locale :es
+   :publication/revision :source/current
+   :publication/state :published
+   :publication/path "/es/notes/hello"
+   :translation/review :required
+   :document/source-locale :en})
+
+(def ^:private artifact
+  {:artifact/content "<!doctype html><p>Hola</p>"
+   :artifact/media-type "text/html"
+   :artifact/encoding "utf-8"
+   :artifact/locale :es
+   :artifact/revision "rev-7f3a91c"})
+
+;; ── path derivation ────────────────────────────────────────────────────────
+
+(deftest artifact-path-is-document-locale-revision
+  (is (= "artifacts/knoxx.docs/probe/es/rev-7f3a91c.html"
+         (manifest/artifact-relative-path intent artifact)))
+  (testing "the locale segment comes from the INTENT, not the artifact — the
+            boundary established they agree, and the file layout belongs to
+            the publication that asked for it"
+    (is (= "artifacts/knoxx.docs/probe/es/rev-7f3a91c.html"
+           (manifest/artifact-relative-path
+            intent (assoc artifact :artifact/locale :es)))))
+  (testing "the extension follows the media type's subtype"
+    (is (= "artifacts/knoxx.docs/probe/es/rev-7f3a91c.svg"
+           (manifest/artifact-relative-path
+            intent (assoc artifact :artifact/media-type "image/svg+xml"))))
+    (is (= "artifacts/knoxx.docs/probe/es/rev-7f3a91c.txt"
+           (manifest/artifact-relative-path
+            intent (assoc artifact :artifact/media-type "text/plain"))))))
+
+(deftest path-segments-cannot-escape-the-content-root
+  (testing "a revision carrying separators or traversal is flattened into one
+            inert segment — contract-checked upstream, re-checked here because
+            this string touches a filesystem"
+    (is (= "artifacts/knoxx.docs/probe/es/a-b-c.html"
+           (manifest/artifact-relative-path
+            intent (assoc artifact :artifact/revision "a/b\\c"))))
+    (is (= "artifacts/knoxx.docs/probe/es/-rev.html"
+           (manifest/artifact-relative-path
+            intent (assoc artifact :artifact/revision "../rev"))))
+    (is (not (str/includes?
+              (manifest/artifact-relative-path
+               intent (assoc artifact :artifact/revision "../rev"))
+              ".."))
+        "no traversal survives, however the dots fall")
+    (is (every? (fn [segment]
+                  (and (not= ".." segment) (not= "." segment) (seq segment)))
+                (-> (manifest/artifact-relative-path
+                     intent (assoc artifact :artifact/revision "..."))
+                    (str/split #"/"))))))
+
+;; ── routes ─────────────────────────────────────────────────────────────────
+
+(deftest route-carries-artifact-values-verbatim
+  (let [route (manifest/route-for-artifact intent artifact)]
+    (is (= "/es/notes/hello" (:route/path route)))
+    (is (= :es (:route/locale route)))
+    (is (= "rev-7f3a91c" (:route/revision route)))
+    (is (= "text/html" (:route/media-type route)))
+    (is (= "utf-8" (:route/encoding route)))
+    (is (= :knoxx.docs/probe-es (:publication/id route)))
+    (testing "`:route/artifact` is a PATH — never the artifact value the
+              memory target stores"
+      (is (= "artifacts/knoxx.docs/probe/es/rev-7f3a91c.html"
+             (:route/artifact route))))))
+
+(deftest upsert-replaces-by-publication-id
+  (let [route (manifest/route-for-artifact intent artifact)
+        manifest (-> (manifest/empty-manifest)
+                     (manifest/upsert-route route))]
+    (is (= 1 (count (:manifest/routes manifest))))
+    (testing "a path move leaves exactly one route: replacement is keyed on
+              publication identity, so the old path is displaced wherever it
+              points"
+      (let [moved (assoc route :route/path "/es/notes/moved")
+            updated (manifest/upsert-route manifest moved)]
+        (is (= 1 (count (:manifest/routes updated))))
+        (is (= "/es/notes/moved"
+               (:route/path (first (:manifest/routes updated)))))))
+    (testing "a different publication id is a different route"
+      (let [other (assoc route :publication/id :knoxx.docs/other-es)
+            updated (manifest/upsert-route manifest other)]
+        (is (= 2 (count (:manifest/routes updated))))))))
+
+(deftest find-and-remove-are-keyed-on-publication-id
+  (let [route (manifest/route-for-artifact intent artifact)
+        manifest (manifest/upsert-route (manifest/empty-manifest) route)]
+    (is (= route (manifest/find-route manifest :knoxx.docs/probe-es)))
+    (testing "found by identity even after the path moved"
+      (is (= (assoc route :route/path "/moved")
+             (manifest/find-route
+              (manifest/upsert-route manifest (assoc route :route/path "/moved"))
+              :knoxx.docs/probe-es))))
+    (is (nil? (manifest/find-route manifest :knoxx.docs/never-published)))
+    (is (empty? (:manifest/routes
+                 (manifest/remove-route manifest :knoxx.docs/probe-es))))
+    (testing "removal is idempotent"
+      (is (= (manifest/remove-route manifest :knoxx.docs/never-published)
+             manifest)))))
+
+;; ── contract and EDN round-trip ────────────────────────────────────────────
+
+(deftest the-empty-manifest-is-valid
+  (is (map? (manifest/assert-manifest! (manifest/empty-manifest))))
+  (is (= [] (:manifest/routes (manifest/empty-manifest)))))
+
+(deftest manifest-edn-round-trips-with-namespaced-keys-intact
+  (let [route (manifest/route-for-artifact intent artifact)
+        written (-> (manifest/empty-manifest)
+                    (manifest/upsert-route route)
+                    (manifest/touch))
+        read-back (manifest/edn->manifest (manifest/manifest->edn written))]
+    (is (= written read-back))
+    (testing "qualified keywords survive — the reason the contract chose EDN
+              over JSON in the first place"
+      (is (= :knoxx.docs/probe-es
+             (:publication/id (first (:manifest/routes read-back))))))))
+
+(deftest malformed-manifests-fail-loudly
+  (doseq [[label bad] [["no version" {:manifest/routes []}]
+                       ["unsupported version" {:manifest/version 2
+                                               :manifest/generated-at "t"
+                                               :manifest/routes []}]
+                       ["route without an artifact path"
+                        {:manifest/version 1
+                         :manifest/generated-at "t"
+                         :manifest/routes [{:route/path "/x"
+                                            :route/locale :es
+                                            :route/media-type "text/html"
+                                            :route/encoding "utf-8"
+                                            :route/revision "r"
+                                            :publication/id :a/b}]}]
+                       ["route with a traversal artifact path"
+                        {:manifest/version 1
+                         :manifest/generated-at "t"
+                         :manifest/routes [{:route/path "/x"
+                                            :route/locale :es
+                                            :route/artifact "../escape"
+                                            :route/media-type "text/html"
+                                            :route/encoding "utf-8"
+                                            :route/revision "r"
+                                            :publication/id :a/b}]}]
+                       ["route with no publication id"
+                        {:manifest/version 1
+                         :manifest/generated-at "t"
+                         :manifest/routes [{:route/path "/x"
+                                            :route/locale :es
+                                            :route/artifact "artifacts/a"
+                                            :route/media-type "text/html"
+                                            :route/encoding "utf-8"
+                                            :route/revision "r"}]}]]]
+    (testing label
+      (is (thrown? js/Error (manifest/assert-manifest! bad)))))
+  (testing "unparseable EDN throws rather than reading as empty"
+    (is (thrown? js/Error (manifest/edn->manifest "{:manifest/version"))))
+  (testing "a reader rule the writer shares: garbage is a defect, not an
+            empty published set"
+    (is (thrown? js/Error (manifest/edn->manifest "42")))))


### PR DESCRIPTION
## Card
knoxx-publication-static-site-target

## Verification
- Ran 1092 tests containing 3981 assertions. 0 failures, 0 errors.
- 0 warnings on typecheck and compile.

## Key decisions
- Manifest law in `.cljc`.
- Artifact path derives from intent, not `:artifact/locale`.
- Write-beside-then-rename provides atomic artifact and manifest updates.
- `O_EXCL` `manifest.lock` with 30s abandonment.
- `IIdempotencyStore` is synchronous.
- Orphaned tmp files are retained and sweepable.

## Notes
- Repairs the registry-test fixture: merge-order red from #250 landing after #251.
- The pre-existing clj-kondo warning in `domain/node/fs.cljs` (`clojure.string` unused) is at HEAD and was not introduced by this change.