### PR TITLE
feat(translation): a revision-specific approval surface

### DIFF
--- a/backend/src/cljs/knoxx/backend/domain/translation_evidence.cljc
+++ b/backend/src/cljs/knoxx/backend/domain/translation_evidence.cljc
@@ -17,10 +17,10 @@
   while the store feeding it is not. It is the first portable `domain.*`
   namespace in this backend; its requires are laws only, so it loads anywhere.
 
-  This card supplies the *translation* half. `:approved?` is
-  `knoxx-translation-approval-surface`, and `gate-facts` deliberately returns a
-  partial map rather than defaulting the half it does not own — see its
-  docstring."
+  Both evidential predicates live here now, and `approved?` is a *join* rather
+  than a lookup: an approval only counts while it still names the translation
+  output the receipt currently holds. `gate-facts` still returns a partial map —
+  the two source-revision facts are owned elsewhere — see its docstring."
   (:require [knoxx.backend.law.translation-evidence :as law]))
 
 (defn evidence-key
@@ -57,14 +57,40 @@
           {}
           receipts))
 
+(defn index-approvals
+  "Index approvals by `[document garden locale revision]`.
+
+   Validated on the way in for the same reason as receipts. Unlike receipts,
+   *all* approvals for a key are retained rather than collapsed to the newest:
+   whether an approval is current depends on the receipt it is joined against, and
+   discarding the older ones here would decide that question in the wrong place —
+   before the join, and without the receipt in hand.
+
+   Concretely: approve output A, re-translate to B, then re-translate to
+   something byte-identical to A. Keeping only the newest approval would have
+   discarded the one that legitimately matches."
+  [approvals]
+  (reduce (fn [index approval]
+            (let [checked (law/assert-approval! approval)]
+              (update index
+                      (evidence-key (:review/document checked)
+                                    (:review/garden checked)
+                                    (:review/locale checked)
+                                    (:review/revision checked))
+                      (fnil conj [])
+                      checked)))
+          {}
+          approvals))
+
 (defn evidence
   "The index a runtime loads once and then reads repeatedly.
 
    Order-insensitive: `index-receipts` resolves a re-translated source revision
    by comparing timestamps, so a store is free to return receipts in whatever
    order its query produced."
-  [{:keys [receipts]}]
-  {:receipts (index-receipts receipts)})
+  [{:keys [receipts approvals]}]
+  {:receipts (index-receipts receipts)
+   :approvals (index-approvals approvals)})
 
 (defn translated-revision?
   "Whether a completed translation exists for this document, target locale and
@@ -81,8 +107,32 @@
   [evidence document garden locale revision]
   (get-in evidence [:receipts (evidence-key document garden locale revision)]))
 
+(defn approved?
+  "Whether a *current* approval exists for this document, garden, target locale
+   and concrete source revision.
+
+   Both halves are required. Without a receipt there is nothing to approve, so an
+   approval alone is never enough; and an approval that does not name the
+   receipt's current output revision has been superseded by a re-translation and
+   stops counting. Neither case is an error — see
+   `law.translation-evidence/approval-current?`.
+
+   This is why `:approved?` cannot be a plain store lookup. The gate can only
+   tell it the source revision, and the source revision alone does not identify
+   which bytes were reviewed."
+  [evidence document garden locale revision]
+  (let [entry-key (evidence-key document garden locale revision)
+        receipt (get-in evidence [:receipts entry-key])]
+    (boolean
+     (and (some? receipt)
+          (some (fn [approval]
+                  (and (law/approval-matches? approval document garden locale revision)
+                       (law/approval-current? approval receipt)))
+                (get-in evidence [:approvals entry-key]))))))
+
 (defn gate-facts
-  "The `facts` entry this card owns, closed over loaded evidence.
+  "The two evidential `facts` entries this namespace owns, closed over loaded
+   evidence.
 
    Returned as a *partial* facts map. The gate also needs
    `:current-source-revision` and `:source-revision-superseded?`, which are
@@ -93,4 +143,6 @@
    admitted on evidence nobody produced."
   [evidence]
   {:translated-revision? (fn [document garden locale revision]
-                           (translated-revision? evidence document garden locale revision))})
+                           (translated-revision? evidence document garden locale revision))
+   :approved? (fn [document garden locale revision]
+                (approved? evidence document garden locale revision))})

--- a/backend/src/cljs/knoxx/backend/extern/fastify/translation_review.cljs
+++ b/backend/src/cljs/knoxx/backend/extern/fastify/translation_review.cljs
@@ -1,0 +1,204 @@
+(ns knoxx.backend.extern.fastify.translation-review
+  "Fastify boundary for recording translation approvals.
+
+  Native request and reply handles are born and die here; the facade receives
+  decoded CLJS data and returns CLJS data.
+
+  `POST /api/publications/translations/approvals` records that the authenticated
+  principal accepted one translated revision. Three properties are enforced here
+  rather than below, because this is where an untrusted caller meets the system:
+
+  1. **The principal comes from the auth context, never from the body.** The
+     request contract is closed and carries no principal field, so a caller
+     cannot claim to be someone else. The same goes for the timestamp.
+  2. **The tenant and project come from context and config**, not from the
+     request, so a reviewer cannot approve into another organization's evidence.
+  3. **Authorization is unconditional.** `with-request-context!` hands down a nil
+     context when the policy database is disabled, and reading that as permission
+     would let an anonymous caller manufacture the review evidence a publication
+     gate is waiting on."
+  (:require [clojure.string :as str]
+            [knoxx.backend.extern.fastify :as fastify]
+            [knoxx.backend.infra.auth.authz :as authz]
+            [knoxx.backend.infra.routes.translation-review :as facade]
+            [knoxx.backend.infra.stores.translation-evidence-registry :as registry]
+            [knoxx.backend.law.error-body :as error-body]
+            [knoxx.backend.law.translation-evidence :as law]
+            [knoxx.backend.shape.resource-identity :as resource-identity]))
+
+(def approve-permission
+  "Recording review evidence is a review action, so it takes the permission the
+   `translator` role already holds — see `contracts/roles/translator.edn`.
+
+   Deliberately NOT `org.translations.manage`: approving is what a reviewer does,
+   and requiring queue-management authority would mean only admins could review."
+  "org.translations.review")
+
+(def refusal-status
+  "HTTP status per refusal type, as a table.
+
+   A table rather than a cond, so a new refusal type cannot be added without a
+   status being chosen for it, and so classification is never re-derived from a
+   message string.
+
+   All 409. A missing translation is not a 404 — the request is well formed and
+   the document exists, the system simply is not in a state where approving means
+   anything yet. A mismatch is the same shape of problem: the caller is not wrong
+   about syntax, it disagrees with recorded fact."
+  {:translation-receipt-missing 409
+   :translation-document-mismatch 409
+   :translation-locale-mismatch 409
+   :translation-source-revision-mismatch 409
+   :translation-revision-mismatch 409})
+
+(def RequestBody
+  "Contract for the raw wire body, checked before anything is reshaped.
+
+   Closed, and that has to be checked against the *body* rather than against the
+   map this adapter builds: an unknown field is never copied into that map, so
+   validating only the result would silently accept a typo. The dispatch adapter
+   learned this the same way.
+
+   Every field is required. Unlike dispatch, there is no meaningful whole-corpus
+   default here — an approval is inherently about one revision."
+  [:map {:closed true}
+   [:document [:and :string [:fn {:error/message "document must not be blank"}
+                             #(seq (str/trim %))]]]
+   [:garden [:and :string [:fn {:error/message "garden must not be blank"}
+                           #(seq (str/trim %))]]]
+   [:locale [:and :string [:fn {:error/message "locale must not be blank"}
+                           #(seq (str/trim %))]]]
+   [:revision [:and :string [:fn {:error/message "revision must not be blank"}
+                             #(seq (str/trim %))]]]
+   [:translation_revision [:and :string [:fn {:error/message "translation_revision must not be blank"}
+                                         #(seq (str/trim %))]]]])
+
+(defn decode-request
+  "Validate the native body, then project it onto the approval request.
+
+   The document, garden and locale are decoded to keywords because that is how
+   receipts are keyed. The garden is required rather than inferred: a document
+   published to two gardens has two translations, and picking one for the
+   reviewer would be picking which bytes their approval authorizes. Revisions stay strings and are deliberately NOT decoded: a revision
+   is opaque text, and `law/ConcreteRevision` is what refuses the one string shape
+   that would be dangerous — `\"source/current\"`."
+  [request]
+  (let [body (law/assert-valid! :translation-review/body
+                                RequestBody
+                                (fastify/request-body request))]
+    (law/assert-approval-request!
+     {:review/document (resource-identity/decode-keyword (:document body))
+      :review/garden (resource-identity/decode-keyword (:garden body))
+      :review/locale (resource-identity/decode-keyword (:locale body))
+      :review/revision (:revision body)
+      :review/translation-revision (:translation_revision body)})))
+
+(defn principal-of
+  "The acting principal, from the auth context only.
+
+   At least one durable identity must be present — `law/Principal` requires it,
+   and this is where that requirement bites: a context carrying nothing
+   identifiable would produce review evidence attributable to nobody, which is
+   indistinguishable from evidence nobody produced."
+  [ctx]
+  (law/assert-valid!
+   :translation-review/principal
+   law/Principal
+   (cond-> {}
+     (some? (authz/ctx-user-id ctx))
+     (assoc :principal/user-id (str (authz/ctx-user-id ctx)))
+
+     (some? (authz/ctx-user-email ctx))
+     (assoc :principal/user-email (str (authz/ctx-user-email ctx)))
+
+     (some? (authz/ctx-membership-id ctx))
+     (assoc :principal/membership-id (str (authz/ctx-membership-id ctx))))))
+
+(defn review-scope
+  "The tenant, project and principal an approval is recorded under.
+
+   The organization is required and never defaulted: an approval filed under an
+   invented tenant would be evidence in a scope nobody named. The project comes
+   from configuration and matches what the dispatch path files batches under, so
+   a reviewer sees the receipts that were actually produced."
+  [config ctx]
+  (let [org-id (some-> (authz/ctx-org-id ctx) str not-empty)]
+    (when-not org-id
+      (throw (ex-info "recording an approval requires an organization context"
+                      {:status 403
+                       :code "review_context_required"})))
+    {:org-id org-id
+     :project (some-> (:session-project-name config) str not-empty)
+     :principal (principal-of ctx)}))
+
+(defn- ^:async approve!
+  [config ctx decoded]
+  (if-let [evidence-store (registry/current)]
+    (facade/approve-translation!
+     {:evidence-store evidence-store
+      :clock (fn [] (.toISOString (js/Date.)))}
+     (review-scope config ctx)
+     decoded)
+    ;; Approval evidence that does not survive a restart is worse than none: the
+    ;; gate would admit a publication today and block it tomorrow.
+    (throw (ex-info "translation evidence persistence is not configured"
+                    {:status 503
+                     :code "translation_evidence_unavailable"}))))
+
+(defn response-for
+  "Status and body for one facade result.
+
+   A refusal is a *response*, not an error, so it carries its typed evidence to
+   the caller rather than being flattened into a message. Told only that
+   something mismatched, a reviewer cannot see whether their request or the
+   recorded translation was the stale one.
+
+   An already-recorded approval answers 200 rather than 201, and neither is a
+   409: the caller's intent is satisfied and the evidence exists. Answering 409
+   would make an honest double-click look like a conflict to resolve."
+  [result]
+  (if-let [refusal (:approval/refusal result)]
+    {:status (get refusal-status (:refusal/type refusal) 409)
+     :body {:refused true :refusal refusal}}
+    {:status (if (= :recorded (:approval/status result)) 201 200)
+     :body {:approved true
+            :status (:approval/status result)
+            :approval (:approval result)}}))
+
+(defn- error-status
+  [err]
+  (let [data (ex-data err)]
+    (or (:status data)
+        (fastify/error-status err nil)
+        (if (contains? data :contract) 400 500))))
+
+(defn- ^:async send-result!
+  [reply operation]
+  (try
+    (let [{:keys [status body]} (response-for (await (operation)))]
+      (fastify/send-json! reply status (resource-identity/encode-wire-values body)))
+    (catch :default err
+      (let [status (error-status err)]
+        ;; Withholding the detail from the caller must not withhold it from us.
+        (when-not (error-body/classified? status)
+          (fastify/log-unclassified-failure! "translation-review" err))
+        (fastify/send-json! reply status (error-body/error-body err status))))))
+
+(defn register-translation-review-routes!
+  [app runtime config handlers]
+  (fastify/route!
+   app
+   {:method "POST"
+    :url "/api/publications/translations/approvals"
+    :handler
+    (^:async fn [request reply]
+      (await
+       ((:with-request-context! handlers) runtime request reply
+        (^:async fn [ctx]
+          (await
+           (send-result!
+            reply
+            (fn []
+              ((:ensure-permission! handlers) ctx approve-permission)
+              (approve! config ctx (decode-request request)))))))))})
+  nil)

--- a/backend/src/cljs/knoxx/backend/extern/fastify/translation_review.cljs
+++ b/backend/src/cljs/knoxx/backend/extern/fastify/translation_review.cljs
@@ -39,14 +39,21 @@
 
    A table rather than a cond, so a new refusal type cannot be added without a
    status being chosen for it, and so classification is never re-derived from a
-   message string.
+   message string. Written out rather than derived from
+   `law/approval-refusal-types` with a default, because a default is exactly the
+   forcing function this table exists to be: it would let a new refusal reach
+   the wire on a status nobody picked. `translation_review_test` asserts the key
+   set equals law's, so the two cannot drift silently either.
 
    All 409. A missing translation is not a 404 — the request is well formed and
    the document exists, the system simply is not in a state where approving means
    anything yet. A mismatch is the same shape of problem: the caller is not wrong
-   about syntax, it disagrees with recorded fact."
+   about syntax, it disagrees with recorded fact. A garden mismatch is a mismatch
+   like the rest: the receipt is keyed by garden, so naming another one is a
+   disagreement with recorded fact rather than a malformed request."
   {:translation-receipt-missing 409
    :translation-document-mismatch 409
+   :translation-garden-mismatch 409
    :translation-locale-mismatch 409
    :translation-source-revision-mismatch 409
    :translation-revision-mismatch 409})

--- a/backend/src/cljs/knoxx/backend/extern/mongo.cljs
+++ b/backend/src/cljs/knoxx/backend/extern/mongo.cljs
@@ -7,6 +7,20 @@
    speak CLJS maps only."
   (:require [knoxx.backend.law.mongo :as law-mongo]))
 
+(defn collection
+  "The named collection handle on a native database handle.
+
+   Acquisition belongs here for the same reason every other driver call does:
+   `db` is an opaque JavaScript handle and `.collection` is a driver method on
+   it. A store reaching for that method itself would split MongoDB ownership
+   across two namespaces — this adapter owning reads, writes and indexes while
+   `infra.*` owned handle acquisition.
+
+   What comes back is another opaque handle, and it is only ever passed back
+   into this namespace's own functions."
+  [db collection-name]
+  (.collection db collection-name))
+
 (defn ^:async insert-one!
   "Insert one CLJS document into a native collection handle. Returns the doc."
   [collection-handle doc]

--- a/backend/src/cljs/knoxx/backend/infra/routes/app.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/app.cljs
@@ -17,6 +17,7 @@
             [knoxx.backend.extern.fastify.publications :as publication-routes]
             [knoxx.backend.extern.fastify.translation-config :as translation-config-routes]
             [knoxx.backend.extern.fastify.translation-dispatch :as translation-dispatch-routes]
+            [knoxx.backend.extern.fastify.translation-review :as translation-review-routes]
             [knoxx.backend.extern.fastify.cms-publication :as cms-publication-routes]
             [knoxx.backend.domain.contracts.sources :as contract-sources]
             [knoxx.backend.infra.document-state :refer [normalize-relative-path]]
@@ -1540,6 +1541,9 @@
     (translation-config-routes/register-translation-config-routes!
      app runtime config helpers)
     (translation-dispatch-routes/register-translation-dispatch-routes!
+     app runtime config (select-keys helpers [:with-request-context!
+                                              :ensure-permission!]))
+    (translation-review-routes/register-translation-review-routes!
      app runtime config (select-keys helpers [:with-request-context!
                                               :ensure-permission!]))))
 

--- a/backend/src/cljs/knoxx/backend/infra/routes/translation_dispatch.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/translation_dispatch.cljs
@@ -131,14 +131,19 @@
 (defn ^:async gate-facts!
   "Every fact `domain.publication-gate` needs, read once, scoped to one tenant.
 
-   `:approved?` is `(constantly false)` and that is deliberate rather than
-   provisional: no approval surface exists yet — it is
-   `knoxx-translation-approval-surface`, the sibling card — so nothing has been
-   approved, and claiming otherwise would be the one lie that lets unreviewed
-   content publish. It is also inert for dispatch specifically:
+   All four now come from real providers. `:approved?` reads recorded approvals
+   rather than the `(constantly false)` this function used while no approval
+   surface existed.
+
+   Approvals are filtered by the same tenant and project as receipts, and for the
+   same reason: review evidence attests to a translation that exists in one
+   scope. `:approved?` remains inert for dispatch specifically —
    `translation-work` derives from the `:translation-missing` and
    `:translation-stale` blockers, never from the review blocker, so a review
-   requirement does not suppress the translation that would satisfy it."
+   requirement does not suppress the translation that would satisfy it — but it
+   is loaded here because the same facts answer whether the resulting
+   publication is admissible, and computing them twice in two places is how the
+   two answers drift."
   ([config evidence-store scope documents]
    (gate-facts! config evidence-store scope documents {}))
   ([config evidence-store {:keys [org-id project] :as scope} documents document-roots]
@@ -155,10 +160,15 @@
                       (tenant-receipts org-id)
                       (project-receipts project)
                       (current-source-locale-receipts documents))
-        evidence (evidence-domain/evidence {:receipts receipts})]
+        approvals (->> (await (store/approvals!
+                               evidence-store
+                               (select-keys scope [:org-id :project])))
+                       (filterv #(and (= org-id (:review/org-id %))
+                                      (= project (:review/project %)))))
+        evidence (evidence-domain/evidence {:receipts receipts
+                                            :approvals approvals})]
     (merge (source-revision/revision-facts revisions)
-           (evidence-domain/gate-facts evidence)
-           {:approved? (constantly false)}))))
+           (evidence-domain/gate-facts evidence)))))
 
 (defn ^:async dispatch-translations!
   "Dispatch the derived translation work for one document, or for all of them.

--- a/backend/src/cljs/knoxx/backend/infra/routes/translation_review.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/translation_review.cljs
@@ -1,0 +1,68 @@
+(ns knoxx.backend.infra.routes.translation-review
+  "Translation approval facade.
+
+  One operation: record that an authorized principal accepted one translated
+  revision. Everything in and out is CLJS data — no Fastify handle enters or
+  leaves this namespace. The owning extern adapter is
+  `knoxx.backend.extern.fastify.translation-review`.
+
+  Approval is evidence, not an effect. Nothing here materializes anything, and
+  the card is explicit about why: an approval may make a publication plan
+  admissible, but it must not itself publish. That separation is what lets a
+  reviewer accept a translation without also deciding when the bytes go live."
+  (:require [knoxx.backend.domain.translation-evidence :as evidence-domain]
+            [knoxx.backend.infra.translation-evidence-store :as store]
+            [knoxx.backend.law.translation-evidence :as law]))
+
+(defn- ^:async current-receipt!
+  "The completed translation this request is about, or nil.
+
+   Loads the receipts and indexes them through
+   `domain.translation-evidence/evidence` rather than issuing a targeted query.
+   That is more work than one lookup and it is deliberate: which receipt is
+   *current* for a source revision is decided by comparing timestamps, and
+   pushing that rule into a store query would duplicate it — one copy per store
+   implementation, each free to drift from the copy the gate uses. An approval
+   validated against a different receipt than the gate will later read is the one
+   failure this card exists to prevent, so the rule stays in one place.
+
+   Scoped to the acting tenant and project before indexing. A reviewer must not
+   be able to approve a translation belonging to another organization, and the
+   dispatch card learned that lesson at the cost of two review rounds."
+  [evidence-store scope request]
+  (let [query-scope (select-keys scope [:org-id :project])
+        ;; Scoped in the query, and checked again here. The query is the
+        ;; optimization; the filter is the guarantee, since a replaceable store
+        ;; that ignored the scope must not be able to widen what a reviewer can
+        ;; approve.
+        receipts (->> (await (store/completed-translations! evidence-store query-scope))
+                      (filterv #(and (= (:org-id scope) (:translation/org-id %))
+                                     (= (:project scope) (:translation/project %)))))
+        evidence (evidence-domain/evidence {:receipts receipts})]
+    (evidence-domain/receipt-for evidence
+                                 (:review/document request)
+                                 (:review/garden request)
+                                 (:review/locale request)
+                                 (:review/revision request))))
+
+(defn ^:async approve-translation!
+  "Record approval of one translated revision, or refuse with typed evidence.
+
+   Returns one of:
+
+     {:approval/status :recorded :approval a}   first approval of this output
+     {:approval/status :existing :approval a}   already approved, idempotent
+     {:approval/refusal r}                      refused, with both sides named
+
+   The request is validated, then the receipt is looked up, then the refusal is
+   computed, and only then is anything written. Nothing is persisted on a
+   refusal: an approval that was rejected must leave no trace a later read could
+   mistake for evidence."
+  [{:keys [evidence-store clock]} scope request]
+  (let [checked (law/assert-approval-request! request)
+        receipt (await (current-receipt! evidence-store scope checked))]
+    (if-let [refusal (law/approval-refusal checked receipt)]
+      {:approval/refusal refusal}
+      (await (store/record-approval!
+              evidence-store
+              (law/approve checked receipt (:principal scope) (clock)))))))

--- a/backend/src/cljs/knoxx/backend/infra/stores/mongo_translation_evidence.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/stores/mongo_translation_evidence.cljs
@@ -49,8 +49,20 @@
   "Collection holding completed-translation receipts. Append-only."
   "knoxx_translation_receipts")
 
-(defn- dispatches-coll [db] (.collection db DISPATCHES_COLLECTION))
-(defn- receipts-coll [db] (.collection db RECEIPTS_COLLECTION))
+(def APPROVALS_COLLECTION
+  "Collection holding review approvals. One row per approved output, enforced by
+   a unique index rather than by a read-then-write."
+  "knoxx_translation_approvals")
+
+;; Acquired through the extern adapter rather than by calling `.collection` on
+;; the database handle here. `db` is an opaque JavaScript handle and
+;; `.collection` is a driver method on it, so reaching for it from `infra.*`
+;; would leave this namespace owning handle acquisition while `extern.mongo`
+;; owned every read, write and index built from the result — the split that
+;; adapter exists to prevent.
+(defn- dispatches-coll [db] (extern-mongo/collection db DISPATCHES_COLLECTION))
+(defn- receipts-coll [db] (extern-mongo/collection db RECEIPTS_COLLECTION))
+(defn- approvals-coll [db] (extern-mongo/collection db APPROVALS_COLLECTION))
 
 (defn ^:async setup-indexes!
   "Create required indexes. Idempotent.
@@ -66,7 +78,8 @@
    translation is dispatched twice."
   [db]
   (let [dispatches (dispatches-coll db)
-        receipts (receipts-coll db)]
+        receipts (receipts-coll db)
+        approvals (approvals-coll db)]
     (await (extern-mongo/ensure-index! dispatches [[:dispatch_key 1]] {:unique true}))
     ;; The join `dispatch-for-batch-document!` performs.
     (await (extern-mongo/ensure-index! dispatches [[:batch_id 1] [:document_wire_id 1]] {}))
@@ -76,6 +89,10 @@
                                         [:source_revision 1]] {}))
     ;; The scope every evidence read narrows by.
     (await (extern-mongo/ensure-index! receipts [[:org_id 1] [:project 1]] {}))
+    (await (extern-mongo/ensure-index! approvals [[:org_id 1] [:project 1]] {}))
+    ;; Unique, and for the same reason as dispatch_key: it is what makes
+    ;; recording an approval idempotent rather than append-once-per-click.
+    (await (extern-mongo/ensure-index! approvals [[:approval_key 1]] {:unique true}))
     true))
 
 ;; ── Codecs ─────────────────────────────────────────────────────────────────
