### PR TITLE
feat(publication): reconciler runtime, trigger contract, and an authorized route

### DIFF
--- a/backend/src/cljs/knoxx/backend/domain/publication_resolver.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/publication_resolver.cljs
@@ -46,8 +46,12 @@
   [:garden/id :garden/title :garden/status :garden/locales])
 
 (def publication-projection-keys
-  [:publication/id :publication/document :publication/garden :publication/locale
-   :publication/revision :publication/state :publication/path :translation/review])
+  ;; `:publication/target` is declared desired state (which adapter the intent
+  ;; asks for), so it projects — the reconciler resolves it through the target
+  ;; registry. Dropping it here made every loaded intent untargeted.
+  [:publication/id :publication/document :publication/garden :publication/target
+   :publication/locale :publication/revision :publication/state :publication/path
+   :translation/review])
 
 (defn canonicalize-document
   [resource]

--- a/backend/src/cljs/knoxx/backend/infra/publication_reconciler.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/publication_reconciler.cljs
@@ -1,0 +1,242 @@
+(ns knoxx.backend.infra.publication-reconciler
+  "The publication reconciler runtime: turns a trigger into plan → effects and
+   records what actually happened.
+
+   One trigger reconciles ONE publication. The runtime loads desired state
+   fresh, resolves the intent's declared target through the registry, observes
+   that target, asks the pure planner for a decision, executes it through the
+   registry boundary, and emits exactly one validated, correlated receipt per
+   trigger — materialized, removed, noop, blocked, or failed. There is no path
+   that attempts an effect and records nothing, and no path that records a
+   materialization an adapter did not confirm.
+
+   The runtime owns observation (`:materialized-publication`) because the
+   planner must compare desired state against what the SAME target reports in
+   THIS run; a provider-supplied observation could describe somewhere else.
+   Translation and review evidence is provider-supplied: the runtime does not
+   know where those receipts live and must not guess.
+
+   Nothing here writes desired state. Resources are loaded and read; receipts
+   are emitted to the configured sink. A failed effect leaves resource
+   declarations byte-identical — drift is reported, never repaired by editing
+   the goalposts."
+  (:require [knoxx.backend.domain.publication-plan :as plan]
+            [knoxx.backend.infra.publication-effects :as effects]
+            [knoxx.backend.infra.publication-target-registry :as registry]
+            [knoxx.backend.law.publication :as publication-law]
+            [knoxx.backend.law.publication-receipts :as receipts-law]
+            [knoxx.backend.law.publication-reconciler :as trigger-law]))
+
+;; ── The reconciler bundle ──────────────────────────────────────────────────
+
+(def bundle-functions
+  "The function-valued members a reconciler bundle must supply:
+
+     :load-index!         [] -> Promise<resource-index> — fresh desired state
+     :evidence-facts      [intent] -> gate evidence map (the four lookups in
+                          `gate-evidence-keys`); observation is NOT the
+                          provider's to supply
+     :artifact-source     [intent concrete-revision] -> Promise<artifact|nil>
+     :locale-admissible?  [declaration intent artifact] -> boolean — the
+                          locale-catalog guard the registry requires
+     :emit-receipt!       [receipt] -> Promise<any> — the receipt sink"
+  [:load-index! :evidence-facts :artifact-source :locale-admissible? :emit-receipt!])
+
+(defn make-reconciler
+  "Validate and return a reconciler bundle. Construction refuses an incomplete
+   bundle so a trigger can never discover halfway through a run that there is
+   no artifact source or no receipt sink — both would surface as fake drift or
+   as evidence that vanished."
+  [{:keys [registry store] :as bundle}]
+  (when-not (and (map? registry) (map? (:declarations registry))
+                 (map? (:factories registry)))
+    (throw (ex-info "reconciler requires a publication target registry"
+                    {:bundle/key :registry})))
+  (when-not (satisfies? effects/IIdempotencyStore store)
+    (throw (ex-info "reconciler requires an IIdempotencyStore"
+                    {:bundle/key :store})))
+  (doseq [k bundle-functions]
+    (when-not (fn? (get bundle k))
+      (throw (ex-info "reconciler bundle member must be a function"
+                      {:bundle/key k}))))
+  (select-keys bundle (conj bundle-functions :registry :store)))
+
+;; ── Facts: provider evidence, runtime observation ──────────────────────────
+
+(def gate-evidence-keys
+  "The evidence lookups the publication gate requires of its facts map. Named
+   so an incomplete provider fails here with the missing key, rather than
+   inside the gate as an arity error on nil."
+  [:current-source-revision :translated-revision? :approved?
+   :source-revision-superseded?])
+
+(defn- assert-evidence-facts!
+  [facts]
+  (doseq [k gate-evidence-keys]
+    (when-not (fn? (get facts k))
+      (throw (ex-info "reconciler evidence facts are incomplete"
+                      {:missing-key k}))))
+  facts)
+
+(defn- runtime-facts
+  "The planner's facts: provider evidence plus runtime-owned observation.
+
+   `:materialized-publication` answers from the target observation this run
+   already made, whatever the provider supplied for that key — the planner
+   must compare desired state against what the same adapter reports in the
+   same run, or convergence is decided against a rumor."
+  [evidence-facts intent observed]
+  (assoc (evidence-facts intent)
+         :materialized-publication
+         (fn [queried]
+           (when (= (:publication/id queried) (:publication/id intent))
+             observed))))
+
+;; ── Receipts ───────────────────────────────────────────────────────────────
+
+(defn- failure-receipt
+  "The receipt for an effect that never completed. Never a materialization: a
+   failed attempt records drift, and a typed artifact conflict travels with it
+   so the reader can tell which side was stale. Internal stage markers are
+   stripped from the evidence before it goes on the receipt."
+  [target plan err]
+  (let [evidence (dissoc (ex-data err) ::plan ::target)]
+    (receipts-law/assert-receipt!
+     (cond-> {:receipt/type :publication/failed
+              :failure/reason (or (not-empty (str (ex-message err)))
+                                  "unknown failure")
+              :failure/drift? true}
+       (and target (= :publish (:op plan)))
+       (assoc :idempotency/key
+              (try (effects/publish-idempotency-key (effects/target-id target)
+                                                    (:intent plan)
+                                                    (:concrete-revision plan))
+                   (catch :default _ nil)))
+       (or (receipts-law/artifact-revision-conflict? evidence)
+           (receipts-law/artifact-locale-conflict? evidence))
+       (assoc :failure/conflict evidence)))))
+
+(defn- ^:async record!
+  "Correlate, validate, and emit one receipt; return it.
+
+   Validation happens BEFORE emission, so the sink never sees a receipt the
+   law would reject. A sink failure propagates: the receipt is the only
+   evidence an effect left, and dropping it quietly is worse than failing the
+   trigger loudly."
+  [reconciler trigger concrete-revision receipt]
+  (let [correlated (->> (trigger-law/correlation trigger concrete-revision)
+                        (trigger-law/correlate receipt)
+                        (receipts-law/assert-receipt!))]
+    (await ((:emit-receipt! reconciler) correlated))
+    correlated))
+
+;; ── Plan, then effects ─────────────────────────────────────────────────────
+
+(defn- ^:async publish-artifact!
+  "Produce the artifact for a publish plan, above the effect boundary. A source
+   answering nil is a failure, not a new blocker: the planner already decided
+   the evidence admits publication, and proceeding without bytes would record
+   a materialization that did not happen."
+  [artifact-source intent plan]
+  (or (await (artifact-source intent (:concrete-revision plan)))
+      (throw (ex-info "artifact source produced no artifact for a publish plan"
+                      {:publication/id (:publication/id intent)
+                       :concrete-revision (:concrete-revision plan)}))))
+
+(defn- ^:async plan-then-execute!
+  "Ask the pure planner for a decision, then execute it through the registry.
+
+   Planning happens strictly before any adapter effect: the artifact is
+   produced only for a `:publish` plan, above the effect boundary, and the
+   registry re-validates target and locale admission before delegating. A
+   failure after planning is rethrown carrying the plan and target, so the
+   failure receipt can name the exact operation and revision that failed."
+  [reconciler target ctx index intent observed]
+  (let [facts (assert-evidence-facts!
+               (runtime-facts (:evidence-facts reconciler) intent observed))
+        planned (plan/reconcile-plan index intent facts)]
+    (try
+      {:plan planned
+       :receipt
+       (await (registry/execute-plan!
+               (:registry reconciler) (:store reconciler) ctx planned
+               (when (= :publish (:op planned))
+                 (await (publish-artifact! (:artifact-source reconciler) intent planned)))
+               (:locale-admissible? reconciler)))}
+      (catch :default err
+        (throw (ex-info (ex-message err)
+                        (assoc (ex-data err) ::plan planned ::target target)
+                        err))))))
+
+(defn- find-intent
+  "The intent `publication-id` names in the freshly loaded index, or nil."
+  [index publication-id]
+  (->> (:publications index)
+       (filter #(= publication-id (:publication/id %)))
+       first))
+
+(defn- ^:async reconcile-intent!
+  "Resolve, observe, plan, execute, record — for an intent known to exist."
+  [reconciler trigger index raw-intent]
+  (let [intent (publication-law/hydrate-publication-intent index raw-intent)
+        ctx {:reconciliation/trigger (:trigger/id trigger)
+             :reconciliation/origin (:trigger/origin trigger)}]
+    (try
+      (let [target (registry/resolve-target! (:registry reconciler)
+                                             (:publication/target intent))
+            observed (await (effects/observe! target ctx intent))
+            {:keys [plan receipt]} (await (plan-then-execute! reconciler target ctx
+                                                              index intent observed))]
+        (await (record! reconciler trigger (:concrete-revision plan) receipt)))
+      (catch :default err
+        ;; Every failure past intent lookup — unresolvable target, failed
+        ;; observation, missing artifact, refused effect — is a failed receipt,
+        ;; so a broken target is observable in the same channel as every other
+        ;; outcome rather than as an exception nobody correlated.
+        (let [evidence (ex-data err)]
+          (await (record! reconciler trigger
+                          (some-> evidence ::plan :concrete-revision)
+                          (failure-receipt (::target evidence) (::plan evidence)
+                                           err))))))))
+
+(defn ^:async reconcile!
+  "Run one reconciliation trigger to a receipt.
+
+   Loads desired state fresh, plans purely, executes through the registry, and
+   emits one correlated receipt. An UNKNOWN publication is not a receipt
+   outcome — the trigger names desired state that does not exist, so it throws
+   with `:publication/id` in ex-data for the channel to classify."
+  [reconciler trigger]
+  (let [trigger (trigger-law/assert-trigger! trigger)
+        index (await ((:load-index! reconciler)))
+        intent (find-intent index (:publication/id trigger))]
+    (when-not intent
+      (throw (ex-info "unknown publication"
+                      {:publication/id (:publication/id trigger)})))
+    (await (reconcile-intent! reconciler trigger index intent))))
+
+;; ── The default emission channel ───────────────────────────────────────────
+
+(def receipt-journal-limit
+  "Bound on the in-memory receipt journal. Process-local and deliberately lossy
+   past the bound — durable receipt persistence is a store decision this card
+   does not take."
+  200)
+
+(defn make-receipt-journal
+  "A receipt sink keeping the newest `receipt-journal-limit` receipts in
+   memory: `{:emit! (fn [receipt] ...) :receipts (fn [] [...])}`.
+
+   The default emission channel when no durable sink is configured. Emission
+   is real — every receipt the runtime validated is queryable until the bound
+   — it is just not persistent, and the docstring on
+   `receipt-journal-limit` says so rather than letting a restart look like a
+   clean slate."
+  []
+  (let [receipts* (atom [])]
+    {:emit! (fn [receipt]
+              (swap! receipts*
+                     (fn [receipts]
+                       (vec (take-last receipt-journal-limit (conj receipts receipt)))))
+              nil)
+     :receipts (fn [] @receipts*)}))

--- a/backend/src/cljs/knoxx/backend/infra/publication_reconciler.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/publication_reconciler.cljs
@@ -175,29 +175,53 @@
        (filter #(= publication-id (:publication/id %)))
        first))
 
+(defn- ^:async outcome-of!
+  "The receipt one trigger produced, and the revision to correlate it with.
+
+   Every failure past intent lookup — a dangling document reference,
+   an unresolvable target, a failed observation, a missing artifact, a refused
+   effect — becomes a failed receipt here, so a broken publication is
+   observable in the same channel as every other outcome rather than as an
+   exception nobody correlated.
+
+   Hydration is deliberately INSIDE this try. It was outside, which meant a
+   dangling `:publication/document` escaped the runtime with no receipt at all
+   — the one failure the comment above it promised could not happen.
+
+   Emission is deliberately OUTSIDE it: see `reconcile-intent!`."
+  [reconciler ctx index raw-intent]
+  (try
+    (let [intent (publication-law/hydrate-publication-intent index raw-intent)
+          target (registry/resolve-target! (:registry reconciler)
+                                           (:publication/target intent))
+          observed (await (effects/observe! target ctx intent))
+          {:keys [plan receipt]} (await (plan-then-execute! reconciler target ctx
+                                                            index intent observed))]
+      {:revision (:concrete-revision plan) :receipt receipt})
+    (catch :default err
+      (let [evidence (ex-data err)]
+        {:revision (some-> evidence ::plan :concrete-revision)
+         :receipt (failure-receipt (::target evidence) (::plan evidence) err)}))))
+
 (defn- ^:async reconcile-intent!
-  "Resolve, observe, plan, execute, record — for an intent known to exist."
+  "Resolve, observe, plan, execute, record — for an intent known to exist.
+
+   Exactly one `record!`, and it is outside the failure handling on purpose.
+   With emission inside the try, a sink that threw while writing a *success*
+   receipt was caught as though the reconciliation had failed, and the handler
+   emitted a second receipt describing the sink failure instead of the outcome.
+   One trigger, two emission attempts, and the error that propagated was the
+   second one — so the actual result of the run was lost.
+
+   Now the outcome is decided first and emitted once. A sink failure propagates
+   untouched, which is what the receipt being the only evidence of an effect
+   demands: dropping it quietly, or replacing it with a receipt about the
+   dropping, are both worse than failing the trigger loudly."
   [reconciler trigger index raw-intent]
-  (let [intent (publication-law/hydrate-publication-intent index raw-intent)
-        ctx {:reconciliation/trigger (:trigger/id trigger)
-             :reconciliation/origin (:trigger/origin trigger)}]
-    (try
-      (let [target (registry/resolve-target! (:registry reconciler)
-                                             (:publication/target intent))
-            observed (await (effects/observe! target ctx intent))
-            {:keys [plan receipt]} (await (plan-then-execute! reconciler target ctx
-                                                              index intent observed))]
-        (await (record! reconciler trigger (:concrete-revision plan) receipt)))
-      (catch :default err
-        ;; Every failure past intent lookup — unresolvable target, failed
-        ;; observation, missing artifact, refused effect — is a failed receipt,
-        ;; so a broken target is observable in the same channel as every other
-        ;; outcome rather than as an exception nobody correlated.
-        (let [evidence (ex-data err)]
-          (await (record! reconciler trigger
-                          (some-> evidence ::plan :concrete-revision)
-                          (failure-receipt (::target evidence) (::plan evidence)
-                                           err))))))))
+  (let [ctx {:reconciliation/trigger (:trigger/id trigger)
+             :reconciliation/origin (:trigger/origin trigger)}
+        {:keys [revision receipt]} (await (outcome-of! reconciler ctx index raw-intent))]
+    (await (record! reconciler trigger revision receipt))))
 
 (defn ^:async reconcile!
   "Run one reconciliation trigger to a receipt.

--- a/backend/src/cljs/knoxx/backend/infra/routes/app.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/app.cljs
@@ -14,6 +14,7 @@
             [knoxx.backend.infra.auth.authz :refer [policy-db policy-db-enabled? policy-db-promise with-request-context! ensure-permission! ensure-tool! ensure-any-permission! ensure-org-scope! primary-context-role ctx-permitted? system-admin? ctx-role-slugs ctx-user-id ctx-user-email ctx-org-id run-visible?]]
             [knoxx.backend.infra.core-memory :refer [fetch-openplanner-session-rows! session-visible? session-matches-page-actor-filter? filter-authorized-memory-hits! authorized-session-ids!]]
             [knoxx.backend.infra.routes.resources :as resource-routes]
+            [knoxx.backend.infra.routes.publication-reconcile :as reconcile-routes]
             [knoxx.backend.extern.fastify.publications :as publication-routes]
             [knoxx.backend.extern.fastify.translation-config :as translation-config-routes]
             [knoxx.backend.extern.fastify.translation-dispatch :as translation-dispatch-routes]
@@ -1538,6 +1539,9 @@
      app runtime config (select-keys helpers [:with-request-context!
                                               :ensure-permission!]))
     (cms-publication-routes/register-cms-publication-routes! app runtime config helpers)
+    (reconcile-routes/register-publication-reconcile-routes!
+     app runtime config (select-keys helpers [:with-request-context!
+                                              :ensure-permission!]))
     (translation-config-routes/register-translation-config-routes!
      app runtime config helpers)
     (translation-dispatch-routes/register-translation-dispatch-routes!

--- a/backend/src/cljs/knoxx/backend/infra/routes/publication_reconcile.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/publication_reconcile.cljs
@@ -1,0 +1,210 @@
+(ns knoxx.backend.infra.routes.publication-reconcile
+  "The authorized runtime route that triggers publication reconciliation — the
+   explicit trigger integration for `infra.publication-reconciler`, so the
+   runtime is something a production path actually calls.
+
+   POST /api/publications/reconcile decodes a trigger, runs the reconciler,
+   and answers with the correlated receipt. GET /api/publications/receipts
+   answers with the receipt journal the runtime emitted into. Both authorize:
+   reconciliation changes what is public (`org.publications.manage`), while
+   receipts only name what happened (`org.publications.read`).
+
+   The reconciler is built once per config from `:publication/reconciliation`:
+
+     :targets            registry declarations (data)
+     :evidence-facts     [intent] -> gate evidence map
+     :artifact-source    [intent concrete-revision] -> Promise<artifact|nil>
+     :locale-admissible? [declaration intent artifact] -> boolean
+     :store              optional IIdempotencyStore (default: process-local
+                         memory store — a restart forgets reservations, which
+                         the effect layer already tolerates by observing first)
+     :target-factories   optional extra kind -> factory merges over the
+                         built-in static-site factory
+     :load-index!        optional desired-state loader (default: the resource
+                         projection over this config)
+     :emit-receipt!      optional receipt sink (default: the in-memory journal
+                         the receipts route serves)
+
+   With no spec the routes answer 503 — loudly unconfigured, rather than a
+   reconciler that silently cannot publish. Fastify handles are decoded
+   through `extern.fastify`; no native object crosses into the runtime."
+  (:require [clojure.string :as str]
+            [knoxx.backend.extern.fastify :as fastify]
+            [knoxx.backend.infra.publication-reconciler :as reconciler]
+            [knoxx.backend.infra.publication-target-memory :as memory]
+            [knoxx.backend.infra.publication-target-registry :as registry]
+            [knoxx.backend.infra.publication-target-static-site :as static-site]
+            [knoxx.backend.infra.routes.publications :as publications]
+            [knoxx.backend.law.error-body :as error-body]
+            [knoxx.backend.law.publication-reconciler :as trigger-law]
+            [knoxx.backend.shape.resource-identity :as resource-identity]))
+
+(def reconcile-permission
+  "Reconciliation changes what is public, so it holds the publication write
+   permission rather than inventing a parallel one."
+  "org.publications.manage")
+
+(def receipts-permission
+  "Receipts name what was materialized where — publication read authority."
+  "org.publications.read")
+
+(def default-trigger-id
+  "The trigger id a route demand carries when the caller named none: the route
+   itself, so the receipt still says which channel asked."
+  :publication.reconcile/http-request)
+
+;; ── Trigger decoding ───────────────────────────────────────────────────────
+
+(defn- body-keyword
+  "A `\"namespace/name\"` string (or keyword) from a decoded body as a keyword,
+   or nil. Bare values keywordize as-is, matching the resolver's `query-id`
+   convention so a standalone unqualified id stays reachable."
+  [value]
+  (cond
+    (keyword? value) value
+    (and (string? value) (str/includes? value "/"))
+    (let [[ns-part name-part] (str/split value #"/" 2)]
+      (keyword ns-part name-part))
+    (string? value) (keyword value)
+    :else nil))
+
+(defn decode-trigger
+  "Decode a request body into a validated reconciliation trigger. The origin is
+   fixed to `:route` here — a caller may not claim its demand arrived by
+   another channel."
+  [body]
+  (trigger-law/assert-trigger!
+   {:trigger/id (or (body-keyword (:triggerId body)) default-trigger-id)
+    :trigger/origin :route
+    :publication/id (body-keyword (:publicationId body))}))
+
+;; ── Reconciler construction ────────────────────────────────────────────────
+
+(defonce ^:private runtimes* (atom {}))
+
+(defn reset-cached-runtimes!
+  "Forget every constructed reconciler. Test support: construction is memoized
+   per config so idempotency reservations and the receipt journal survive
+   across requests, and a test needs a clean memo."
+  []
+  (reset! runtimes* {}))
+
+(defn- build-runtime
+  "Construct the reconciler and its default journal one config spec describes.
+   An incomplete spec throws at the first request, not at registration — an
+   unconfigured route is a 503, but a MISconfigured one is an operator defect
+   and must fail loudly."
+  [config spec]
+  (let [journal (reconciler/make-receipt-journal)]
+    {:journal journal
+     :reconciler
+     (reconciler/make-reconciler
+      {:registry (registry/make-registry
+                  (:targets spec)
+                  (merge {:publication-target/static-site
+                          static-site/static-site-target}
+                         (:target-factories spec)))
+       :store (or (:store spec) (:store (memory/memory-store)))
+       :load-index! (or (:load-index! spec)
+                        (fn [] (publications/publication-index! config)))
+       :evidence-facts (:evidence-facts spec)
+       :artifact-source (:artifact-source spec)
+       :locale-admissible? (:locale-admissible? spec)
+       :emit-receipt! (or (:emit-receipt! spec) (:emit! journal))})}))
+
+(defn- runtime-for
+  "The `{:reconciler ... :journal ...}` for `config`, built once per distinct
+   config value. nil when the config declares no `:publication/reconciliation`
+   spec."
+  [config]
+  (or (get @runtimes* config)
+      (when-let [spec (:publication/reconciliation config)]
+        (let [built (build-runtime config spec)]
+          (swap! runtimes* assoc config built)
+          built))))
+
+;; ── Responses ──────────────────────────────────────────────────────────────
+
+(defn- error-status
+  "The HTTP status for a thrown reconcile failure. A denied request keeps the
+   status it already carries; a malformed trigger is a 400; an unknown
+   publication is a 404; contradictory desired state is a 409; anything else
+   is a 500 with an opaque body."
+  [err]
+  (let [data (ex-data err)]
+    (or (:status data)
+        (fastify/error-status err nil)
+        (cond
+          (= :publication/reconcile-trigger (:contract data)) 400
+          (contains? data :publication/id) 404
+          (or (contains? data :blockers)
+              (contains? data :conflicts)
+              (contains? data :conflicting-payloads)) 409
+          :else 500))))
+
+(defn- ^:async send-result!
+  "Answer with the operation's wire-encoded result, or with a classified error
+   body. Keyword values are encoded as `namespace/name` so publication and
+   trigger identity survive JSON."
+  [reply operation]
+  (try
+    (fastify/send-json! reply 200
+                        (resource-identity/encode-wire-values (await (operation))))
+    (catch :default err
+      (let [status (error-status err)]
+        (when-not (error-body/classified? status)
+          (fastify/log-unclassified-failure! "publication-reconcile" err))
+        (fastify/send-json! reply status
+                            (resource-identity/encode-wire-values
+                             (error-body/error-body err status)))))))
+
+(defn- ^:async handle-reconcile!
+  "Run one decoded trigger and answer with its correlated receipt. 503 when no
+   reconciler is configured: the demand is lawful, the capability is absent."
+  [config request reply]
+  (if-let [{:keys [reconciler]} (runtime-for config)]
+    (await (send-result! reply
+                         #(reconciler/reconcile!
+                           reconciler
+                           (decode-trigger (fastify/request-body request)))))
+    (fastify/send-json! reply 503
+                        {:detail "publication reconciliation is not configured"})))
+
+(defn- ^:async handle-receipts!
+  "Answer with the receipt journal the configured reconciler has emitted into."
+  [config _request reply]
+  (if-let [{:keys [journal]} (runtime-for config)]
+    (await (send-result! reply (fn [] {:receipts ((:receipts journal))})))
+    (fastify/send-json! reply 503
+                        {:detail "publication reconciliation is not configured"})))
+
+;; ── Registration ───────────────────────────────────────────────────────────
+
+(defn register-publication-reconcile-routes!
+  "Register the reconciliation trigger routes. Both enter the request context
+   and authorize BEFORE touching resources, the registry, or the journal — a
+   nil context fails closed, as on the other publication surfaces."
+  [app runtime config {:keys [with-request-context! ensure-permission!]}]
+  (fastify/route!
+   app
+   {:method "POST"
+    :url "/api/publications/reconcile"
+    :handler
+    (^:async fn [request reply]
+      (await (with-request-context!
+              runtime request reply
+              (^:async fn [ctx]
+                (ensure-permission! ctx reconcile-permission)
+                (await (handle-reconcile! config request reply))))))})
+  (fastify/route!
+   app
+   {:method "GET"
+    :url "/api/publications/receipts"
+    :handler
+    (^:async fn [request reply]
+      (await (with-request-context!
+              runtime request reply
+              (^:async fn [ctx]
+                (ensure-permission! ctx receipts-permission)
+                (await (handle-receipts! config request reply))))))})
+  nil)

--- a/backend/src/cljs/knoxx/backend/law/publication_reconciler.cljc
+++ b/backend/src/cljs/knoxx/backend/law/publication_reconciler.cljc
@@ -1,0 +1,82 @@
+(ns knoxx.backend.law.publication-reconciler
+  "Contracts for the publication reconciler runtime: the trigger that demands a
+   reconciliation and the correlation stamped onto every receipt one trigger
+   produces.
+
+   Portable (`.cljc`) so any channel — an authorized route, an event listener,
+   a scheduled job — validates the same trigger shape before the runtime runs,
+   and the runtime never has to trust the channel's decoding. No I/O lives
+   here."
+  (:require [clojure.string :as str]
+            [malli.core :as m]
+            [malli.error :as me]))
+
+(defn nonblank-string?
+  "True for a string carrying at least one non-whitespace character. Restated
+   locally: `law.publication`'s copy lives in `.cljs` (its bytes predicate has
+   no portable spelling) and this contract must stay portable."
+  [value]
+  (and (string? value) (seq (str/trim value))))
+
+(def TriggerOrigin
+  "Every channel a reconciliation demand may arrive by. The origin is fixed by
+   the channel that decoded the trigger, never read from caller-supplied data,
+   so a request cannot claim its demand arrived by another channel."
+  [:enum :route :event :schedule :manual])
+
+(def ReconcileTrigger
+  "One reconciliation demand: run plan → effects for one publication and record
+   what happened. Closed — a trigger carrying undeclared fields is a decoding
+   defect to surface, not extra data to quietly drop."
+  [:map {:closed true}
+   [:trigger/id :qualified-keyword]
+   [:trigger/origin TriggerOrigin]
+   [:publication/id :qualified-keyword]])
+
+(def ReceiptCorrelation
+  "The trace every emitted receipt carries: which trigger demanded the
+   reconciliation, for which publication, at which concrete revision. The
+   revision is maybe — a blocked plan with an unresolvable selector has none,
+   and recording that honestly beats inventing one."
+  [:map {:closed true}
+   [:correlation/trigger :qualified-keyword]
+   [:correlation/origin TriggerOrigin]
+   [:correlation/publication :qualified-keyword]
+   [:correlation/revision [:maybe [:fn nonblank-string?]]]])
+
+(defn- assert-valid!
+  [contract-id schema value]
+  (if (m/validate schema value)
+    value
+    (throw
+     (ex-info (str "Publication reconciler contract violation: " contract-id)
+              {:contract contract-id
+               :errors (me/humanize (m/explain schema value))}))))
+
+(defn assert-trigger!
+  "Return `trigger` when it is a lawful reconciliation demand; otherwise throw
+   before any resource is loaded or any effect is attempted."
+  [trigger]
+  (assert-valid! :publication/reconcile-trigger ReconcileTrigger trigger))
+
+(defn assert-correlation!
+  "Return `correlation` when it satisfies the receipt-correlation contract;
+   otherwise throw."
+  [correlation]
+  (assert-valid! :publication/receipt-correlation ReceiptCorrelation correlation))
+
+(defn correlation
+  "Build the validated correlation for `trigger` at `concrete-revision` (nil
+   when the plan never resolved one)."
+  [trigger concrete-revision]
+  (assert-correlation! {:correlation/trigger (:trigger/id trigger)
+                        :correlation/origin (:trigger/origin trigger)
+                        :correlation/publication (:publication/id trigger)
+                        :correlation/revision concrete-revision}))
+
+(defn correlate
+  "Return `receipt` carrying `correlation`. Receipt law maps are open, so the
+   correlation survives receipt validation; it is asserted here so the runtime
+   can never emit an untraceable receipt."
+  [receipt correlation]
+  (merge receipt (assert-correlation! correlation)))