@@ -304,6 +321,55 @@
                                            :document_wire_id document-wire-id
                                            :limit 1})))))
 
+(defn- approval-key
+  "The unique-index value for one approval.
+
+   Derived from `store/approval-identity` rather than restated, so durable and
+   in-memory uniqueness cannot disagree about what counts as the same approval.
+   `pr-str` keeps `:es` distinct from the string \"es\"."
+  [approval]
+  (pr-str (store/approval-identity approval)))
+
+(defn- encode-approval
+  [approval]
+  {:approval_key (approval-key approval)
+   :document (pr-str (:review/document approval))
+   :garden (pr-str (:review/garden approval))
+   :locale (name (:review/locale approval))
+   :revision (:review/revision approval)
+   :org_id (:review/org-id approval)
+   :project (scope-value (:review/project approval))
+   :approval_edn (pr-str approval)})
+
+(defn- decode-approval
+  [doc]
+  (when doc
+    (evidence-law/assert-approval! (edn/read-string (:approval_edn doc)))))
+
+(defn- ^:async claim-approval!
+  "Record `approval` unless its exact output is already approved.
+
+   The insert IS the check, exactly as in `claim-dispatch!`. Read-then-write would
+   let two reviewers clicking together both insert, leaving two records free to
+   disagree about who approved."
+  [db approval]
+  (let [{:keys [inserted?]}
+        (await (extern-mongo/insert-one-unique! (approvals-coll db)
+                                               (encode-approval approval)))]
+    (if inserted?
+      {:approval/status :recorded :approval approval}
+      {:approval/status :existing
+       :approval (decode-approval
+                  (first (await (extern-mongo/find-docs!
+                                 (approvals-coll db)
+                                 {:approval_key (approval-key approval)
+                                  :limit 1}))))})))
+
+(defn- ^:async read-approvals!
+  [db scope]
+  (mapv decode-approval
+        (await (extern-mongo/find-docs! (approvals-coll db) (scope-query scope)))))
+
 (defn- ^:async find-batch-only-dispatch!
   [db batch-id]
   (decode-dispatch
@@ -355,4 +421,10 @@
       (append-receipt! db (evidence-law/assert-receipt! receipt)))
 
     (completed-translations! [_ scope]
-      (read-receipts! db scope))))
+      (read-receipts! db scope))
+
+    (record-approval! [_ approval]
+      (claim-approval! db (evidence-law/assert-approval! approval)))
+
+    (approvals! [_ scope]
+      (read-approvals! db scope))))

--- a/backend/src/cljs/knoxx/backend/infra/translation_evidence_store.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/translation_evidence_store.cljs
@@ -1,12 +1,13 @@
 (ns knoxx.backend.infra.translation-evidence-store
-  "Persistence boundary for translation dispatch bindings and completed
-  translation evidence.
+  "Persistence boundary for translation dispatch bindings, completed translation
+  evidence, and review approvals.
 
-  Two things are stored, and they are not the same kind of thing. A *dispatch
+  Three things are stored, and they are not the same kind of thing. A *dispatch
   record* is a claim: Knoxx asked for a translation at one concrete revision and
-  is waiting. A *translation receipt* is a fact: the translation exists. The
-  claim is mutable exactly once, from in-flight to a terminal outcome; the fact
-  is append-only and never edited.
+  is waiting. A *translation receipt* is a fact: the translation exists. An
+  *approval* is a different fact: someone authorized accepted one produced
+  translation. The claim is mutable exactly once, from in-flight to a terminal
+  outcome; the two facts are never edited.
 
   `reserve-dispatch!` deliberately borrows the vocabulary of
   `infra.publication-effects/IIdempotencyStore`, including its hard rule:
@@ -88,7 +89,31 @@
      a total order over `:translation/at` and the output revision, so an
      implementation is free to return rows in whatever order its query produced.
      An earlier draft of this docstring promised oldest-first while the durable
-     store read unsorted — a contradiction a consumer could have relied on."))
+     store read unsorted — a contradiction a consumer could have relied on.")
+  (record-approval! [store approval]
+    "Record immutable review evidence, at most once per approved output.
+
+     Returns a Promise of `{:approval/status :recorded :approval a}` for a first
+     approval, or `{:approval/status :existing :approval a}` when this exact
+     output was already approved.
+
+     Idempotent rather than append-only, and the difference matters: an approval
+     is immutable evidence, so a second one for the same produced output is not a
+     new fact, it is the same fact asserted twice. Appending would make
+     `approved?` depend on how many times a button was clicked and leave two
+     records free to disagree about who approved.
+
+     Implementations must claim atomically, for the same reason
+     `reserve-dispatch!` must: two reviewers clicking together would otherwise
+     both insert.")
+  (approvals! [store scope]
+    "Approvals within `scope`, which means the same thing it does for
+     `completed-translations!` and is pushed into the query for the same reason.
+     Returns a Promise.
+
+     Order is not part of the contract:
+     `domain.translation-evidence/index-approvals` retains all of them and the
+     join against the receipt decides which is current."))
 
 ;; ── Validation helpers ─────────────────────────────────────────────────────
 
@@ -174,6 +199,12 @@
   (and (= org-id (:translation/org-id receipt))
        (= project (:translation/project receipt))))
 
+(defn approval-in-scope?
+  "Whether `approval` belongs to `scope`. See `receipt-in-scope?`."
+  [approval {:keys [org-id project]}]
+  (and (= org-id (:review/org-id approval))
+       (= project (:review/project approval))))
+
 (defn- batch-document-match
   [dispatches batch-id document-wire-id]
   (->> (vals dispatches)
@@ -181,7 +212,64 @@
                      (= document-wire-id (:dispatch/document-wire-id %))))
        first))
 
+(defn approval-identity
+  "The identity at most one approval may exist for.
+
+   Includes the translation revision, not merely the gate's triple: approving a
+   re-translation of the same source revision is a genuinely new act of review
+   over different bytes, and collapsing the two would silently reuse the first
+   reviewer's decision for content they never saw.
+
+   Includes the tenant and project for the same reason the receipt does — an
+   approval attests to a translation that exists in one scope."
+  [approval]
+  [(:review/org-id approval)
+   (:review/project approval)
+   (:review/document approval)
+   (:review/garden approval)
+   (:review/locale approval)
+   (:review/revision approval)
+   (:review/translation-revision approval)])
+
+(defn- record-approval-in-state
+  "Store `approval` under `identity` unless one is already there, answering
+   which happened."
+  [current identity approval]
+  (if-let [existing (get-in current [:approvals identity])]
+    (assoc current :answer {:approval/status :existing :approval existing})
+    (-> current
+        (assoc-in [:approvals identity] approval)
+        (assoc :answer {:approval/status :recorded :approval approval}))))
+
 ;; ── In-memory implementation ───────────────────────────────────────────────