--- a/backend/test/cljs/knoxx/backend/infra/publication_reconciler_test.cljs
+++ b/backend/test/cljs/knoxx/backend/infra/publication_reconciler_test.cljs
@@ -92,7 +92,7 @@
    so `public-routes` and `materialization-count` observe the same target the
    runtime published through."
   [& {:keys [facts fail? load-index! locale-admissible? artifact-source
-             declarations*]}]
+             declarations* emit-receipt!]}]
   (let [bundle (memory/memory-target {:id target-id :fail? fail?})
         receipts (atom [])
         resources (atom (index))]
@@ -109,7 +109,10 @@
        :evidence-facts (or facts (evidence-facts))
        :artifact-source (or artifact-source artifact-for)
        :locale-admissible? (or locale-admissible? (constantly true))
-       :emit-receipt! (fn [receipt] (swap! receipts conj receipt) nil)})}))
+       :emit-receipt! (fn [receipt]
+                        (swap! receipts conj receipt)
+                        (when emit-receipt! (emit-receipt! receipt))
+                        nil)})}))
 
 (defn- trigger
   [& {:keys [id] :or {id :test/trigger}}]
@@ -316,6 +319,53 @@
       (is (= :publication/blocked (:receipt/type receipt)))
       (is (= [:publication-revision-unresolved] (vec (:blockers receipt)))))
     (is (= 0 (memory/materialization-count target)))))
+
+;; ── Exactly one receipt, whatever happens ──────────────────────────────────
+
+(deftest ^:async a-failing-sink-is-not-answered-with-a-second-receipt
+  ;; The regression: `record!` used to sit inside the failure handling, so a
+  ;; sink that threw while writing a SUCCESS receipt was caught as though the
+  ;; reconciliation had failed — and the handler emitted a second receipt
+  ;; describing the sink failure instead of the outcome. One trigger, two
+  ;; emission attempts, and the error that propagated was the second one, so
+  ;; the actual result of the run was lost.
+  (let [{:keys [reconciler receipts target]}
+        (fixture :emit-receipt! (fn [_] (throw (ex-info "sink is down" {}))))]
+    (testing "the sink failure propagates rather than being swallowed"
+      (is (thrown? js/Error (await (reconciler/reconcile! reconciler (trigger))))))
+
+    (testing "the sink was offered exactly one receipt"
+      ;; Two would mean the failure handler re-entered emission.
+      (is (= 1 (count @receipts)))
+      (is (= :publication/materialized (:receipt/type (first @receipts)))))
+
+    (testing "and the effect itself still happened"
+      ;; A sink that cannot record is not a reason to claim nothing was
+      ;; published — that is exactly the divergence the receipt exists to make
+      ;; visible, and pretending otherwise would hide it.
+      (is (= 1 (memory/materialization-count target))))))
+
+(deftest ^:async a-dangling-document-reference-is-a-receipt-not-an-escape
+  ;; `hydrate-publication-intent` throws on a dangling `:publication/document`
+  ;; rather than defaulting a source locale. It used to run outside the failure
+  ;; handling, so that throw left the runtime with no receipt at all — the one
+  ;; failure the handler's own comment promised could not happen.
+  (let [{:keys [reconciler receipts resources target]} (fixture)
+        _ (swap! resources update :documents dissoc :knoxx.docs/probe)
+        receipt (await (reconciler/reconcile! reconciler (trigger)))]
+    (testing "the broken reference is reported as drift"
+      (is (= :publication/failed (:receipt/type receipt)))
+      (is (true? (:failure/drift? receipt))))
+
+    (testing "it is correlated, and it is the only receipt"
+      (is (= :knoxx.docs/probe-es (:correlation/publication receipt)))
+      (is (= :test/trigger (:correlation/trigger receipt)))
+      ;; No plan was ever produced, so there is no revision to correlate with.
+      (is (nil? (:correlation/revision receipt)))
+      (is (= 1 (count @receipts))))
+
+    (testing "and nothing was published on the strength of a missing document"
+      (is (= 0 (memory/materialization-count target))))))
 
 ;; ── The trigger itself ─────────────────────────────────────────────────────
 