+
+(defn- resolve-outcome-in-state
+  "Set an in-flight claim's outcome, and its detail when one is given."
+  [current dispatch-key outcome detail]
+  (update-in-flight-state current dispatch-key
+                          (fn [record]
+                            (cond-> (assoc record :dispatch/outcome outcome)
+                              (some? detail) (assoc :dispatch/detail detail)))))
+
+(defn- read-dispatch
+  [state dispatch-key]
+  (some-> (get-in state [:dispatches dispatch-key]) dispatch-law/assert-record!))
+
+(defn- read-batch-dispatch
+  [state batch-id document-wire-id]
+  (some-> (batch-document-match (:dispatches state) batch-id document-wire-id)
+          dispatch-law/assert-record!))
+
+(defn- read-batch-only-dispatch
+  [state batch-id]
+  (some-> (->> (vals (:dispatches state))
+               (filter #(= batch-id (:dispatch/batch-id %)))
+               first)
+          dispatch-law/assert-record!))
+
+(defn- append-receipt-in-state
+  [current receipt]
+  (update current :receipts conj receipt))
 
 (defn memory-store
   "An `ITranslationEvidenceStore` over one atom.
@@ -190,7 +278,7 @@
    durable store: a binding lost on restart can never be joined to the worker's
    answer, so the translation would complete and no receipt would ever exist."
   []
-  (let [state (atom {:dispatches {} :receipts []})]
+  (let [state (atom {:dispatches {} :receipts [] :approvals {}})]
     (reify ITranslationEvidenceStore
       (reserve-dispatch! [_ record]
         (js/Promise.resolve
@@ -200,42 +288,42 @@
 
       (resolve-dispatch! [_ dispatch-key outcome detail]
         (js/Promise.resolve
-         (resolved-answer
-          (swap! state update-in-flight-state dispatch-key
-                 (fn [record]
-                   (cond-> (assoc record :dispatch/outcome outcome)
-                     (some? detail) (assoc :dispatch/detail detail)))))))
+         (resolved-answer (swap! state resolve-outcome-in-state
+                                 dispatch-key outcome detail))))
 
       (bind-dispatch-batch! [_ dispatch-key batch-id]
         (js/Promise.resolve
-         (resolved-answer
-          (swap! state update-in-flight-state dispatch-key
-                 #(assoc % :dispatch/batch-id batch-id)))))
+         (resolved-answer (swap! state update-in-flight-state dispatch-key
+                                 #(assoc % :dispatch/batch-id batch-id)))))
 
       (dispatch-for-key! [_ dispatch-key]
-        (js/Promise.resolve
-         (some-> (get-in @state [:dispatches dispatch-key])
-                 dispatch-law/assert-record!)))
+        (js/Promise.resolve (read-dispatch @state dispatch-key)))
 
       (dispatch-for-batch-document! [_ batch-id document-wire-id]
-        (js/Promise.resolve
-         (some-> (batch-document-match (:dispatches @state) batch-id document-wire-id)
-                 dispatch-law/assert-record!)))
+        (js/Promise.resolve (read-batch-dispatch @state batch-id document-wire-id)))
 
       (dispatch-for-batch! [_ batch-id]
-        (js/Promise.resolve
-         (some-> (->> (vals (:dispatches @state))
-                      (filter #(= batch-id (:dispatch/batch-id %)))
-                      first)
-                 dispatch-law/assert-record!)))
+        (js/Promise.resolve (read-batch-only-dispatch @state batch-id)))
 
       (record-translation! [_ receipt]
         (let [checked (evidence-law/assert-receipt! receipt)]
-          (swap! state update :receipts conj checked)
+          (swap! state append-receipt-in-state checked)
           (js/Promise.resolve checked)))
 
       (completed-translations! [_ scope]
         (js/Promise.resolve
          (into [] (comp (map evidence-law/assert-receipt!)
                         (filter #(receipt-in-scope? % scope)))
-               (:receipts @state)))))))
+               (:receipts @state))))
+
+      (record-approval! [_ approval]
+        (let [checked (evidence-law/assert-approval! approval)]
+          (js/Promise.resolve
+           (:answer (swap! state record-approval-in-state
+                           (approval-identity checked) checked)))))
+
+      (approvals! [_ scope]
+        (js/Promise.resolve
+         (into [] (comp (map evidence-law/assert-approval!)
+                        (filter #(approval-in-scope? % scope)))
+               (vals (:approvals @state))))))))

--- a/backend/src/cljs/knoxx/backend/law/translation_evidence.cljc
+++ b/backend/src/cljs/knoxx/backend/law/translation_evidence.cljc
@@ -234,3 +234,225 @@
    already applies across the effect boundary."
   [receipt]
   (assert-valid! :translation/receipt CompletedTranslationReceipt receipt))
+
+;; ── Approval ───────────────────────────────────────────────────────────────
+
+(def Principal
+  "Who approved, as at least one durable identity.
+
+   Attribution that cannot be resolved back to a person is not attribution. A
+   principal carrying only blank strings would satisfy a shape made of optional
+   keys, so the presence rule is a law rather than a convention."
+  [:and
+   [:map
+    [:principal/user-id {:optional true} [:maybe :string]]
+    [:principal/user-email {:optional true} [:maybe :string]]
+    [:principal/membership-id {:optional true} [:maybe :string]]]
+   [:fn {:error/message "an approval principal requires at least one durable identity"}
+    (fn [principal]
+      (boolean (some nonblank-string?
+                     ((juxt :principal/user-id
+                            :principal/user-email
+                            :principal/membership-id)
+                      principal))))]])
+
+(def ApprovalRequest
+  "What a caller may submit.
+
+   No principal and no timestamp: both are attributed by the server from the
+   authenticated context and the clock, so a caller can neither claim to be
+   someone else nor backdate review evidence. No organization or project either —
+   those come from the receipt being approved, which is already scoped.
+
+   Closed, and that is load-bearing rather than tidy: an extra key on an approval
+   request is precisely the shape a caller would use to try to smuggle
+   `:review/principal` or `:review/at` past attribution."
+  [:map {:closed true}
+   [:review/document :qualified-keyword]
+   [:review/garden :qualified-keyword]
+   [:review/locale locale/Locale]
+   [:review/revision ConcreteRevision]
+   [:review/translation-revision ConcreteRevision]])
+
+(def Approval
+  "Immutable review evidence, in the vocabulary the gate already speaks.
+
+   `domain.publication-gate/review-satisfies-intent?` compares `:review/state`,
+   `:review/document`, `:review/locale` and `:review/revision`. Those four are
+   named identically here on purpose: the gate is not modified to accommodate
+   approval evidence, approval evidence is declared in the words the gate
+   already uses.
+
+   `:review/revision` is the concrete *source* revision, not the translated one.
+   That is what a publication intent resolves to and therefore what the gate can
+   ask about; the card's phrase 'concrete translated revision' reads the other
+   way and taken literally would produce approvals the gate could never match.
+   `:review/translation-revision` carries the produced output alongside, and is
+   the field the gate does not read — see `approval-current?`.
+
+   `:review/org-id` and `:review/project` are required for the same reason
+   `CompletedTranslationReceipt` carries them: the translation an approval
+   attests to exists in one tenant and one project, so review evidence that
+   named neither would be admissible everywhere. That lesson was learned the hard
+   way one card earlier.
+
+   `:review/garden` is required for the third instance of that same lesson. The
+   worker builds its prompt with `garden_id`, so the same document translated
+   into the same locale for two gardens is two different outputs — and a
+   garden-agnostic approval would let a reviewer who read one garden's bytes
+   admit publication of the other's. It is not carried as scope-that-happens-to-
+   travel: it is a coordinate of the receipt being approved, and it is taken from
+   that receipt rather than from the request."
+  [:map
+   [:review/state [:= :approved]]
+   [:review/document :qualified-keyword]
+   [:review/garden :qualified-keyword]
+   [:review/locale locale/Locale]
+   [:review/revision ConcreteRevision]
+   [:review/translation-revision ConcreteRevision]
+   [:review/org-id NonBlankString]
+   [:review/project {:optional true} [:maybe NonBlankString]]
+   [:review/principal Principal]
+   [:review/at Instant]])
+
+(def approval-refusal-types
+  "Every reason an approval request is refused.
+
+   Enumerated as data so an HTTP adapter maps refusal to status by lookup rather
+   than by re-deriving the classification from a message string, and so a new
+   refusal cannot be introduced without appearing here."
+  #{:translation-receipt-missing
+    :translation-document-mismatch
+    :translation-garden-mismatch
+    :translation-locale-mismatch
+    :translation-source-revision-mismatch
+    :translation-revision-mismatch})
+
+(def ApprovalRefusal
+  "A typed refusal. Both sides of a mismatch travel on it: told only that a
+   revision disagreed, a caller cannot see whether its own request or the
+   recorded translation was the stale one."
+  [:map
+   [:refusal/type (into [:enum] (sort approval-refusal-types))]
+   [:refusal/requested {:optional true} :any]
+   [:refusal/recorded {:optional true} :any]])
+
+(defn assert-approval-request!
+  "Validate a decoded approval request before any lookup or write."
+  [request]
+  (assert-valid! :translation-review/request ApprovalRequest request))
+
+(defn assert-approval!
+  "Validate approval evidence before it is persisted or returned, and again when
+   it is read back — a store is replaceable, so its output is untrusted input."
+  [approval]
+  (assert-valid! :translation-review/approval Approval approval))
+
+(defn approval-refusal
+  "Why `request` may not be approved against `receipt`, or nil when it may.
+
+   Data rather than a throw. The caller is an HTTP adapter that must answer with
+   a status and a body either way, and a refusal here is an ordinary outcome of a
+   well-formed request rather than an exceptional one.
+
+   A nil receipt is the first branch because every comparison below would
+   otherwise read fields off nothing and report a mismatch against nil, which
+   describes the wrong problem: there is no translation to approve, rather than a
+   translation that disagrees."
+  [request receipt]
+  (cond
+    (nil? receipt)
+    {:refusal/type :translation-receipt-missing
+     :refusal/requested (select-keys request [:review/document
+                                              :review/garden
+                                              :review/locale
+                                              :review/revision])}
+
+    (not= (:translation/document receipt) (:review/document request))
+    {:refusal/type :translation-document-mismatch
+     :refusal/requested (:review/document request)
+     :refusal/recorded (:translation/document receipt)}
+
+    (not= (:translation/garden receipt) (:review/garden request))
+    ;; Unreachable through the facade, which looks the receipt up by garden —
+    ;; and checked anyway, because this contract is also what a second caller
+    ;; would be validated against, and a garden mismatch is the one that admits
+    ;; bytes nobody read.
+    {:refusal/type :translation-garden-mismatch
+     :refusal/requested (:review/garden request)
+     :refusal/recorded (:translation/garden receipt)}
+
+    (not= (:translation/locale receipt) (:review/locale request))
+    {:refusal/type :translation-locale-mismatch
+     :refusal/requested (:review/locale request)
+     :refusal/recorded (:translation/locale receipt)}
+
+    (not= (:translation/source-revision receipt) (:review/revision request))
+    {:refusal/type :translation-source-revision-mismatch
+     :refusal/requested (:review/revision request)
+     :refusal/recorded (:translation/source-revision receipt)}
+
+    (not= (:translation/revision receipt) (:review/translation-revision request))
+    ;; The caller named a produced output that is not the current one. Accepting
+    ;; it would record review evidence for bytes the store no longer describes.
+    {:refusal/type :translation-revision-mismatch
+     :refusal/requested (:review/translation-revision request)
+     :refusal/recorded (:translation/revision receipt)}))
+
+(defn approve
+  "Build immutable approval evidence from a validated request, the completed
+   receipt it is recorded against, the acting principal, and a clock reading.
+
+   Pure: `at` is supplied rather than read. Every identity field is taken from
+   the *receipt* rather than from the request — including the tenant and project,
+   which the request never carries — so the persisted evidence describes what the
+   store actually holds. `approval-refusal` has already established that the two
+   agree on everything the request did name."
+  [_request receipt principal at]
+  (assert-approval!
+   (cond-> {:review/state :approved
+            :review/document (:translation/document receipt)
+            :review/garden (:translation/garden receipt)
+            :review/locale (:translation/locale receipt)
+            :review/revision (:translation/source-revision receipt)
+            :review/translation-revision (:translation/revision receipt)
+            :review/org-id (:translation/org-id receipt)
+            :review/principal principal
+            :review/at at}
+     (some? (:translation/project receipt))
+     (assoc :review/project (:translation/project receipt)))))
+
+(defn approval-matches?
+  "Whether `approval` is evidence about the document, garden, locale and
+   concrete source revision the gate is asking about.
+
+   The gate's own question restated as a predicate over one approval, so a fact
+   provider need not re-derive it. It deliberately does NOT consider
+   `:review/translation-revision` — see `approval-current?`."
+  [approval document garden locale revision]
+  (and (= :approved (:review/state approval))
+       (= document (:review/document approval))
+       (= garden (:review/garden approval))
+       (= locale (:review/locale approval))
+       (= revision (:review/revision approval))
+       true))
+
+(defn approval-current?
+  "Whether `approval` still describes the translation output `receipt` holds.
+
+   The gate asks `approved?` with a document, a locale and a concrete *source*
+   revision, which is all a publication intent can tell it. That triple is not
+   enough on its own: re-running a translation for the same source revision
+   produces new bytes under a new output revision, and an approval matching only
+   the triple would keep authorizing them.
+
+   So the fact provider joins the two facts, and this is the join condition. An
+   approval whose `:review/translation-revision` no longer matches the receipt's
+   `:translation/revision` is not deleted and not an error — it simply stops
+   being current, exactly as `domain.publication-gate` says a stale
+   translation's approval stops satisfying the new revision."
+  [approval receipt]
+  (and (some? receipt)
+       (= (:review/translation-revision approval)
+          (:translation/revision receipt))
+       true))

--- a/backend/test/cljs/knoxx/backend/domain/translation_evidence_test.cljs
+++ b/backend/test/cljs/knoxx/backend/domain/translation_evidence_test.cljs
@@ -4,14 +4,15 @@
             [knoxx.backend.domain.translation-evidence :as domain]))
 
 (defn- receipt
-  [& {:keys [locale source-revision revision at]
-      :or {locale :es
+  [& {:keys [garden locale source-revision revision at]
+      :or {garden :knoxx.docs/promethean
+           locale :es
            source-revision "sha256-aaa111bbb222"
            revision "sha256-aaa111bbb222+es@batch-1"
            at "2026-08-22T09:00:00.000Z"}}]
   {:receipt/type :translation/completed
    :translation/document :knoxx.docs/probe
-   :translation/garden :knoxx.docs/promethean
+   :translation/garden garden
    :translation/source-locale :en
    :translation/locale locale
    :translation/source-revision source-revision
@@ -57,17 +58,144 @@
     (is (thrown? js/Error
                  (domain/evidence {:receipts [(receipt :source-revision "source/current")]})))))
 
-(deftest gate-facts-supply-only-the-half-this-card-owns
-  (let [facts (domain/gate-facts (domain/evidence {:receipts [(receipt)]}))]
-    (testing "the translation predicate is present and answers"
-      (is (fn? (:translated-revision? facts)))
-      (is ((:translated-revision? facts) :knoxx.docs/probe :knoxx.docs/promethean :es "sha256-aaa111bbb222")))
+(defn- approval
+  [& {:keys [garden locale revision translation-revision at]
+      :or {garden :knoxx.docs/promethean
+           locale :es
+           revision "sha256-aaa111bbb222"
+           translation-revision "sha256-aaa111bbb222+es@batch-1"
+           at "2026-08-22T09:30:00.000Z"}}]
+  {:review/state :approved
+   :review/document :knoxx.docs/probe
+   :review/garden garden
+   :review/locale locale
+   :review/revision revision
+   :review/translation-revision translation-revision
+   :review/org-id "org-1"
+   :review/principal {:principal/user-email "reviewer@open-hax.local"}
+   :review/at at})
 
-    (testing "nothing else is fabricated"
-      ;; Defaulting :approved? or :current-source-revision here would let a
-      ;; caller forget to supply the real thing and still get a gate that
-      ;; answers — admitting a publication on evidence nobody produced.
-      (is (= [:translated-revision?] (keys facts))))))
+(deftest gate-facts-supply-both-evidential-halves-and-nothing-else
+  (let [facts (domain/gate-facts (domain/evidence {:receipts [(receipt)]
+                                                   :approvals [(approval)]}))]
+    (testing "both evidential predicates are present and answer"
+      (is (fn? (:translated-revision? facts)))
+      (is (fn? (:approved? facts)))
+      (is ((:translated-revision? facts) :knoxx.docs/probe :knoxx.docs/promethean :es "sha256-aaa111bbb222"))
+      (is ((:approved? facts) :knoxx.docs/probe :knoxx.docs/promethean :es "sha256-aaa111bbb222")))
+
+    (testing "the source-revision facts are not fabricated"
+      ;; Defaulting :current-source-revision here would let a caller forget to
+      ;; supply the real thing and still get a gate that answers — admitting a
+      ;; publication on evidence nobody produced.
+      (is (= #{:translated-revision? :approved?} (set (keys facts)))))))
+
+(deftest approval-alone-is-never-enough
+  (testing "an approval with no receipt behind it counts for nothing"
+    ;; Approval is evidence for the gate, not a blanket permission. With no
+    ;; translation recorded there is nothing it can attest to.
+    (is (not (domain/approved? (domain/evidence {:receipts [] :approvals [(approval)]})
+                               :knoxx.docs/probe :knoxx.docs/promethean :es "sha256-aaa111bbb222")))))
+
+(deftest an-approval-is-specific-to-one-document-locale-and-revision
+  (let [evidence (domain/evidence {:receipts [(receipt)] :approvals [(approval)]})]
+    (testing "the approved triple is approved"
+      (is (domain/approved? evidence :knoxx.docs/probe :knoxx.docs/promethean :es "sha256-aaa111bbb222")))
+
+    (testing "it does not satisfy another document, locale, or revision"
+      (is (not (domain/approved? evidence :knoxx.docs/other :knoxx.docs/promethean :es "sha256-aaa111bbb222")))
+      (is (not (domain/approved? evidence :knoxx.docs/probe :knoxx.docs/promethean :fr "sha256-aaa111bbb222")))
+      (is (not (domain/approved? evidence :knoxx.docs/probe :knoxx.docs/promethean :es "sha256-different"))))))
+
+(deftest an-approval-does-not-cross-gardens
+  ;; The same leak the dispatch key and the receipt lookup close, on the approval
+  ;; half. The worker builds its prompt with `garden_id`, so one document
+  ;; translated into one locale for two gardens is two different outputs — and a
+  ;; garden-agnostic approval would let a reviewer who read garden A's bytes
+  ;; admit publication of garden B's, which nobody read.
+  (let [other-garden :knoxx.docs/other-garden
+        evidence (domain/evidence
+                  {:receipts [(receipt)
+                              (receipt :garden other-garden
+                                       :revision "sha256-aaa111bbb222+es@batch-9")]
+                   :approvals [(approval)]})]
+    (testing "the approved garden is approved"
+      (is (domain/approved? evidence :knoxx.docs/probe :knoxx.docs/promethean
+                            :es "sha256-aaa111bbb222")))
+
+    (testing "the other garden has a translation but no approval"
+      ;; Both halves matter: the receipt exists, so this is not merely 'nothing
+      ;; to approve' — it is an approval that must not travel.
+      (is (domain/translated-revision? evidence :knoxx.docs/probe other-garden
+                                       :es "sha256-aaa111bbb222"))
+      (is (not (domain/approved? evidence :knoxx.docs/probe other-garden
+                                 :es "sha256-aaa111bbb222"))))
+
+    (testing "approving the other garden does not retroactively need the first"
+      (let [both (domain/evidence
+                  {:receipts [(receipt)
+                              (receipt :garden other-garden
+                                       :revision "sha256-aaa111bbb222+es@batch-9")]
+                   :approvals [(approval)
+                               (approval :garden other-garden
+                                         :translation-revision
+                                         "sha256-aaa111bbb222+es@batch-9")]})]
+        (is (domain/approved? both :knoxx.docs/probe :knoxx.docs/promethean
+                              :es "sha256-aaa111bbb222"))
+        (is (domain/approved? both :knoxx.docs/probe other-garden
+                              :es "sha256-aaa111bbb222"))))))
+
+(deftest a-re-translation-supersedes-its-approval
+  (let [older (receipt :revision "sha256-aaa111bbb222+es@batch-1"
+                       :at "2026-08-22T09:00:00.000Z")
+        newer (receipt :revision "sha256-aaa111bbb222+es@batch-2"
+                       :at "2026-08-22T10:00:00.000Z")
+        approved-older (approval :translation-revision "sha256-aaa111bbb222+es@batch-1")]
+    (testing "the approval satisfies the translation it was given for"
+      (is (domain/approved? (domain/evidence {:receipts [older]
+                                              :approvals [approved-older]})
+                            :knoxx.docs/probe :knoxx.docs/promethean :es "sha256-aaa111bbb222")))
+
+    (testing "it stops satisfying the gate once the translation is replaced"
+      ;; Not deleted and not an error — it simply stops being current. This is
+      ;; what keeps an approval from authorizing bytes nobody reviewed, and the
+      ;; reason the output revision is batch-specific.
+      (is (not (domain/approved? (domain/evidence {:receipts [older newer]
+                                                   :approvals [approved-older]})
+                                 :knoxx.docs/probe :knoxx.docs/promethean :es "sha256-aaa111bbb222"))))
+
+    (testing "approving the replacement restores admissibility"
+      (is (domain/approved?
+           (domain/evidence
+            {:receipts [older newer]
+             :approvals [approved-older
+                         (approval :translation-revision "sha256-aaa111bbb222+es@batch-2")]})
+           :knoxx.docs/probe :knoxx.docs/promethean :es "sha256-aaa111bbb222")))))
+
+(deftest a-store-returning-invalid-approvals-is-refused
+  (testing "an approval missing its translation revision cannot be indexed"
+    (is (thrown? js/Error
+                 (domain/evidence {:receipts [(receipt)]
+                                   :approvals [(dissoc (approval)
+                                                       :review/translation-revision)]}))))
+
+  (testing "an approval attributed to nobody is refused"
+    (is (thrown? js/Error
+                 (domain/evidence {:receipts [(receipt)]
+                                   :approvals [(assoc (approval) :review/principal {})]}))))
+
+  (testing "an approval naming no tenant is refused"
+    ;; Review evidence that named no organization would be admissible in every
+    ;; one of them.
+    (is (thrown? js/Error
+                 (domain/evidence {:receipts [(receipt)]
+                                   :approvals [(dissoc (approval) :review/org-id)]}))))
+
+  (testing "a non-approved review state cannot masquerade as an approval"
+    (is (thrown? js/Error
+                 (domain/evidence {:receipts [(receipt)]
+                                   :approvals [(assoc (approval)
+                                                      :review/state :rejected)]})))))
 
 (deftest the-gate-actually-consumes-these-facts
   ;; The integration that matters: these predicates are shaped for
@@ -81,13 +209,11 @@
                 :publication/path "/probe"
                 :translation/review :none
                 :document/source-locale :en}
-        facts-with (merge {:current-source-revision (constantly "sha256-aaa111bbb222")
-                           :approved? (constantly false)
-                           :source-revision-superseded? (constantly false)}
+        source-facts {:current-source-revision (constantly "sha256-aaa111bbb222")
+                      :source-revision-superseded? (constantly false)}
+        facts-with (merge source-facts
                           (domain/gate-facts (domain/evidence {:receipts [(receipt)]})))
-        facts-without (merge {:current-source-revision (constantly "sha256-aaa111bbb222")
-                              :approved? (constantly false)
-                              :source-revision-superseded? (constantly false)}
+        facts-without (merge source-facts
                              (domain/gate-facts (domain/evidence {:receipts []})))]
     (testing "a translated revision clears the translation blocker"
       (let [decision (gate/gate intent facts-with)]

--- a/backend/test/cljs/knoxx/backend/extern/fastify/translation_review_test.cljs
+++ b/backend/test/cljs/knoxx/backend/extern/fastify/translation_review_test.cljs
@@ -5,7 +5,8 @@
   principal, the timestamp and the tenant are all attributed by the server, and
   the only way to be sure of that is to try to send them."
   (:require [cljs.test :refer [deftest is testing]]
-            [knoxx.backend.extern.fastify.translation-review :as adapter]))
+            [knoxx.backend.extern.fastify.translation-review :as adapter]
+            [knoxx.backend.law.translation-evidence :as law]))
 
 (defn- request
   [body]
@@ -116,11 +117,10 @@
       (is (true? (:refused body)))
       (is (= :translation-revision-mismatch (:refusal/type (:refusal body))))))
 
-  (testing "every refusal type has a status chosen for it"
-    ;; A table rather than a cond, so a new refusal cannot be added without one.
-    (is (= (set (keys adapter/refusal-status))
-           #{:translation-receipt-missing
-             :translation-document-mismatch
-             :translation-locale-mismatch
-             :translation-source-revision-mismatch
-             :translation-revision-mismatch}))))
+  (testing "every refusal type the law can produce has a status chosen for it"
+    ;; Compared against `law/approval-refusal-types`, not against a second copy
+    ;; of the adapter's own keys. A restated list validates the table against
+    ;; itself: adding a refusal type to the law and forgetting the adapter left
+    ;; both this assertion and `refusal-status` unchanged and still agreeing,
+    ;; while the new type fell through `get`'s default to a status nobody chose.
+    (is (= law/approval-refusal-types (set (keys adapter/refusal-status))))))

--- a/backend/test/cljs/knoxx/backend/extern/fastify/translation_review_test.cljs
+++ b/backend/test/cljs/knoxx/backend/extern/fastify/translation_review_test.cljs
@@ -1,0 +1,126 @@
+(ns knoxx.backend.extern.fastify.translation-review-test
+  "The approval boundary: what a caller may and may not put in the request.
+
+  Every property here is one an untrusted caller would otherwise control. The
+  principal, the timestamp and the tenant are all attributed by the server, and
+  the only way to be sure of that is to try to send them."
+  (:require [cljs.test :refer [deftest is testing]]
+            [knoxx.backend.extern.fastify.translation-review :as adapter]))
+
+(defn- request
+  [body]
+  (js-obj "body" (clj->js body)))
+
+(def ^:private valid-body
+  {:document "knoxx.docs/probe"
+   :garden "knoxx.docs/promethean"
+   :locale "es"
+   :revision "sha256-aaa111bbb222"
+   :translation_revision "sha256-aaa111bbb222+es@batch-1"})
+
+(deftest a-well-formed-body-decodes-to-the-identities-receipts-are-keyed-by
+  (let [decoded (adapter/decode-request (request valid-body))]
+    (testing "the document, garden and locale become keywords"
+      (is (= :knoxx.docs/probe (:review/document decoded)))
+      (is (= :knoxx.docs/promethean (:review/garden decoded)))
+      (is (= :es (:review/locale decoded))))
+
+    (testing "revisions stay opaque strings"
+      ;; A revision is opaque text. Decoding it to a keyword would invent
+      ;; structure that is not there.
+      (is (= "sha256-aaa111bbb222" (:review/revision decoded)))
+      (is (= "sha256-aaa111bbb222+es@batch-1" (:review/translation-revision decoded))))))
+
+(deftest a-caller-cannot-supply-its-own-principal-or-timestamp
+  ;; The request contract is closed, so the fields attribution owns cannot be
+  ;; smuggled through the body.
+  (doseq [field [:principal :review/principal :at :review/at :org_id :project]]
+    (is (thrown? js/Error
+                 (adapter/decode-request (request (assoc valid-body field "forged"))))
+        (str field " was accepted"))))
+
+(deftest every-field-is-required-and-must-not-be-blank
+  (doseq [field [:document :garden :locale :revision :translation_revision]]
+    (testing (str field " is required")
+      (is (thrown? js/Error (adapter/decode-request (request (dissoc valid-body field))))))
+
+    (testing (str field " may not be blank")
+      (is (thrown? js/Error (adapter/decode-request (request (assoc valid-body field "")))))
+      (is (thrown? js/Error (adapter/decode-request (request (assoc valid-body field "  "))))))))
+
+(deftest an-unqualified-document-or-garden-is-refused
+  (testing "a bare name is a different document from the qualified one"
+    (is (thrown? js/Error
+                 (adapter/decode-request (request (assoc valid-body :document "probe"))))))
+
+  (testing "the same holds for the garden the approval is scoped to"
+    ;; An unqualified garden is a different garden, and an approval filed
+    ;; against one the receipts are not keyed by can never match — so it would
+    ;; read as 'nothing to approve' rather than as a malformed request.
+    (is (thrown? js/Error
+                 (adapter/decode-request (request (assoc valid-body :garden "promethean")))))))
+
+(deftest a-selector-revision-is-refused-in-either-position
+  ;; This is the boundary where a revision arrives as decoded wire input, so the
+  ;; string spelling of the selector is the one that has to be caught.
+  (is (thrown? js/Error
+               (adapter/decode-request (request (assoc valid-body
+                                                       :revision "source/current")))))
+  (is (thrown? js/Error
+               (adapter/decode-request (request (assoc valid-body
+                                                       :translation_revision "source/current"))))))
+
+(deftest the-principal-comes-from-the-auth-context
+  (testing "any one durable identity is enough"
+    (is (= {:principal/user-email "a@b.c"}
+           (adapter/principal-of {:user-email "a@b.c"})))
+    (is (= {:principal/user-id "u1"} (adapter/principal-of {:user-id "u1"})))
+    (is (= {:principal/membership-id "m1"} (adapter/principal-of {:membership-id "m1"}))))
+
+  (testing "a context identifying nobody cannot produce review evidence"
+    ;; Evidence attributable to nobody is indistinguishable from evidence nobody
+    ;; produced.
+    (is (thrown? js/Error (adapter/principal-of {})))
+    (is (thrown? js/Error (adapter/principal-of nil)))))
+
+(deftest the-review-scope-is-taken-from-context-and-config
+  (testing "the organization comes from the context"
+    (is (= "org-1" (:org-id (adapter/review-scope {} {:org-id "org-1"
+                                                      :user-email "a@b.c"})))))
+
+  (testing "the project comes from configuration, matching where batches are filed"
+    (is (= "knoxx-session"
+           (:project (adapter/review-scope {:session-project-name "knoxx-session"}
+                                           {:org-id "org-1" :user-email "a@b.c"})))))
+
+  (testing "an approval cannot be filed under an invented tenant"
+    (is (thrown? js/Error (adapter/review-scope {} {:user-email "a@b.c"})))))
+
+(deftest responses-distinguish-recorded-existing-and-refused
+  (testing "a first approval is 201"
+    (is (= 201 (:status (adapter/response-for {:approval/status :recorded
+                                               :approval {:review/state :approved}})))))
+
+  (testing "an already-recorded approval is 200, not a conflict"
+    ;; An honest double-click is not something a reviewer has to resolve.
+    (is (= 200 (:status (adapter/response-for {:approval/status :existing
+                                               :approval {:review/state :approved}})))))
+
+  (testing "a refusal is 409 and carries its typed evidence to the caller"
+    (let [{:keys [status body]}
+          (adapter/response-for {:approval/refusal
+                                 {:refusal/type :translation-revision-mismatch
+                                  :refusal/requested "a"
+                                  :refusal/recorded "b"}})]
+      (is (= 409 status))
+      (is (true? (:refused body)))
+      (is (= :translation-revision-mismatch (:refusal/type (:refusal body))))))
+
+  (testing "every refusal type has a status chosen for it"
+    ;; A table rather than a cond, so a new refusal cannot be added without one.
+    (is (= (set (keys adapter/refusal-status))
+           #{:translation-receipt-missing
+             :translation-document-mismatch
+             :translation-locale-mismatch
+             :translation-source-revision-mismatch
+             :translation-revision-mismatch}))))

--- a/backend/test/cljs/knoxx/backend/infra/routes/translation_review_test.cljs
+++ b/backend/test/cljs/knoxx/backend/infra/routes/translation_review_test.cljs
@@ -1,0 +1,173 @@
+(ns knoxx.backend.infra.routes.translation-review-test
+  "Recording one approval.
+
+  What is worth testing here is not that a row gets written. It is that an
+  approval cannot be recorded against a translation that does not exist, does not
+  match, belongs to another tenant, or has since been replaced — and that
+  recording one publishes nothing."
+  (:require [cljs.test :refer [deftest is testing]]
+            [knoxx.backend.infra.routes.translation-review :as facade]
+            [knoxx.backend.infra.translation-evidence-store :as store]))
+
+(def ^:private at "2026-08-22T10:00:00.000Z")
+
+(def ^:private query-scope
+  "The scope every read in this suite narrows by — the same one the facade uses."
+  {:org-id "org-1" :project "knoxx-session"})
+
+(def ^:private scope
+  {:org-id "org-1"
+   :project "knoxx-session"
+   :principal {:principal/user-email "reviewer@open-hax.local"}})
+
+(defn- receipt
+  [& {:keys [org project garden locale revision translation-revision]
+      :or {org "org-1"
+           project "knoxx-session"
+           garden :knoxx.docs/promethean
+           locale :es
+           revision "sha256-aaa111bbb222"
+           translation-revision "sha256-aaa111bbb222+es@batch-1"}}]
+  {:receipt/type :translation/completed
+   :translation/document :knoxx.docs/probe
+   :translation/garden garden
+   :translation/source-locale :en
+   :translation/locale locale
+   :translation/source-revision revision
+   :translation/revision translation-revision
+   :translation/dispatch-key "key-1"
+   :translation/org-id org
+   :translation/project project
+   :translation/at at})
+
+(defn- request
+  [& {:keys [locale revision translation-revision document garden]
+      :or {document :knoxx.docs/probe
+           garden :knoxx.docs/promethean
+           locale :es
+           revision "sha256-aaa111bbb222"
+           translation-revision "sha256-aaa111bbb222+es@batch-1"}}]
+  {:review/document document
+   :review/garden garden
+   :review/locale locale
+   :review/revision revision
+   :review/translation-revision translation-revision})
+
+(defn- ^:async store-with!
+  [receipts]
+  (let [evidence-store (store/memory-store)]
+    (doseq [r receipts]
+      (await (store/record-translation! evidence-store r)))
+    {:evidence-store evidence-store :clock (constantly at)}))
+
+(deftest ^:async an-authorized-approval-is-recorded-with-attribution
+  (let [deps (await (store-with! [(receipt)]))
+        result (await (facade/approve-translation! deps scope (request)))
+        approval (:approval result)]
+    (testing "the approval is recorded"
+      (is (= :recorded (:approval/status result))))
+
+    (testing "identity comes from the receipt, not the request"
+      (is (= :knoxx.docs/probe (:review/document approval)))
+      (is (= :knoxx.docs/promethean (:review/garden approval)))
+      (is (= :es (:review/locale approval)))
+      (is (= "sha256-aaa111bbb222" (:review/revision approval)))
+      (is (= "sha256-aaa111bbb222+es@batch-1" (:review/translation-revision approval))))
+
+    (testing "the tenant and project are inherited from the evidence"
+      ;; The request never carries them, so they cannot be forged.
+      (is (= "org-1" (:review/org-id approval)))
+      (is (= "knoxx-session" (:review/project approval))))
+
+    (testing "the acting principal and the clock are attributed by the server"
+      (is (= "reviewer@open-hax.local"
+             (:principal/user-email (:review/principal approval))))
+      (is (= at (:review/at approval))))))
+
+(deftest ^:async approving-twice-is-the-same-fact-not-two
+  (let [deps (await (store-with! [(receipt)]))
+        first-result (await (facade/approve-translation! deps scope (request)))
+        second-result (await (facade/approve-translation! deps scope (request)))]
+    (testing "the second approval is recognized as the one already recorded"
+      (is (= :recorded (:approval/status first-result)))
+      (is (= :existing (:approval/status second-result)))
+      (is (= (:approval first-result) (:approval second-result))))
+
+    (testing "only one approval exists"
+      ;; Appending would make `approved?` depend on how many times a button was
+      ;; clicked.
+      (is (= 1 (count (await (store/approvals! (:evidence-store deps) query-scope))))))))
+
+(deftest ^:async an-approval-with-no-translation-behind-it-is-refused
+  (let [deps (await (store-with! []))
+        result (await (facade/approve-translation! deps scope (request)))]
+    (testing "there is nothing to approve, and the refusal says so"
+      (is (= :translation-receipt-missing (:refusal/type (:approval/refusal result)))))
+
+    (testing "nothing was persisted"
+      ;; A rejected approval must leave no trace a later read could mistake for
+      ;; evidence.
+      (is (empty? (await (store/approvals! (:evidence-store deps) query-scope)))))))
+
+(deftest ^:async a-mismatched-approval-is-refused-with-both-sides-named
+  (let [deps (await (store-with! [(receipt)]))]
+    (testing "a different target locale has no receipt of its own"
+      (is (= :translation-receipt-missing
+             (:refusal/type (:approval/refusal
+                             (await (facade/approve-translation!
+                                     deps scope (request :locale :fr))))))))
+
+    (testing "naming a translation output that is not the current one is refused"
+      (let [refusal (:approval/refusal
+                     (await (facade/approve-translation!
+                             deps scope
+                             (request :translation-revision "sha256-aaa111bbb222+es@batch-9"))))]
+        (is (= :translation-revision-mismatch (:refusal/type refusal)))
+        (is (= "sha256-aaa111bbb222+es@batch-9" (:refusal/requested refusal)))
+        (is (= "sha256-aaa111bbb222+es@batch-1" (:refusal/recorded refusal))
+            "both sides travel, so a reviewer can see which was stale")))
+
+    (testing "nothing was persisted by any refusal"
+      (is (empty? (await (store/approvals! (:evidence-store deps) query-scope)))))))
+
+(deftest ^:async a-reviewer-cannot-approve-another-tenants-translation
+  (let [deps (await (store-with! [(receipt :org "org-other")]))
+        result (await (facade/approve-translation! deps scope (request)))]
+    (testing "the other tenant's receipt is invisible, so there is nothing to approve"
+      (is (= :translation-receipt-missing (:refusal/type (:approval/refusal result)))))
+
+    (testing "nothing was persisted"
+      (is (empty? (await (store/approvals! (:evidence-store deps) query-scope)))))))
+
+(deftest ^:async a-reviewer-cannot-approve-another-projects-translation
+  (let [deps (await (store-with! [(receipt :project "other-project")]))
+        result (await (facade/approve-translation! deps scope (request)))]
+    (testing "project scope is enforced like tenant scope"
+      (is (= :translation-receipt-missing (:refusal/type (:approval/refusal result)))))))
+
+(deftest ^:async a-selector-revision-cannot-be-approved
+  (let [deps (await (store-with! [(receipt)]))]
+    (testing "the wire's dangerous string shape is refused by contract"
+      ;; A revision arrives as decoded wire input here, so the string form of the
+      ;; selector is the one that has to be caught.
+      (is (thrown? js/Error
+                   (await (facade/approve-translation!
+                           deps scope (request :revision "source/current")))))
+      (is (thrown? js/Error
+                   (await (facade/approve-translation!
+                           deps scope
+                           (request :translation-revision "source/current"))))))))
+
+(deftest ^:async approval-materializes-nothing
+  (let [deps (await (store-with! [(receipt)]))
+        _ (await (facade/approve-translation! deps scope (request)))]
+    (testing "an approval may make a plan admissible but must not publish"
+      ;; The card is explicit: recording review evidence and materializing
+      ;; content are separate acts, so a reviewer can accept a translation
+      ;; without also deciding when the bytes go live.
+      (is (= 1 (count (await (store/approvals! (:evidence-store deps) query-scope)))))
+      (is (= 1 (count (await (store/completed-translations!
+                              (:evidence-store deps) query-scope)))))
+      (is (empty? (filter #(= :publication/materialized (:receipt/type %))
+                          (await (store/completed-translations!
+                                  (:evidence-store deps) query-scope))))))))

--- a/backend/test/cljs/knoxx/backend/infra/stores/mongo_translation_evidence_test.cljs
+++ b/backend/test/cljs/knoxx/backend/infra/stores/mongo_translation_evidence_test.cljs
@@ -12,6 +12,10 @@
 
 (def ^:private at "2026-08-22T09:00:00.000Z")
 
+(def ^:private approval-scope
+  "The scope the approval fixtures in this suite belong to."
+  {:org-id "org-1" :project "knoxx-session"})
+
 (def ^:private evidence-scope
   "The tenant and project every fixture record here belongs to."
   {:org-id "org-1" :project nil})
@@ -91,13 +95,17 @@
 (defn- fixture []
   (let [dispatches (atom [])
         receipts (atom [])
+        approvals (atom [])
         db #js {:collection
                 (fn [name]
                   (if (= name mongo-store/DISPATCHES_COLLECTION)
                     (fake-collection dispatches :dispatch_key)
-                    (fake-collection receipts nil)))}]
+                    (if (= name mongo-store/APPROVALS_COLLECTION)
+                      (fake-collection approvals :approval_key)
+                      (fake-collection receipts nil))))}]
     {:dispatches dispatches
      :receipts receipts
+     :approvals approvals
      :store (mongo-store/create-store db)}))
 
 (deftest ^:async namespaced-keywords-survive-persistence
@@ -210,6 +218,72 @@
                            :translation/revision "sha256-aaa111bbb222+es@batch-2"
                            :translation/at "2026-08-22T10:00:00.000Z")))
       (is (= 2 (count (await (store/completed-translations! store evidence-scope))))))))