--- a/backend/test/cljs/knoxx/backend/infra/publication_reconciler_test.cljs
+++ b/backend/test/cljs/knoxx/backend/infra/publication_reconciler_test.cljs
@@ -1,0 +1,383 @@
+(ns knoxx.backend.infra.publication-reconciler-test
+  "The reconciler runtime, end to end over the real seam.
+
+  Every test here drives `reconcile!` with a real registry, a real idempotency
+  store, the real pure planner and a real adapter — only desired state, the
+  evidence provider and the artifact source are fixtures. That is the point:
+  the planner, the gate, the effects and the adapters were merged and proven in
+  isolation, and what was never proven is that a trigger walks all of them and
+  leaves evidence behind.
+
+  What is asserted, per the card's definition of done: that planning strictly
+  precedes any adapter effect; that a materialization, a noop, a blocker, a
+  removal and an adapter failure each produce one correlated receipt of the
+  expected type; that repeating a trigger publishes once; and that no receipt
+  can edit desired state or talk its way past a review blocker."
+  (:require [cljs.test :refer [deftest is testing]]
+            [knoxx.backend.domain.publication-plan :as plan]
+            [knoxx.backend.infra.publication-reconciler :as reconciler]
+            [knoxx.backend.infra.publication-target-memory :as memory]
+            [knoxx.backend.infra.publication-target-registry :as registry]))
+
+;; ── Desired state ──────────────────────────────────────────────────────────
+
+(def ^:private revision "sha256-aaa111bbb222")
+
+(def ^:private target-id :knoxx.publication/memory)
+
+(defn- intent
+  [& {:keys [state review locale] :or {state :published
+                                       review :required
+                                       locale :es}}]
+  {:publication/id :knoxx.docs/probe-es
+   :publication/document :knoxx.docs/probe
+   :publication/garden :knoxx.docs/promethean
+   :publication/target target-id
+   :publication/locale locale
+   :publication/revision :source/current
+   :publication/state state
+   :publication/path "/probe-es"
+   :translation/review review})
+
+(defn- index
+  [& {:keys [garden-status] :as opts}]
+  {:documents {:knoxx.docs/probe {:document/id :knoxx.docs/probe
+                                  :document/title "Probe"
+                                  :document/source-locale :en
+                                  :document/source {:path "docs/probe.md"}}}
+   :gardens {:knoxx.docs/promethean {:garden/id :knoxx.docs/promethean
+                                     :garden/title "Promethean"
+                                     :garden/status (or garden-status :active)
+                                     :garden/locales [:en :es]}}
+   :publications [(apply intent (mapcat identity (dissoc opts :garden-status)))]})
+
+(def ^:private declarations
+  [{:publication-target/id target-id
+    :publication-target/kind :publication-target/memory
+    :publication-target/config {}
+    :publication-target/enabled? true}])
+
+;; ── The bundle under test ──────────────────────────────────────────────────
+
+(defn- evidence-facts
+  "The four gate lookups a provider owns. `translated?` and `approved?` are the
+   two the review blocker turns on; both default to satisfied so a test that
+   cares about something else does not have to restate them.
+
+   `unresolvable-revision?` is a flag rather than `:source-revision nil`
+   because destructuring `:or` cannot tell an absent key from a nil value, and
+   a fixture that silently substituted a default for the very thing under test
+   would prove the opposite of what it claims."
+  [& {:keys [translated? approved? superseded? unresolvable-revision?]
+      :or {translated? true approved? true superseded? false}}]
+  (fn [_intent]
+    {:current-source-revision (constantly (when-not unresolvable-revision? revision))
+     :translated-revision? (fn [_document _garden _locale _revision] translated?)
+     :approved? (fn [_document _garden _locale _revision] approved?)
+     :source-revision-superseded? (fn [_intent _revision] superseded?)}))
+
+(defn- artifact-for
+  [_intent concrete-revision]
+  (js/Promise.resolve {:artifact/content "<p>traducido</p>"
+                       :artifact/media-type "text/html"
+                       :artifact/encoding "utf-8"
+                       :artifact/locale :es
+                       :artifact/revision concrete-revision}))
+
+(defn- fixture
+  "A reconciler over a real registry, store, planner and memory adapter.
+
+   Returns the bundle plus the adapter and receipt handles a test reads. The
+   adapter instance is created once and handed back by the factory every time,
+   so `public-routes` and `materialization-count` observe the same target the
+   runtime published through."
+  [& {:keys [facts fail? load-index! locale-admissible? artifact-source
+             declarations*]}]
+  (let [bundle (memory/memory-target {:id target-id :fail? fail?})
+        receipts (atom [])
+        resources (atom (index))]
+    {:target bundle
+     :receipts receipts
+     :resources resources
+     :reconciler
+     (reconciler/make-reconciler
+      {:registry (registry/make-registry
+                  (or declarations* declarations)
+                  {:publication-target/memory (constantly (:target bundle))})
+       :store (:store (memory/memory-store))
+       :load-index! (or load-index! (fn [] (js/Promise.resolve @resources)))
+       :evidence-facts (or facts (evidence-facts))
+       :artifact-source (or artifact-source artifact-for)
+       :locale-admissible? (or locale-admissible? (constantly true))
+       :emit-receipt! (fn [receipt] (swap! receipts conj receipt) nil)})}))
+
+(defn- trigger
+  [& {:keys [id] :or {id :test/trigger}}]
+  {:trigger/id id
+   :trigger/origin :manual
+   :publication/id :knoxx.docs/probe-es})
+
+;; ── Ordering ───────────────────────────────────────────────────────────────
+
+(deftest ^:async planning-happens-before-any-adapter-effect
+  ;; The card asks for this specifically, and it is not a style point: an
+  ;; effect that ran before the plan decided would be an effect no evidence
+  ;; admitted. Observed rather than assumed — the planner is wrapped and asked
+  ;; what the adapter had done at the moment it was called.
+  (let [{:keys [reconciler target]} (fixture)
+        published-at-plan-time (atom nil)
+        real plan/reconcile-plan]
+    (with-redefs [plan/reconcile-plan
+                  (fn [index* intent* facts*]
+                    (reset! published-at-plan-time
+                            (memory/materialization-count target))
+                    (real index* intent* facts*))]
+      (let [receipt (await (reconciler/reconcile! reconciler (trigger)))]
+        (testing "nothing had been published when the planner ran"
+          (is (= 0 @published-at-plan-time)))
+
+        (testing "and the plan it produced is what got materialized"
+          (is (= :publication/materialized (:receipt/type receipt)))
+          (is (= 1 (memory/materialization-count target))))))))
+
+(deftest ^:async a-blocked-plan-never-reaches-the-artifact-source
+  ;; The other half of the ordering claim. Producing an artifact is work, and
+  ;; for a plan that cannot publish it is work whose only possible effect is to
+  ;; make a refused publication look attempted.
+  (let [asked (atom 0)
+        {:keys [target reconciler]}
+        (fixture :facts (evidence-facts :approved? false)
+                 :artifact-source (fn [i r] (swap! asked inc) (artifact-for i r)))
+        receipt (await (reconciler/reconcile! reconciler (trigger)))]
+    (testing "the trigger is refused with the review blocker"
+      (is (= :publication/blocked (:receipt/type receipt)))
+      (is (= [:translation-review-required] (vec (:blockers receipt)))))
+
+    (testing "no artifact was produced and nothing was published"
+      (is (= 0 @asked))
+      (is (= 0 (memory/materialization-count target)))
+      (is (empty? (memory/public-routes target))))))
+
+;; ── One receipt per outcome ────────────────────────────────────────────────
+
+(deftest ^:async a-materialization-produces-a-correlated-receipt
+  (let [{:keys [reconciler receipts target]} (fixture)
+        receipt (await (reconciler/reconcile! reconciler (trigger)))]
+    (testing "the receipt names the materialization"
+      (is (= :publication/materialized (:receipt/type receipt)))
+      (is (= :knoxx.docs/probe-es (:publication/id receipt)))
+      (is (= revision (:materialized/revision receipt)))
+      (is (= "/probe-es" (:materialized/path receipt))))
+
+    (testing "it carries the correlation the trigger supplied"
+      (is (= :test/trigger (:correlation/trigger receipt)))
+      (is (= :manual (:correlation/origin receipt)))
+      (is (= :knoxx.docs/probe-es (:correlation/publication receipt)))
+      (is (= revision (:correlation/revision receipt))))
+
+    (testing "exactly one receipt was emitted, and the route serves the bytes"
+      (is (= 1 (count @receipts)))
+      (is (= "<p>traducido</p>"
+             (:artifact/content (memory/served-artifact target "/probe-es")))))))
+
+(deftest ^:async a-converged-publication-reconciles-to-a-noop
+  (let [{:keys [reconciler receipts target]} (fixture)
+        _ (await (reconciler/reconcile! reconciler (trigger)))
+        second-run (await (reconciler/reconcile! reconciler (trigger)))]
+    (testing "the second trigger finds desired and observed already equal"
+      (is (= :publication/noop (:receipt/type second-run))))
+
+    (testing "it is still a receipt, and still correlated"
+      (is (= 2 (count @receipts)))
+      (is (= :knoxx.docs/probe-es (:correlation/publication second-run)))
+      (is (= revision (:correlation/revision second-run))))
+
+    (testing "and a noop published nothing new and took nothing down"
+      ;; The failure this rules out is a noop that reads as convergence while
+      ;; having quietly removed the route it converged on.
+      (is (= 1 (memory/materialization-count target)))
+      (is (= 1 (count (memory/public-routes target))))
+      (is (some? (memory/served-artifact target "/probe-es"))))))
+
+(deftest ^:async a-withheld-publication-reconciles-to-a-removal
+  ;; Removal is decided before translation and review evidence — a publication
+  ;; being taken down must not be held up by evidence about publishing it.
+  (let [{:keys [reconciler receipts resources target]} (fixture)
+        _ (await (reconciler/reconcile! reconciler (trigger)))
+        _ (reset! resources (index :state :withheld))
+        removal (await (reconciler/reconcile! reconciler (trigger)))]
+    (testing "the route comes down"
+      (is (= :publication/removed (:receipt/type removal)))
+      (is (= "/probe-es" (:removed/path removal)))
+      (is (empty? (memory/public-routes target))))
+
+    (testing "the removal is correlated like every other outcome"
+      ;; Two so far: the materialization, then this removal.
+      (is (= 2 (count @receipts)))
+      (is (= :knoxx.docs/probe-es (:correlation/publication removal))))
+
+    (testing "a withheld publication with nothing materialized is a noop"
+      (is (= :publication/noop
+             (:receipt/type (await (reconciler/reconcile! reconciler (trigger)))))))))
+
+(deftest ^:async an-adapter-failure-is-drift-not-a-materialization
+  (let [{:keys [reconciler receipts target]} (fixture :fail? true)
+        receipt (await (reconciler/reconcile! reconciler (trigger)))]
+    (testing "the failure is a receipt rather than an exception"
+      (is (= :publication/failed (:receipt/type receipt)))
+      (is (true? (:failure/drift? receipt)))
+      (is (string? (:failure/reason receipt))))
+
+    (testing "it is correlated, so a broken target is traceable to its trigger"
+      (is (= :test/trigger (:correlation/trigger receipt)))
+      (is (= revision (:correlation/revision receipt))))
+
+    (testing "and nothing became public"
+      (is (= 0 (memory/materialization-count target)))
+      (is (empty? (memory/public-routes target)))
+      (is (= 1 (count @receipts))))))
+
+(deftest ^:async an-unresolvable-target-is-a-failed-receipt-not-a-crash
+  ;; A misdeclared target is an operator defect, and it has to be observable in
+  ;; the same channel as every other outcome rather than as an exception nobody
+  ;; correlated.
+  (let [{:keys [reconciler receipts]}
+        (fixture :declarations* [(assoc (first declarations)
+                                        :publication-target/enabled? false)])
+        receipt (await (reconciler/reconcile! reconciler (trigger)))]
+    (is (= :publication/failed (:receipt/type receipt)))
+    (is (true? (:failure/drift? receipt)))
+    (is (= :knoxx.docs/probe-es (:correlation/publication receipt)))
+    (is (= 1 (count @receipts)))))
+
+;; ── Idempotency ────────────────────────────────────────────────────────────
+
+(deftest ^:async repeating-a-trigger-publishes-once
+  ;; Not the same claim as the noop test. That one proves the *planner* sees
+  ;; convergence; this one proves the idempotency store refuses a second
+  ;; publish of the same operation even when the planner is asked for one,
+  ;; which is what a retry after a lost response actually looks like.
+  (let [{:keys [reconciler target]} (fixture)
+        first-run (await (reconciler/reconcile! reconciler (trigger)))
+        ;; A different trigger id, so nothing is deduplicated by correlation —
+        ;; the operation identity has to be what stops the second publish.
+        second-run (await (reconciler/reconcile! reconciler (trigger :id :test/retry)))]
+    (testing "both triggers answer with a receipt"
+      (is (= :publication/materialized (:receipt/type first-run)))
+      (is (some? (:receipt/type second-run))))
+
+    (testing "the adapter published exactly once"
+      (is (= 1 (memory/materialization-count target)))
+      (is (= 1 (count (memory/public-routes target)))))
+
+    (testing "and the second answer is correlated to its own trigger"
+      (is (= :test/retry (:correlation/trigger second-run))))))
+
+;; ── Receipts are evidence, never authority ─────────────────────────────────
+
+(deftest ^:async a-failed-effect-leaves-desired-state-byte-identical
+  ;; Drift is reported, never repaired by moving the goalposts. If a failure
+  ;; could edit resources, the next run would converge on the damage.
+  (let [{:keys [reconciler resources]} (fixture :fail? true)
+        before @resources
+        _ (await (reconciler/reconcile! reconciler (trigger)))]
+    (is (= before @resources))))
+
+(deftest ^:async no-number-of-triggers-talks-past-a-review-blocker
+  ;; The blocker is evidential, so it cannot be worn down by repetition — and a
+  ;; receipt recording that it blocked must not become the evidence that
+  ;; unblocks it.
+  (let [{:keys [reconciler receipts target]}
+        (fixture :facts (evidence-facts :approved? false))]
+    (doseq [_ (range 3)]
+      (await (reconciler/reconcile! reconciler (trigger))))
+    (testing "every attempt is blocked for the same reason"
+      (is (= 3 (count @receipts)))
+      (is (every? #(= :publication/blocked (:receipt/type %)) @receipts))
+      (is (every? #(= [:translation-review-required] (vec (:blockers %))) @receipts)))
+
+    (testing "and nothing was ever published"
+      (is (= 0 (memory/materialization-count target)))
+      (is (empty? (memory/public-routes target))))))
+
+(deftest ^:async a-missing-translation-blocks-publication
+  (let [{:keys [reconciler target]}
+        (fixture :facts (evidence-facts :translated? false))
+        receipt (await (reconciler/reconcile! reconciler (trigger)))]
+    (is (= :publication/blocked (:receipt/type receipt)))
+    (is (= [:translation-missing] (vec (:blockers receipt))))
+    (is (= 0 (memory/materialization-count target)))))
+
+(deftest ^:async an-unresolvable-source-revision-blocks-before-any-lookup
+  (let [{:keys [reconciler target]}
+        (fixture :facts (evidence-facts :unresolvable-revision? true))
+        receipt (await (reconciler/reconcile! reconciler (trigger)))]
+    (testing "no revision means no evidence can be keyed, so it blocks"
+      (is (= :publication/blocked (:receipt/type receipt)))
+      (is (= [:publication-revision-unresolved] (vec (:blockers receipt)))))
+    (is (= 0 (memory/materialization-count target)))))
+
+;; ── The trigger itself ─────────────────────────────────────────────────────
+
+(deftest ^:async an-unknown-publication-is-not-a-receipt-outcome
+  ;; The trigger names desired state that does not exist. There is nothing to
+  ;; record a receipt about, and inventing one would put a publication id into
+  ;; the evidence stream that no resource declares.
+  (let [{:keys [reconciler receipts]} (fixture)]
+    (is (thrown? js/Error
+                 (await (reconciler/reconcile!
+                         reconciler
+                         (assoc (trigger) :publication/id :knoxx.docs/nope)))))
+    (is (empty? @receipts))))
+
+(deftest ^:async a-malformed-trigger-is-refused-before-desired-state-is-loaded
+  (let [loads (atom 0)
+        {:keys [reconciler]} (fixture :load-index! (fn []
+                                                     (swap! loads inc)
+                                                     (js/Promise.resolve (index))))]
+    (doseq [[label bad] [["no origin" (dissoc (trigger) :trigger/origin)]
+                         ["no publication" (dissoc (trigger) :publication/id)]
+                         ["unqualified id" (assoc (trigger) :publication/id :probe)]
+                         ["extra field" (assoc (trigger) :sneaky "x")]]]
+      (testing label
+        (is (thrown? js/Error (await (reconciler/reconcile! reconciler bad))))))
+    (testing "not one of them reached desired state"
+      (is (= 0 @loads)))))
+
+(deftest an-incomplete-bundle-is-refused-at-construction
+  ;; Refused when the reconciler is built, not halfway through a run: a missing
+  ;; artifact source surfaces as fake drift and a missing sink as evidence that
+  ;; vanished, and both are far from the line that caused them.
+  (let [complete {:registry (registry/make-registry
+                             declarations
+                             {:publication-target/memory
+                              (constantly (:target (memory/memory-target {:id target-id})))})
+                  :store (:store (memory/memory-store))
+                  :load-index! (fn [])
+                  :evidence-facts (fn [_])
+                  :artifact-source (fn [_ _])
+                  :locale-admissible? (fn [_ _ _])
+                  :emit-receipt! (fn [_])}]
+    (testing "the complete bundle builds"
+      (is (some? (reconciler/make-reconciler complete))))
+
+    (doseq [k [:load-index! :evidence-facts :artifact-source
+               :locale-admissible? :emit-receipt!]]
+      (testing (str "missing " k)
+        (is (thrown? js/Error (reconciler/make-reconciler (dissoc complete k))))))
+
+    (testing "missing registry"
+      (is (thrown? js/Error (reconciler/make-reconciler (dissoc complete :registry)))))
+
+    (testing "missing idempotency store"
+      (is (thrown? js/Error (reconciler/make-reconciler (dissoc complete :store)))))))
+
+(deftest ^:async an-incomplete-evidence-provider-fails-with-the-missing-key
+  ;; Rather than as an arity error on nil somewhere inside the gate.
+  (let [{:keys [reconciler receipts]}
+        (fixture :facts (fn [_] {:current-source-revision (constantly revision)}))
+        receipt (await (reconciler/reconcile! reconciler (trigger)))]
+    (testing "it surfaces as a failed receipt naming the defect"
+      (is (= :publication/failed (:receipt/type receipt)))
+      (is (re-find #"evidence facts are incomplete" (:failure/reason receipt))))
+    (is (= 1 (count @receipts)))))

--- a/backend/test/cljs/knoxx/backend/law/publication_reconciler_test.cljs
+++ b/backend/test/cljs/knoxx/backend/law/publication_reconciler_test.cljs
@@ -1,0 +1,45 @@
+(ns knoxx.backend.law.publication-reconciler-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [knoxx.backend.law.publication-reconciler :as law]))
+
+(def ^:private valid-trigger
+  {:trigger/id :test/reconcile
+   :trigger/origin :route
+   :publication/id :knoxx.docs/probe-es})
+
+(deftest trigger-contract-admits-one-lawful-demand
+  (is (= valid-trigger (law/assert-trigger! valid-trigger))))
+
+(deftest trigger-contract-refuses-undeclared-or-missing-data
+  (doseq [[label trigger]
+          [["missing publication" (dissoc valid-trigger :publication/id)]
+           ["missing origin" (dissoc valid-trigger :trigger/origin)]
+           ["undeclared field" (assoc valid-trigger :trigger/note "hi")]
+           ["unknown origin" (assoc valid-trigger :trigger/origin :carrier-pigeon)]
+           ["unqualified publication id"
+            (assoc valid-trigger :publication/id :probe-es)]
+           ["unqualified trigger id"
+            (assoc valid-trigger :trigger/id "test/reconcile")]]]
+    (testing label
+      (is (thrown? js/Error (law/assert-trigger! trigger))))))
+
+(deftest correlation-carries-trigger-publication-and-revision
+  (is (= {:correlation/trigger :test/reconcile
+          :correlation/origin :route
+          :correlation/publication :knoxx.docs/probe-es
+          :correlation/revision "rev-1"}
+         (law/correlation valid-trigger "rev-1")))
+  (testing "a plan that never resolved a revision records nil, not an invention"
+    (is (nil? (:correlation/revision (law/correlation valid-trigger nil)))))
+  (testing "a blank revision is not a revision"
+    (is (thrown? js/Error (law/correlation valid-trigger "  ")))))
+
+(deftest correlate-stamps-and-validates
+  (let [receipt {:receipt/type :publication/noop :reason :publication-not-public}
+        correlation (law/correlation valid-trigger "rev-1")
+        stamped (law/correlate receipt correlation)]
+    (is (= :publication/noop (:receipt/type stamped)))
+    (is (= "rev-1" (:correlation/revision stamped)))
+    (is (= :knoxx.docs/probe-es (:correlation/publication stamped)))
+    (is (thrown? js/Error
+                 (law/correlate receipt (dissoc correlation :correlation/trigger))))))


### PR DESCRIPTION
> Card: `knoxx-publication-reconciler-runtime` (P1, `ready`)
> Parent epic: `knoxx-translated-publication-to-website`

## Problem

The publication epic's planner, gate, effects, receipts and adapters have all been merged — and nothing calls them. `docs/review/publication-epic-review-findings.md` records exactly that: they are libraries without a production caller. The card's own wording asks for *"an explicit trigger integration (event, scheduled job, or authorized runtime route) rather than a library function that no production path calls."*

This is the caller.

## What lands

- **`law.publication-reconciler`** — the trigger contract and the correlation every receipt from one trigger carries. Portable (`.cljc`), so any channel validates the same shape and the runtime never has to trust a channel's decoding. `:trigger/origin` is fixed by the channel, never read from caller data.

- **`infra.publication-reconciler`** — loads desired state fresh, resolves the declared target through the registry, observes *that* target in *this* run, plans purely, executes through the registry, and emits exactly one validated, correlated receipt per trigger. No path attempts an effect and records nothing; no path records a materialization an adapter did not confirm.

  Observation is runtime-owned on purpose: the planner must compare desired state against what the same adapter reports in the same run, or convergence is decided against a rumor. Translation and review evidence is provider-supplied — the runtime does not know where those receipts live and must not guess.

- **`infra.routes.publication-reconcile`** — `POST /api/publications/reconcile` and `GET /api/publications/receipts`, both authorized (`org.publications.manage` / `org.publications.read`), registered in `routes.app`. Unconfigured answers 503 — loudly absent rather than silently unable to publish. Misconfigured throws at the first request, because that is an operator defect.

## A real defect this surfaced

`publication-projection-keys` dropped `:publication/target`. Every loaded intent was untargeted, so no registry lookup could ever have succeeded. Fixed here — it is declared desired state and it projects.

## Tests

Integration, not unit, because that is what the card asks for and the unit halves were proven months ago. Every test drives `reconcile!` over a real registry, store, planner and adapter.

| DoD item | test |
| --- | --- |
| planning precedes adapter effects | `planning-happens-before-any-adapter-effect` wraps the planner and asks the adapter what it has published *at plan time*; also `a-blocked-plan-never-reaches-the-artifact-source` |
| materialization / noop / blocker / removal / adapter failure each produce a receipt with correlation | five tests, each asserting receipt type, the correlation triple, and the emitted count |
| a retry preserves idempotency, no duplicate publication | `repeating-a-trigger-publishes-once`, using a **different trigger id** so operation identity — not correlation — has to be what stops it |
| a receipt cannot mutate desired state or bypass a blocker | `a-failed-effect-leaves-desired-state-byte-identical`, `no-number-of-triggers-talks-past-a-review-blocker` |

Plus: malformed triggers refused before desired state is loaded (verified by counting loads), unknown publication throws rather than inventing a receipt, incomplete bundle refused at construction, incomplete evidence provider surfaces as a failed receipt naming the missing key.

## Verification

- `pnpm -C backend exec shadow-cljs compile test` — **1209 tests, 4522 assertions, 0 failures, 0 errors, 0 compiler warnings**
- `pnpm -C backend run typecheck` — clean
- `pnpm -C backend run boundary:check` — clean
- `clj-kondo` — 0 errors, 0 warnings on every file added

## Not in scope

Durable receipt persistence. The default sink is a bounded in-memory journal and `receipt-journal-limit`'s docstring says so rather than letting a restart look like a clean slate; a durable sink is a store decision this card does not take.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added publication reconciliation through authorized API endpoints.
  - Reconciliation now evaluates desired publication state, validates targets and evidence, applies eligible changes, and records correlated receipts.
  - Added receipt retrieval for reviewing reconciliation outcomes, including successful changes, no-ops, removals, review blocks, and failures.
  - Added trigger validation and clear handling for unavailable configuration or unknown publications.

- **Bug Fixes**
  - Publication target information is now preserved through reconciliation, enabling downstream target-specific processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->