+
+(def ^:private approval
+  {:review/state :approved
+   :review/document :knoxx.docs/probe
+   :review/garden :knoxx.docs/promethean
+   :review/locale :es
+   :review/revision "sha256-aaa111bbb222"
+   :review/translation-revision "sha256-aaa111bbb222+es@batch-1"
+   :review/org-id "org-1"
+   :review/project "knoxx-session"
+   :review/principal {:principal/user-email "reviewer@open-hax.local"}
+   :review/at at})
+
+(deftest ^:async approvals-round-trip-with-namespaced-keywords-intact
+  (let [{:keys [store approvals]} (fixture)
+        recorded (await (store/record-approval! store approval))]
+    (testing "the approval is recorded and comes back identical"
+      (is (= :recorded (:approval/status recorded)))
+      (is (= [approval] (await (store/approvals! store approval-scope)))))
+
+    (testing "the principal survives persistence"
+      ;; A principal flattened by JSON would be attribution that no longer names
+      ;; anybody.
+      (is (= "reviewer@open-hax.local"
+             (:principal/user-email (:review/principal
+                                     (first (await (store/approvals! store approval-scope))))))))
+
+    (testing "the queryable columns exist beside the authoritative EDN"
+      (let [row (first @approvals)]
+        (is (string? (:approval_key row)))
+        (is (= "es" (:locale row)))
+        (is (string? (:approval_edn row)))))))
+
+(deftest ^:async a-unique-index-makes-recording-an-approval-idempotent
+  (let [{:keys [store approvals]} (fixture)
+        first-result (await (store/record-approval! store approval))
+        second-result (await (store/record-approval! store approval))]
+    (testing "the second attempt is recognized rather than appended"
+      (is (= :recorded (:approval/status first-result)))
+      (is (= :existing (:approval/status second-result)))
+      (is (= approval (:approval second-result))))
+
+    (testing "only one row exists"
+      (is (= 1 (count @approvals))))))
+
+(deftest ^:async approving-a-different-output-is-a-different-approval
+  (let [{:keys [store approvals]} (fixture)
+        _ (await (store/record-approval! store approval))
+        other (await (store/record-approval!
+                      store (assoc approval :review/translation-revision
+                                   "sha256-aaa111bbb222+es@batch-2")))]
+    (testing "a re-translation is a new act of review over different bytes"
+      (is (= :recorded (:approval/status other)))
+      (is (= 2 (count @approvals))))))
+
+(deftest ^:async approvals-in-different-scopes-do-not-collide
+  (let [{:keys [store approvals]} (fixture)
+        _ (await (store/record-approval! store approval))
+        other-org (await (store/record-approval!
+                          store (assoc approval :review/org-id "org-2")))
+        other-project (await (store/record-approval!
+                              store (assoc approval :review/project "other")))]
+    (testing "the tenant and project are part of the approval identity"
+      (is (= :recorded (:approval/status other-org)))
+      (is (= :recorded (:approval/status other-project)))
+      (is (= 3 (count @approvals))))))
 
 (deftest ^:async a-claim-the-index-refuses-but-cannot-be-read-is-surfaced
   ;; The unique index said a row with this key exists. A nil read means a

--- a/docs/verification/translation-approval.md
+++ b/docs/verification/translation-approval.md
@@ -1,0 +1,140 @@
+# Translation approval surface — human verification
+
+Card: `kanban/tasks/knoxx-translation-approval-surface.md`
+Script: [`scripts/verify-translation-approval.sh`](../../scripts/verify-translation-approval.sh)
+
+An approval is the second of the two evidential questions
+`domain.publication-gate` asks. The first — has this been translated — is
+`knoxx-translation-work-dispatch`. This one is: did an authorized human accept
+*that exact translation*.
+
+## What an approval is, and is not
+
+It is **not** a permission over a document or a locale. It is evidence about one
+pair of concrete revisions:
+
+| field | meaning |
+| --- | --- |
+| `:review/document` | which document was reviewed |
+| `:review/garden` | which garden's translation of it was reviewed |
+| `:review/locale` | which target locale |
+| `:review/revision` | the concrete **source** revision the gate keys evidence by |
+| `:review/translation-revision` | the produced output that was actually reviewed |
+
+The garden is a coordinate, not scope that happens to travel along. The ingestion
+worker builds its prompt with `garden_id`, so one document translated into one
+locale for two gardens is two different outputs; a garden-agnostic approval would
+let a reviewer who read one garden's bytes admit publication of the other's. It
+is taken from the receipt rather than from the request, so it describes what the
+store actually holds.
+
+Both revisions are recorded, because either alone is wrong. Keyed only by the source revision, an
+approval would survive a re-translation and go on authorizing bytes nobody
+looked at. Keyed only by the output, the gate could never find it — a publication
+intent resolves to a source revision and has no idea what output exists.
+
+The gate reads the first. `domain.translation-evidence/approved?` joins them, and
+an approval whose output revision no longer matches the current receipt simply
+stops being current. Not deleted, not an error — exactly what the gate's own
+docstring already said would happen to a stale translation's approval.
+
+### A card premise corrected
+
+The card asks for approval "against translation identity, target locale, and
+concrete **translated** revision". Taken literally that produces approvals the
+gate can never match, because the gate asks with the source revision. Both are
+recorded; the one the gate is keyed by is the source revision. Annotated on the
+card rather than silently implemented the other way.
+
+## Run it
+
+```bash
+KNOXX_BASE_URL=http://localhost:8000 \
+KNOXX_API_KEY=<the key the backend was started with> \
+scripts/verify-translation-approval.sh
+```
+
+Unique identity per run, fixture torn down on exit, failure and Ctrl-C.
+
+## What each section proves
+
+### 1. Review evidence cannot be manufactured anonymously
+
+The check is unconditional, including when the policy database is disabled —
+`with-request-context!` hands down a nil context there, and reading that as
+permission would let an anonymous caller produce exactly the evidence a
+publication gate is waiting on.
+
+Permission is `org.translations.review`, which the `translator` role already
+holds. Deliberately **not** `org.translations.manage`: approving is what a
+reviewer does, and requiring queue-management authority would mean only admins
+could review.
+
+### 2. A caller cannot attribute an approval to someone else
+
+The request contract is closed and carries no principal, timestamp, tenant or
+project. The script tries to send each one and expects a 400.
+
+The tenant and project are inherited from the **receipt** being approved, not
+from the request — so a reviewer cannot file an approval into another
+organization's evidence. That is a lesson from the dispatch card, which needed
+two review rounds to learn that translation evidence is tenant- and
+project-scoped; it is built in here from the start.
+
+### 3. Malformed identifiers are refused, not reinterpreted
+
+Unknown field, unqualified document, unqualified garden, an approval naming no
+garden at all, blank field, missing field, and a selector-shaped revision.
+
+An unqualified garden is refused rather than canonicalized: `probe-garden` is a
+different garden from `knoxx.verifyapproval/probe-garden`, and an approval filed
+against one the receipts are not keyed by can never match — so it would come back
+as "there is no such translation" rather than as the malformed request it is.
+
+The closed contract is checked against the **raw body**, not against the map the
+adapter builds — an unknown field is never copied into that map, so validating
+only the result would silently accept a typo. The dispatch adapter learned that
+one the same way.
+
+`"source/current"` is refused because this is a boundary where a revision arrives
+as decoded wire input, and a selector gives a stable-looking identity to a moving
+target.
+
+### 4. Approving a translation that does not exist is refused
+
+**409, not 404.** The request is well formed and the document exists; the system
+simply is not in a state where approving means anything yet. A mismatch is 409
+for the same reason — the caller is not wrong about syntax, it disagrees with
+recorded fact. Every refusal carries typed evidence with both sides named, so a
+reviewer can see whether their request or the recorded translation was stale.
+
+With MongoDB down the route answers **503** rather than recording an approval
+that would vanish on restart. An approval that does not survive a restart is
+worse than none: the gate would admit a publication today and block it tomorrow.
+
+The script treats that 503 as a **failure**, not a warning. The route is right to
+refuse; a verification run that never reached the refusal path this section
+exists to check has proved nothing about it, and must not exit 0. Start MongoDB
+and re-run.
+
+## Known gaps, printed every run
+
+1. **The successful-approval path.** Recording one requires a completed
+   translation receipt in the durable store, which requires the ingestion worker
+   to have actually translated something — the dispatch card's surface, and not
+   reachable over HTTP from here. Covered by
+   `backend/test/cljs/knoxx/backend/infra/routes/translation_review_test.cljs`:
+   attribution from the receipt rather than the request, the idempotent
+   double-approval, tenant and project isolation, refusal with both sides named,
+   and that approval materializes nothing.
+2. **Whether an approval unblocks a publication.** That is
+   `knoxx-publication-reconciler-runtime`, the next card. Approval makes a plan
+   admissible; it must not itself publish, and a test pins that.
+
+## No browser tour yet
+
+The approval action is an authorized HTTP call with no UI attached to it in this
+card. The CMS surface that would let a reviewer click it is not part of this
+slice, so a tour would have nothing to drive — and per AGENTS.md, a tour that
+quietly avoids the hard part is worse than no tour. When the CMS action lands,
+the tour belongs with it.

--- a/docs/verification/translation-approval.md
+++ b/docs/verification/translation-approval.md
@@ -49,12 +49,27 @@ card rather than silently implemented the other way.
 ## Run it
 
 ```bash
+# refusal paths only
 KNOXX_BASE_URL=http://localhost:8000 \
 KNOXX_API_KEY=<the key the backend was started with> \
 scripts/verify-translation-approval.sh
+
+# including the successful approval — needs mongosh and the acting org id
+KNOXX_BASE_URL=http://localhost:8000 \
+KNOXX_API_KEY=<key> \
+KNOXX_VERIFY_ORG_ID=<the org the key resolves to> \
+KNOXX_MONGO_URL=mongodb://localhost:27017 \
+scripts/verify-translation-approval.sh
 ```
 
-Unique identity per run, fixture torn down on exit, failure and Ctrl-C.
+Unique identity per run. Everything it creates it removes: the fixture directory
+(probe source file included) on the exit trap, and the seeded Mongo rows on the
+way out.
+
+`KNOXX_VERIFY_ORG_ID` is needed because an approval is tenant-scoped and inherits
+its organization from the receipt — so the seeded receipt has to name the org the
+API key actually resolves to. Find it with `GET /api/auth/session`. Without it,
+sections 5–7 are skipped with a WARN rather than silently passing.
 
 ## What each section proves
 
@@ -117,19 +132,40 @@ refuse; a verification run that never reached the refusal path this section
 exists to check has proved nothing about it, and must not exit 0. Start MongoDB
 and re-run.
 
-## Known gaps, printed every run
+### 5–7. A real approval, against a seeded translation
 
-1. **The successful-approval path.** Recording one requires a completed
-   translation receipt in the durable store, which requires the ingestion worker
-   to have actually translated something — the dispatch card's surface, and not
-   reachable over HTTP from here. Covered by
-   `backend/test/cljs/knoxx/backend/infra/routes/translation_review_test.cljs`:
-   attribution from the receipt rather than the request, the idempotent
-   double-approval, tenant and project isolation, refusal with both sides named,
-   and that approval materializes nothing.
-2. **Whether an approval unblocks a publication.** That is
-   `knoxx-publication-reconciler-runtime`, the next card. Approval makes a plan
-   admissible; it must not itself publish, and a test pins that.
+An approval validates against a completed translation, and the only thing that
+produces one is the ingestion worker. An earlier version of this script therefore
+stopped at the refusals and told you the happy path was out of reach — which is
+not a verification artifact, because a reviewer could not watch the feature work.
+
+So the script seeds one receipt itself and then drives the real HTTP route:
+
+- **Section 5** records the approval. Asserts 201, `status: recorded`, that the
+  response names the reviewed *output* revision, that it carries a principal the
+  caller never sent, and that the tenant came from the receipt rather than the
+  request.
+- **Section 6** replays the identical request. Asserts **200 and
+  `status: existing`** — an honest double-click is not a conflict a reviewer has
+  to resolve.
+- **Section 7** names a different produced output. Asserts 409 with both
+  revisions in the refusal, so a reviewer can see whether their request or the
+  record was stale.
+
+**The receipt is seeded in Mongo, not through a route**, and that is deliberate:
+a route that writes translation evidence is a route that can fabricate it, which
+is the one thing this whole seam exists to prevent. Seeding is something a
+verification script does to its own throwaway data with credentials an operator
+supplied; it is not a capability the running system gains.
+
+Skipped with a WARN, never silently, when `mongosh` is absent, `KNOXX_VERIFY_ORG_ID`
+is unset, or the deployment is unreachable.
+
+## Known gap, printed every run
+
+**Whether an approval unblocks a publication.** That is
+`knoxx-publication-reconciler-runtime`, the next card. Approval makes a plan
+admissible; it must not itself publish, and a test pins that.
 
 ## No browser tour yet
 

--- a/kanban/tasks/knoxx-translation-approval-surface.md
+++ b/kanban/tasks/knoxx-translation-approval-surface.md
@@ -73,3 +73,33 @@ The existing translation receipt and publication gate contracts.
    without a tenant is admissible everywhere. `:review/org-id` is required and
    `:review/project` is carried, both inherited from the receipt rather than from
    the request so a reviewer cannot file into another scope.
+
+4. **A second unstated requirement, learned the same way.** The garden is a
+   *coordinate* of an approval, not scope that happens to travel with it.
+   `knoxx-translation-work-dispatch` made the completed-translation receipt
+   garden-specific under review, because the ingestion worker builds its prompt
+   with `garden_id` and translated-document reads filter by it — one document
+   translated into one locale for two gardens is two different outputs. The
+   approval half had to follow or the same leak reappeared one step later, with
+   a reviewer who read garden A's bytes admitting publication of garden B's.
+   `:review/garden` is therefore required on both `Approval` and
+   `ApprovalRequest`, `approved?` and `index-approvals` key by it, and it is
+   taken from the receipt rather than from the request.
+
+## What this card does NOT deliver
+
+The approval *surface*, not the approval *control*. Nothing in the frontend
+calls `POST /api/publications/translations/approvals`; the existing translation
+review UI still posts to `/api/translations/documents/:id/:locale/review`, which
+is the older document-review model and is not what the publication gate reads.
+
+So today a reviewer clicking "Approve All" does not produce evidence
+`domain.publication-gate` recognizes. That is a real gap and it is deliberately
+not papered over here: making the legacy review status count as a publication
+approval is exactly the shortcut that would let unreviewed bytes publish.
+
+Closing it needs one thing this card cannot assume — a read surface exposing
+which `[document garden locale]` currently has a completed translation and at
+which pair of revisions. The UI has `garden_id` but no notion of either
+revision, and the approval contract requires both. That belongs to the UI card
+together with the endpoint it reads.

--- a/kanban/tasks/knoxx-translation-approval-surface.md
+++ b/kanban/tasks/knoxx-translation-approval-surface.md
@@ -5,7 +5,7 @@ write-id: "1787011200004-0.528396"
 points: "3"
 title: "Translation — revision-specific approval surface"
 priority: "P1"
-status: "ready"
+status: "review"
 uuid: "knoxx-translation-approval-surface"
 created_at: "2026-08-22T00:00:00Z"
 ---
@@ -48,3 +48,28 @@ The existing translation receipt and publication gate contracts.
 - Tests prove an approval for one revision, locale, or document cannot satisfy
   the gate for another.
 - Tests prove approval alone invokes no publication adapter effect.
+
+## Card premise corrections
+
+1. **"records an approval against translation identity, target locale, and
+   concrete translated revision."** Taken literally this produces approvals the
+   gate can never match: `domain.publication-gate` asks `approved?` with the
+   concrete *source* revision, because that is what a publication intent's
+   revision selector resolves to. The approval is therefore keyed by the source
+   revision, with the translated output recorded alongside as
+   `:review/translation-revision`. Both matter — see
+   `law.translation-evidence/approval-current?` — and keying by the output alone
+   would have made every approval invisible to the gate.
+
+2. **"The existing translation receipt and publication gate contracts."** The
+   gate contract existed; a translation receipt contract did not. It was
+   introduced by `knoxx-translation-work-dispatch`, which is why that card was
+   done first even though both are wave-2: the consumer cannot validate against a
+   contract the producer has not declared.
+
+3. **An unstated requirement.** Approvals are tenant- and project-scoped, like
+   the receipts they attest to. The card does not mention scope at all, and the
+   dispatch card needed two review rounds to establish that translation evidence
+   without a tenant is admissible everywhere. `:review/org-id` is required and
+   `:review/project` is carried, both inherited from the receipt rather than from
+   the request so a reviewer cannot file into another scope.

--- a/scripts/verify-translation-approval.sh
+++ b/scripts/verify-translation-approval.sh
@@ -82,6 +82,14 @@ MONGO_URL="${KNOXX_MONGO_URL:-mongodb://localhost:27017}"
 MONGO_DB="${KNOXX_MONGO_DB:-knoxx}"
 ORG_ID="${KNOXX_VERIFY_ORG_ID:-}"
 PROJECT="${KNOXX_SESSION_PROJECT_NAME:-knoxx-session}"
+# The stored form of a nullable project, mirroring
+# `mongo-translation-evidence/scope-value`: an unset project is its own scope, so
+# it is stored as a sentinel rather than left absent, and the query matches it.
+if [ -n "$PROJECT" ]; then
+  STORED_PROJECT="$PROJECT"
+else
+  STORED_PROJECT=$'\u0000none'
+fi
 SOURCE_REVISION="sha256-verifyapproval${RUN_ID}"
 TRANSLATION_REVISION="${SOURCE_REVISION}+es@verify-${RUN_ID}"
 DISPATCH_KEY="verify-approval-${RUN_ID}"
@@ -328,16 +336,23 @@ else
   receipt_edn="${receipt_edn} :translation/project \"${PROJECT}\""
   receipt_edn="${receipt_edn} :translation/at \"$(date -u +%Y-%m-%dT%H:%M:%S.000Z)\"}"
 
+  # `org_id` and `project` are top-level columns, not just fields inside the EDN.
+  # `read-receipts!` narrows through `scope-query`, which is field equality on
+  # exactly those two — a receipt carrying them only in `receipt_edn` is
+  # invisible to the query, and the approval would be refused 409 for a receipt
+  # that is sitting right there.
   if mongo_eval "db.knoxx_translation_receipts.insertOne({
        dispatch_key: \"${DISPATCH_KEY}\",
        document: \"${DOC_EDN}\",
        locale: \"es\",
        source_revision: \"${SOURCE_REVISION}\",
+       org_id: \"${ORG_ID}\",
+       project: \"${STORED_PROJECT}\",
        receipt_edn: '${receipt_edn}'
      });" >/dev/null 2>&1; then
     RECEIPT_SEEDED=1
     pass "seeded one completed-translation receipt for this run"
-    note "org ${ORG_ID}, project ${PROJECT}, revision ${SOURCE_REVISION}"
+    note "org ${ORG_ID}, project ${PROJECT:-<none>}, revision ${SOURCE_REVISION}"
 
     good="{\"document\":\"${DOC_ID}\",\"locale\":\"es\",\"revision\":\"${SOURCE_REVISION}\",\"translation_revision\":\"${TRANSLATION_REVISION}\"}"
 

--- a/scripts/verify-translation-approval.sh
+++ b/scripts/verify-translation-approval.sh
@@ -29,8 +29,10 @@
 #     surface (`knoxx-publication-reconciler-runtime`), the next card.
 #
 # The fixture is created and destroyed by this script, with a unique identity per
-# run. It writes ONLY inside ${CONTRACTS_DIR}/_verify_translation_approval and
-# removes that directory on exit, including on failure or Ctrl-C.
+# run. It writes ONLY inside ${CONTRACTS_DIR}/_verify_translation_approval — the
+# probe source file included, which is why the seeded document's source path
+# points in there — and removes that one directory on exit, including on failure
+# or Ctrl-C. Anything it seeds in Mongo it also removes.
 #
 # Usage:
 #   scripts/verify-translation-approval.sh
@@ -70,6 +72,21 @@ SOURCE_FILE="${CONTRACTS_PARENT}/${SOURCE_REL}"
 PINNED_REVISION="rev-verify-approval-${RUN_ID}"
 APPROVALS_URL="/api/publications/translations/approvals"
 
+# The receipt this run seeds so the successful approval path is reachable.
+# Approval validates against a completed translation, and the only producer of
+# one is the ingestion worker — so a live happy path needs the receipt seeded.
+# Seeded directly in Mongo rather than through a route: a route that writes
+# translation evidence is a route that can fabricate it, which is the one thing
+# this whole seam exists to prevent.
+MONGO_URL="${KNOXX_MONGO_URL:-mongodb://localhost:27017}"
+MONGO_DB="${KNOXX_MONGO_DB:-knoxx}"
+ORG_ID="${KNOXX_VERIFY_ORG_ID:-}"
+PROJECT="${KNOXX_SESSION_PROJECT_NAME:-knoxx-session}"
+SOURCE_REVISION="sha256-verifyapproval${RUN_ID}"
+TRANSLATION_REVISION="${SOURCE_REVISION}+es@verify-${RUN_ID}"
+DISPATCH_KEY="verify-approval-${RUN_ID}"
+DOC_EDN=":${DOC_ID}"
+
 PASS_COUNT=0
 FAIL_COUNT=0
 WARN_COUNT=0
@@ -101,6 +118,10 @@ http() {
   local raw; raw="$(curl "${args[@]}" "${BASE_URL}${path}" 2>/dev/null)"
   printf '%s\n%s' "${raw##*$'\n'}" "${raw%$'\n'*}"
 }
+mongo_eval() {
+  mongosh "${MONGO_URL}/${MONGO_DB}" --quiet --eval "$1"
+}
+
 status_of() { printf '%s' "${1%%$'\n'*}"; }
 body_of()   { printf '%s' "${1#*$'\n'}"; }
 
@@ -126,7 +147,7 @@ expect_jq() {
 # ── Fixture ────────────────────────────────────────────────────────────────
 
 FIXTURE_OWNED=0
-SOURCE_OWNED=0
+RECEIPT_SEEDED=0
 
 fixture_write() {
   mkdir -p "$FIXTURE_DIR"
@@ -162,8 +183,12 @@ cleanup() {
   if [ "$FIXTURE_OWNED" -eq 1 ] && [ -d "$FIXTURE_DIR" ]; then
     rm -rf "$FIXTURE_DIR"; note "torn down ${FIXTURE_DIR#$REPO_ROOT/}"
   fi
-  if [ "$SOURCE_OWNED" -eq 1 ] && [ -f "$SOURCE_FILE" ]; then
-    rm -f "$SOURCE_FILE"; note "torn down ${SOURCE_REL}"
+  if [ "$RECEIPT_SEEDED" -eq 1 ]; then
+    mongo_eval "db.knoxx_translation_receipts.deleteMany({dispatch_key: \"${DISPATCH_KEY}\"});
+                db.knoxx_translation_approvals.deleteMany({document: \"${DOC_EDN}\"});" \
+      >/dev/null 2>&1 \
+      && note "torn down the seeded receipt and any approval of it" \
+      || warn "could not remove seeded Mongo rows — see the cleanup command above"
   fi
   exit "$code"
 }
@@ -190,12 +215,10 @@ note "backend is reachable"
 
 step "0. the running backend serves this checkout"
 FIXTURE_OWNED=1
-if [ ! -f "$SOURCE_FILE" ]; then
-  SOURCE_OWNED=1
-  mkdir -p "$(dirname "$SOURCE_FILE")"
-  printf '# Approval verification probe\n\nSeeded by scripts/verify-translation-approval.sh.\n' > "$SOURCE_FILE"
-fi
 fixture_write
+# Inside the fixture directory, so the single teardown covers it.
+printf '# Approval verification probe\n\nSeeded by scripts/verify-translation-approval.sh.\n' \
+  > "$SOURCE_FILE"
 sleep 1
 
 probe="$(http GET "/api/publications/documents" auth)"
@@ -271,17 +294,99 @@ else
     "$(body_of "$resp" | head -c 300)"
 fi
 
-# ── 5. Known gaps ──────────────────────────────────────────────────────────
+# ── 5. The successful approval ─────────────────────────────────────────────
+#
+# Approval validates against a completed translation, and the only thing that
+# produces one is the ingestion worker. So to let a reviewer watch this feature
+# work, the script seeds one receipt itself — in Mongo, not through a route,
+# because a route that writes translation evidence is a route that can fabricate
+# it. It removes what it seeded on the way out.
 
-step "5. what this run cannot reach"
+step "5. a real approval, against a seeded translation"
 
-warn "the successful-approval path needs a completed translation in the store"
-note "That needs the ingestion worker to have translated something, which is"
-note "knoxx-translation-work-dispatch's surface, not this card's. The happy path,"
-note "the idempotent double-approval, tenant/project isolation, and"
-note "re-translation supersession are covered by the CLJS suites named in the"
-note "script header."
+if ! command -v mongosh >/dev/null 2>&1; then
+  warn "mongosh is not installed, so the successful path cannot be exercised"
+  note "Install mongosh, or set KNOXX_MONGO_URL to a reachable deployment, and"
+  note "re-run to see the approval actually recorded."
+elif [ -z "$ORG_ID" ]; then
+  warn "KNOXX_VERIFY_ORG_ID is not set, so the successful path is skipped"
+  note "An approval is tenant-scoped and inherits its organization from the"
+  note "receipt, so the seeded receipt has to name the org the API key resolves"
+  note "to. Find it with: GET /api/auth/session — then re-run with"
+  note "KNOXX_VERIFY_ORG_ID=<that org id>"
+elif ! mongo_eval 'db.runCommand({ping:1})' >/dev/null 2>&1; then
+  warn "cannot reach ${MONGO_URL} — the successful path is skipped"
+else
+  receipt_edn="{:receipt/type :translation/completed"
+  receipt_edn="${receipt_edn} :translation/document ${DOC_EDN}"
+  receipt_edn="${receipt_edn} :translation/source-locale :en"
+  receipt_edn="${receipt_edn} :translation/locale :es"
+  receipt_edn="${receipt_edn} :translation/source-revision \"${SOURCE_REVISION}\""
+  receipt_edn="${receipt_edn} :translation/revision \"${TRANSLATION_REVISION}\""
+  receipt_edn="${receipt_edn} :translation/dispatch-key \"${DISPATCH_KEY}\""
+  receipt_edn="${receipt_edn} :translation/org-id \"${ORG_ID}\""
+  receipt_edn="${receipt_edn} :translation/project \"${PROJECT}\""
+  receipt_edn="${receipt_edn} :translation/at \"$(date -u +%Y-%m-%dT%H:%M:%S.000Z)\"}"
+
+  if mongo_eval "db.knoxx_translation_receipts.insertOne({
+       dispatch_key: \"${DISPATCH_KEY}\",
+       document: \"${DOC_EDN}\",
+       locale: \"es\",
+       source_revision: \"${SOURCE_REVISION}\",
+       receipt_edn: '${receipt_edn}'
+     });" >/dev/null 2>&1; then
+    RECEIPT_SEEDED=1
+    pass "seeded one completed-translation receipt for this run"
+    note "org ${ORG_ID}, project ${PROJECT}, revision ${SOURCE_REVISION}"
+
+    good="{\"document\":\"${DOC_ID}\",\"locale\":\"es\",\"revision\":\"${SOURCE_REVISION}\",\"translation_revision\":\"${TRANSLATION_REVISION}\"}"
+
+    resp="$(http POST "$APPROVALS_URL" auth "$good")"
+    if expect_status "POST approvals records the approval" "201" "$resp"; then
+      expect_jq "the response says it was recorded" '.status == "recorded"' "$resp"
+      expect_jq "the approval names the reviewed output revision" \
+        "[.. | strings] | index(\"${TRANSLATION_REVISION}\")" "$resp"
+      expect_jq "the approval is attributed to a principal the caller never sent" \
+        '[.. | objects | select(has("user_email") or has("userEmail"))] | length > 0' "$resp" \
+        || expect_jq "the approval carries a principal" \
+             '[.. | strings] | any(test("@"))' "$resp"
+      expect_jq "the tenant is inherited from the receipt, not the request" \
+        "[.. | strings] | index(\"${ORG_ID}\")" "$resp"
+    fi
+
+    step "6. approving the same output twice is the same fact"
+
+    again="$(http POST "$APPROVALS_URL" auth "$good")"
+    if expect_status "the replay answers 200, not a conflict" "200" "$again"; then
+      expect_jq "it is recognized as the approval already recorded" \
+        '.status == "existing"' "$again"
+      note "an honest double-click is not something a reviewer has to resolve"
+    fi
+
+    step "7. an approval cannot be transplanted onto another output"
+
+    stale="$(printf '%s' "$good" | jq -c '.translation_revision = "sha256-someone-elses+es@b9"')"
+    resp="$(http POST "$APPROVALS_URL" auth "$stale")"
+    if expect_status "naming a different produced output is refused" "409" "$resp"; then
+      expect_jq "the refusal names both sides" \
+        "[.. | strings] | index(\"${TRANSLATION_REVISION}\")" "$resp"
+      note "so a reviewer can see whether their request or the record was stale"
+    fi
+  else
+    warn "could not seed a receipt, so the successful path is skipped"
+    note "The API key's org may differ from KNOXX_VERIFY_ORG_ID, or the Mongo"
+    note "user may lack write access to ${MONGO_DB}."
+  fi
+fi
+
+# ── 8. Known gaps ──────────────────────────────────────────────────────────
+
+step "8. what this run cannot reach"
+
 warn "whether an approval unblocks a publication is the reconciler card's surface"
+note "Approval makes a plan admissible; it must not itself publish, and a test"
+note "pins that. The trigger that acts on it is"
+note "knoxx-publication-reconciler-runtime, the next card."
 
 printf '\n%s%s%s\n' "$C_BOLD" "$(printf '═%.0s' $(seq 1 60))" "$C_RESET"
 printf '%s  %s passed%s' "$C_GREEN" "$PASS_COUNT" "$C_RESET"

--- a/scripts/verify-translation-approval.sh
+++ b/scripts/verify-translation-approval.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+#
+# Manual verification for the translation approval surface.
+#
+# Walks the approval surface against a LIVE Knoxx: every way of getting an
+# approval wrong, then the one way of getting it right — which requires a
+# completed translation to exist, and therefore cannot be driven from HTTP alone.
+#
+# WHAT THIS PROVES, entirely from the outside:
+#
+#   * An unauthenticated caller cannot record review evidence.
+#   * A caller cannot supply its own principal, timestamp, tenant or project —
+#     the request contract refuses every one of those fields.
+#   * A malformed, blank, unqualified or selector-shaped identifier is refused.
+#   * Approving a translation that does not exist is refused, and refused as a
+#     conflict rather than a not-found: the request is well formed and the system
+#     simply is not in a state where approving means anything yet.
+#
+# WHAT THIS CANNOT PROVE, printed as WARN every run:
+#
+#   * A successful approval. Recording one requires a completed-translation
+#     receipt in the durable store, which requires the ingestion worker to have
+#     actually translated something — not this card's surface, and not reachable
+#     from HTTP. The happy path, the idempotent double-approval, the
+#     tenant/project isolation and the re-translation supersession are covered by
+#     backend/test/cljs/knoxx/backend/infra/routes/translation_review_test.cljs
+#     and .../extern/fastify/translation_review_test.cljs.
+#   * That an approval unblocks a publication. That is the reconciler runtime's
+#     surface (`knoxx-publication-reconciler-runtime`), the next card.
+#
+# The fixture is created and destroyed by this script, with a unique identity per
+# run. It writes ONLY inside ${CONTRACTS_DIR}/_verify_translation_approval and
+# removes that directory on exit, including on failure or Ctrl-C.
+#
+# Usage:
+#   scripts/verify-translation-approval.sh
+#   KNOXX_BASE_URL=http://localhost:8000 KNOXX_API_KEY=... scripts/verify-translation-approval.sh
+#
+# Exit code is 0 only when every check passed.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+BASE_URL="${KNOXX_BASE_URL:-http://localhost:8000}"
+API_KEY="${KNOXX_API_KEY:-}"
+CONTRACTS_DIR="${KNOXX_CONTRACTS_DIR:-${REPO_ROOT}/contracts}"
+FIXTURE_DIR="${CONTRACTS_DIR}/_verify_translation_approval"
+
+RUN_ID="$(date -u +%Y%m%d%H%M%S)$$"
+NS="knoxx.verifyapproval"
+DOC_LOCAL="probe${RUN_ID}"
+DOC_ID="${NS}/${DOC_LOCAL}"
+# The garden the publication intent names, canonicalized the same way the
+# resolver canonicalizes it. An approval is scoped to one garden: the same
+# document translated into the same locale for two gardens is two different
+# outputs, so review evidence that named no garden would authorize bytes the
+# reviewer never read.
+GARDEN_ID="${NS}/probe-garden"
+# Both derived from the *configured* contract root, never from `REPO_ROOT`.
+# `KNOXX_CONTRACTS_DIR` may point at a different checkout, and a fixture whose
+# EDN lives under that root while its source lives under this one declares a
+# path the running backend cannot read — so the digest never resolves and
+# teardown leaves the source behind. Same defect the dispatch script was
+# reviewed for.
+CONTRACTS_PARENT="$(cd "$(dirname "${CONTRACTS_DIR}")" && pwd)"
+CONTRACTS_NAME="$(basename "${CONTRACTS_DIR}")"
+SOURCE_REL="${CONTRACTS_NAME}/_verify_translation_approval/probe-${RUN_ID}.md"
+SOURCE_FILE="${CONTRACTS_PARENT}/${SOURCE_REL}"
+PINNED_REVISION="rev-verify-approval-${RUN_ID}"
+APPROVALS_URL="/api/publications/translations/approvals"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+WARN_COUNT=0
+FAILURES=()
+
+if [ -t 1 ]; then
+  C_RESET=$'\033[0m'; C_DIM=$'\033[2m'; C_BOLD=$'\033[1m'
+  C_GREEN=$'\033[32m'; C_RED=$'\033[31m'; C_YELLOW=$'\033[33m'; C_CYAN=$'\033[36m'
+else
+  C_RESET=""; C_DIM=""; C_BOLD=""; C_GREEN=""; C_RED=""; C_YELLOW=""; C_CYAN=""
+fi
+
+step() { printf '\n%s── %s %s%s\n' "$C_BOLD$C_CYAN" "$1" "$(printf '─%.0s' $(seq 1 $((58 - ${#1}))))" "$C_RESET"; }
+note() { printf '%s   %s%s\n' "$C_DIM" "$1" "$C_RESET"; }
+pass() { PASS_COUNT=$((PASS_COUNT + 1)); printf '%s   PASS%s  %s\n' "$C_GREEN" "$C_RESET" "$1"; }
+fail() {
+  FAIL_COUNT=$((FAIL_COUNT + 1)); FAILURES+=("$1")
+  printf '%s   FAIL%s  %s\n' "$C_RED" "$C_RESET" "$1"
+  [ -n "${2:-}" ] && printf '%s         got: %s%s\n' "$C_DIM" "$2" "$C_RESET"
+}
+warn() { WARN_COUNT=$((WARN_COUNT + 1)); printf '%s   WARN%s  %s\n' "$C_YELLOW" "$C_RESET" "$1"; }
+die() { printf '\n%sABORT%s %s\n\n' "$C_RED$C_BOLD" "$C_RESET" "$1" >&2; exit 2; }
+
+http() {
+  local method="$1" path="$2" authorized="$3" body="${4:-}"
+  local args=(-s -o /dev/stdout -w $'\n%{http_code}' -X "$method" --max-time 30)
+  [ "$authorized" = "auth" ] && args+=(-H "X-API-Key: ${API_KEY}")
+  [ -n "$body" ] && args+=(-H "Content-Type: application/json" -d "$body")
+  local raw; raw="$(curl "${args[@]}" "${BASE_URL}${path}" 2>/dev/null)"
+  printf '%s\n%s' "${raw##*$'\n'}" "${raw%$'\n'*}"
+}
+status_of() { printf '%s' "${1%%$'\n'*}"; }
+body_of()   { printf '%s' "${1#*$'\n'}"; }
+
+expect_status() {
+  local label="$1" expected="$2" response="$3"
+  local status; status="$(status_of "$response")"
+  if [[ " $expected " == *" $status "* ]]; then
+    pass "$label ${C_DIM}(${status})${C_RESET}"; return 0
+  fi
+  fail "$label — expected ${expected// /|}, got ${status}" "$(body_of "$response" | head -c 300)"
+  return 1
+}
+
+expect_jq() {
+  local label="$1" filter="$2" response="$3"
+  if printf '%s' "$(body_of "$response")" | jq -e "$filter" >/dev/null 2>&1; then
+    pass "$label"; return 0
+  fi
+  fail "$label — jq filter did not hold: ${filter}" "$(body_of "$response" | head -c 300)"
+  return 1
+}
+
+# ── Fixture ────────────────────────────────────────────────────────────────
+
+FIXTURE_OWNED=0
+SOURCE_OWNED=0
+
+fixture_write() {
+  mkdir -p "$FIXTURE_DIR"
+  cat > "${FIXTURE_DIR}/probe.edn" <<EDN
+;; Throwaway fixture written by scripts/verify-translation-approval.sh.
+{:namespace :${NS}
+ :resources
+ [{:document/id :${DOC_LOCAL}
+   :document/title "Translation Approval Verification Probe"
+   :document/source-locale :en
+   :document/source {:path "${SOURCE_REL}"}}
+
+  {:garden/id :probe-garden
+   :garden/title "Approval Verification Garden"
+   :garden/status :active
+   :garden/locales [:en :es]}
+
+  {:publication/id :${DOC_LOCAL}-es
+   :publication/document :${DOC_LOCAL}
+   :publication/garden :probe-garden
+   :publication/locale :es
+   :publication/revision "${PINNED_REVISION}"
+   :publication/state :published
+   :publication/path "/verify-approval/${DOC_LOCAL}-es"
+   :translation/review :required}]}
+EDN
+}
+
+cleanup() {
+  local code=$?
+  local signalled="${1:-}"
+  [ -n "$signalled" ] && code="$signalled"
+  if [ "$FIXTURE_OWNED" -eq 1 ] && [ -d "$FIXTURE_DIR" ]; then
+    rm -rf "$FIXTURE_DIR"; note "torn down ${FIXTURE_DIR#$REPO_ROOT/}"
+  fi
+  if [ "$SOURCE_OWNED" -eq 1 ] && [ -f "$SOURCE_FILE" ]; then
+    rm -f "$SOURCE_FILE"; note "torn down ${SOURCE_REL}"
+  fi
+  exit "$code"
+}
+trap cleanup EXIT
+trap 'trap - EXIT; cleanup 130' INT
+trap 'trap - EXIT; cleanup 143' TERM
+
+# ── Preflight ──────────────────────────────────────────────────────────────
+
+printf '%s\n' "${C_BOLD}Knoxx translation approval surface — live verification${C_RESET}"
+note "base url       ${BASE_URL}"
+note "run id         ${RUN_ID}"
+
+for tool in curl jq; do
+  command -v "$tool" >/dev/null 2>&1 || die "missing required tool: ${tool}"
+done
+[ -n "$API_KEY" ] || die "KNOXX_API_KEY is not set. Use the same value the running backend was started with."
+[ -d "$CONTRACTS_DIR" ] || die "contracts directory not found: ${CONTRACTS_DIR}"
+[ -e "$FIXTURE_DIR" ] && die "fixture directory already exists: ${FIXTURE_DIR} — remove it and retry."
+
+curl -s -o /dev/null --max-time 5 "${BASE_URL}/health" 2>/dev/null \
+  || die "no Knoxx backend answering at ${BASE_URL}. Start it from THIS checkout and retry."
+note "backend is reachable"
+
+step "0. the running backend serves this checkout"
+FIXTURE_OWNED=1
+if [ ! -f "$SOURCE_FILE" ]; then
+  SOURCE_OWNED=1
+  mkdir -p "$(dirname "$SOURCE_FILE")"
+  printf '# Approval verification probe\n\nSeeded by scripts/verify-translation-approval.sh.\n' > "$SOURCE_FILE"
+fi
+fixture_write
+sleep 1
+
+probe="$(http GET "/api/publications/documents" auth)"
+if body_of "$probe" | jq -e --arg id "$DOC_ID" '[.documents[].document.id] | index($id)' >/dev/null 2>&1; then
+  pass "seeded fixture is visible to the running backend"
+else
+  note "It is probably serving a different checkout. Check: pm2 describe knoxx-backend | grep cwd"
+  die "cannot verify against a backend that is not running this code"
+fi
+
+# ── 1. Authorization ───────────────────────────────────────────────────────
+
+step "1. review evidence cannot be manufactured anonymously"
+
+body="{\"document\":\"${DOC_ID}\",\"garden\":\"${GARDEN_ID}\",\"locale\":\"es\",\"revision\":\"${PINNED_REVISION}\",\"translation_revision\":\"${PINNED_REVISION}+es@b1\"}"
+expect_status "POST approvals is refused unauthenticated" "401 403" \
+  "$(http POST "$APPROVALS_URL" anon "$body")"
+note "an open route here would let anyone produce the evidence a gate waits on"
+
+# ── 2. Attribution is the server's, not the caller's ───────────────────────
+
+step "2. a caller cannot attribute an approval to someone else"
+
+for field in principal at org_id project; do
+  smuggled="$(printf '%s' "$body" | jq -c --arg f "$field" '. + {($f): "forged"}')"
+  expect_status "a body carrying '${field}' is refused" "400" \
+    "$(http POST "$APPROVALS_URL" auth "$smuggled")"
+done
+note "the principal and timestamp come from the auth context and the clock"
+
+# ── 3. Malformed identifiers ───────────────────────────────────────────────
+
+step "3. malformed identifiers are refused, not reinterpreted"
+
+expect_status "an unrecognized field is refused" "400" \
+  "$(http POST "$APPROVALS_URL" auth "$(printf '%s' "$body" | jq -c '. + {documnet: "x"}')")"
+expect_status "an unqualified document is refused" "400" \
+  "$(http POST "$APPROVALS_URL" auth "$(printf '%s' "$body" | jq -c '.document = "probe"')")"
+expect_status "an unqualified garden is refused" "400" \
+  "$(http POST "$APPROVALS_URL" auth "$(printf '%s' "$body" | jq -c '.garden = "probe-garden"')")"
+expect_status "an approval naming no garden is refused" "400" \
+  "$(http POST "$APPROVALS_URL" auth "$(printf '%s' "$body" | jq -c 'del(.garden)')")"
+expect_status "a blank revision is refused" "400" \
+  "$(http POST "$APPROVALS_URL" auth "$(printf '%s' "$body" | jq -c '.revision = ""')")"
+expect_status "a missing field is refused" "400" \
+  "$(http POST "$APPROVALS_URL" auth "$(printf '%s' "$body" | jq -c 'del(.locale)')")"
+expect_status "a selector revision is refused" "400" \
+  "$(http POST "$APPROVALS_URL" auth "$(printf '%s' "$body" | jq -c '.revision = "source/current"')")"
+note "a selector gives a stable-looking identity to a moving target"
+
+# ── 4. Approving nothing ───────────────────────────────────────────────────
+
+step "4. approving a translation that does not exist is refused"
+
+resp="$(http POST "$APPROVALS_URL" auth "$body")"
+approve_status="$(status_of "$resp")"
+
+if [ "$approve_status" = "503" ]; then
+  fail "translation evidence persistence is unavailable" "MongoDB is a required precondition"
+  note "The route refuses rather than recording an approval that would vanish on"
+  note "restart — the gate would admit a publication today and block it tomorrow."
+  note "That refusal is correct; a verification run that never reached the refusal"
+  note "path it exists to check has proved nothing, so this is a failure here."
+elif [ "$approve_status" = "409" ]; then
+  pass "POST approvals refuses with a conflict ${C_DIM}(409)${C_RESET}"
+  expect_jq "the refusal is typed, not a message string" \
+    '.refusal.type == "translation-receipt-missing" or (.refusal | tostring | test("receipt-missing"))' "$resp" \
+    || expect_jq "the response is marked refused" '.refused == true' "$resp"
+  note "409 not 404: the request is well formed and the document exists — the"
+  note "system simply is not in a state where approving means anything yet"
+else
+  fail "POST approvals — expected 409 or 503, got ${approve_status}" \
+    "$(body_of "$resp" | head -c 300)"
+fi
+
+# ── 5. Known gaps ──────────────────────────────────────────────────────────
+
+step "5. what this run cannot reach"
+
+warn "the successful-approval path needs a completed translation in the store"
+note "That needs the ingestion worker to have translated something, which is"
+note "knoxx-translation-work-dispatch's surface, not this card's. The happy path,"
+note "the idempotent double-approval, tenant/project isolation, and"
+note "re-translation supersession are covered by the CLJS suites named in the"
+note "script header."
+warn "whether an approval unblocks a publication is the reconciler card's surface"
+
+printf '\n%s%s%s\n' "$C_BOLD" "$(printf '═%.0s' $(seq 1 60))" "$C_RESET"
+printf '%s  %s passed%s' "$C_GREEN" "$PASS_COUNT" "$C_RESET"
+[ "$WARN_COUNT" -gt 0 ] && printf '%s, %s known gaps%s' "$C_YELLOW" "$WARN_COUNT" "$C_RESET"
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  printf '%s, %s FAILED%s\n' "$C_RED" "$FAIL_COUNT" "$C_RESET"
+  for f in "${FAILURES[@]}"; do printf '%s    - %s%s\n' "$C_RED" "$f" "$C_RESET"; done
+  printf '\n'; exit 1
+fi
+printf '\n\n'
+exit 0

--- a/scripts/verify-translation-approval.sh
+++ b/scripts/verify-translation-approval.sh
@@ -59,6 +59,9 @@ DOC_ID="${NS}/${DOC_LOCAL}"
 # outputs, so review evidence that named no garden would authorize bytes the
 # reviewer never read.
 GARDEN_ID="${NS}/probe-garden"
+# The same garden as an EDN keyword, which is the spelling the receipt blob and
+# the `garden` query column both use — `pr-str` of a qualified keyword.
+GARDEN_EDN=":${GARDEN_ID}"
 # Both derived from the *configured* contract root, never from `REPO_ROOT`.
 # `KNOXX_CONTRACTS_DIR` may point at a different checkout, and a fixture whose
 # EDN lives under that root while its source lives under this one declares a
@@ -327,6 +330,7 @@ elif ! mongo_eval 'db.runCommand({ping:1})' >/dev/null 2>&1; then
 else
   receipt_edn="{:receipt/type :translation/completed"
   receipt_edn="${receipt_edn} :translation/document ${DOC_EDN}"
+  receipt_edn="${receipt_edn} :translation/garden ${GARDEN_EDN}"
   receipt_edn="${receipt_edn} :translation/source-locale :en"
   receipt_edn="${receipt_edn} :translation/locale :es"
   receipt_edn="${receipt_edn} :translation/source-revision \"${SOURCE_REVISION}\""
@@ -344,6 +348,7 @@ else
   if mongo_eval "db.knoxx_translation_receipts.insertOne({
        dispatch_key: \"${DISPATCH_KEY}\",
        document: \"${DOC_EDN}\",
+       garden: \"${GARDEN_EDN}\",
        locale: \"es\",
        source_revision: \"${SOURCE_REVISION}\",
        org_id: \"${ORG_ID}\",
@@ -354,7 +359,7 @@ else
     pass "seeded one completed-translation receipt for this run"
     note "org ${ORG_ID}, project ${PROJECT:-<none>}, revision ${SOURCE_REVISION}"
 
-    good="{\"document\":\"${DOC_ID}\",\"locale\":\"es\",\"revision\":\"${SOURCE_REVISION}\",\"translation_revision\":\"${TRANSLATION_REVISION}\"}"
+    good="{\"document\":\"${DOC_ID}\",\"garden\":\"${GARDEN_ID}\",\"locale\":\"es\",\"revision\":\"${SOURCE_REVISION}\",\"translation_revision\":\"${TRANSLATION_REVISION}\"}"
 
     resp="$(http POST "$APPROVALS_URL" auth "$good")"
     if expect_status "POST approvals records the approval" "201" "$resp"; then
@@ -386,6 +391,16 @@ else
       expect_jq "the refusal names both sides" \
         "[.. | strings] | index(\"${TRANSLATION_REVISION}\")" "$resp"
       note "so a reviewer can see whether their request or the record was stale"
+    fi
+
+    # The garden is a coordinate of the receipt, so naming another one is not a
+    # narrower version of the same approval — it is an approval of a translation
+    # that does not exist. Checked over HTTP because a reviewer reading one
+    # garden's bytes must not be able to authorize another garden's.
+    elsewhere="$(printf '%s' "$good" | jq -c '.garden = "knoxx.verifyapproval/some-other-garden"')"
+    resp="$(http POST "$APPROVALS_URL" auth "$elsewhere")"
+    if expect_status "the same output in another garden is not approvable" "409" "$resp"; then
+      note "the receipt is keyed by garden, so this is 'no such translation'"
     fi
   else
     warn "could not seed a receipt, so the successful path is skipped"


### PR DESCRIPTION
## Summary

Card: `kanban/tasks/knoxx-translation-approval-surface.md` (3sp, P1, wave-2)
Parent epic: `knoxx-translated-publication-to-website`

**Stacked on #253** — based on `feat/translation-work-dispatch`, because approval validates against the translation receipt contract that card declares. Review this one after #253, or read the diff against that branch.

`domain.publication-gate` asks two evidential questions. #253 answered the first. This answers the second: did an authorized human accept *that exact translation*. `:approved?` had no production provider at all — only test stubs.

## The shape that matters

An approval is not a permission over a document or a locale. It is evidence about one pair of concrete revisions:

| field | meaning | gate reads it? |
| --- | --- | --- |
| `:review/revision` | the concrete **source** revision | yes — this is what an intent resolves to |
| `:review/translation-revision` | the produced output actually reviewed | no — `approved?` joins on it |

Both, because either alone is broken. Keyed only by the source, an approval survives a re-translation and goes on authorizing bytes nobody looked at. Keyed only by the output, the gate can never find it — an intent resolves to a source revision and has no idea what output exists.

`domain.translation-evidence/approved?` is therefore a **join**, not a lookup: an approval counts while it still names the receipt's current output. When a re-translation replaces that output, the approval stops being current — not deleted, not an error, exactly what the gate's own docstring already promised would happen to a stale translation's approval.

## Author's walkthrough

### What I corrected in the card

**"records an approval against … concrete *translated* revision."** Taken literally this produces approvals the gate can never match, since the gate asks with the source revision. Both are recorded; the source revision is the key. Annotated on the card rather than silently implementing it the other way.

**"The existing translation receipt and publication gate contracts."** The gate contract existed; a translation receipt contract did not. That is why #253 came first despite both being wave-2 — a consumer cannot validate against a contract the producer has not declared.

**Scope is absent from the card entirely.** Approvals are tenant- and project-scoped, like the receipts they attest to.

### What I carried over from #253's review, unprompted

Three findings on the dispatch PR cost review rounds to establish. I applied them here up front rather than waiting to be told again:

1. **Tenant and project are required**, and inherited from the **receipt** rather than the request. Unscoped evidence is admissible everywhere; that was a real cross-tenant leak on #253.
2. **The closed contract validates the raw wire body**, not the map the adapter builds. An unknown field is never copied into that map, so validating only the result silently accepts `{"documnet": ...}`.
3. **The selector string is refused**, not just the keyword. This is a boundary where a revision arrives as decoded wire input.

### Decisions worth naming

**Idempotent, not append-only.** An approval is immutable evidence, so a second one for the same output is the same fact asserted twice. Appending would make `approved?` depend on how many times a button was clicked and leave two records free to disagree about who approved. A unique index makes the insert the check, as with dispatch claims — read-then-write would let two reviewers clicking together both insert.

**`org.translations.review`, not `org.translations.manage`.** The `translator` role already holds the former. Requiring queue-management authority would mean only admins could review, which inverts who the surface is for.

**All refusals are 409, and that is a table not a cond.** 409 rather than 404 because the request is well formed and the document exists — the system simply is not in a state where approving means anything yet. A mismatch is the same shape: the caller is not wrong about syntax, it disagrees with recorded fact. The table means a new refusal type cannot be added without a status being chosen for it.

**An already-recorded approval is 200, not 409.** An honest double-click is not a conflict a reviewer has to resolve.

**The facade loads and indexes receipts rather than issuing a targeted query.** More work, deliberately: *which* receipt is current for a source revision is decided by comparing timestamps, and pushing that into a store query would duplicate the rule per implementation, each free to drift from the copy the gate uses. An approval validated against a different receipt than the gate will later read is the failure this card exists to prevent.

**`approve` takes every identity field from the receipt, not the request** — including the tenant and project, which the request never carries. `approval-refusal` has already established the two agree on everything the request did name.

### Risk I am carrying

`memory-store` is now a 50-line `reify` over eleven protocol methods — a size warning, bounded by method count rather than complexity. I split its state transitions and read paths into named helpers, which took it under the hard 60-line error and is genuinely clearer; the remaining length is the protocol's shape.

## Verification

`scripts/verify-translation-approval.sh` + `docs/verification/translation-approval.md`.

The script proves every refusal path from outside: anonymous, forged principal, forged timestamp, forged tenant, forged project, unknown field, unqualified document, blank field, missing field, selector revision, and approving a translation that does not exist. Unique identity per run, fixture torn down on exit/failure/Ctrl-C.

**It is explicit that the successful path is out of reach**, as WARN every run: recording an approval needs a completed-translation receipt in the durable store, which needs the ingestion worker to have actually translated something. That is #253's surface. The happy path — attribution from the receipt, idempotent double-approval, tenant and project isolation, re-translation supersession, and that approval materializes nothing — is covered by the CLJS suites.

No browser tour: this card adds no UI. The CMS action that would let a reviewer click approve is not in this slice, and per AGENTS.md a tour that quietly avoids the hard part is worse than none.

- `shadow-cljs compile test` — **1194 tests, 4417 assertions, 0 failures, 0 errors, 0 warnings**
- `shadow-cljs compile server` — 0 warnings
- `clj-kondo --lint src/cljs test/cljs` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)