### PR TITLE
feat(mcp): declare /mcp authentication methods as a contract

### DIFF
--- a/backend/src/cljs/knoxx/backend/domain/contracts/loader.cljs
+++ b/backend/src/cljs/knoxx/backend/domain/contracts/loader.cljs
@@ -13,7 +13,7 @@
 ;; ── Constants ──────────────────────────────────────────────────────────────
 
 (def contract-class-order
-  ["agents" "actors" "roles" "capabilities" "policies"
+  ["agents" "actors" "roles" "capabilities" "policies" "authentication"
    "generators" "schedules" "source_modes" "sources" "model_families" "models" "runtime_features" "ingest_sources" "actions" "triggers" "stores" "sub_agents" "cms" "documents" "gardens" "publications"])
 
 ;; ── Predicates ─────────────────────────────────────────────────────────────
@@ -83,6 +83,7 @@
       ("role" "roles") "roles"
       ("cap" "caps" "capability" "capabilities") "capabilities"
       ("policy" "policies") "policies"
+      ("auth" "authentication" "auth-method" "auth-methods" "auth_method" "auth_methods") "authentication"
       ("generator" "generators") "generators"
       ("schedule" "schedules") "schedules"
       ("source-mode" "source-modes" "source_mode" "source_modes") "source_modes"

--- a/backend/src/cljs/knoxx/backend/extern/fastify.cljs
+++ b/backend/src/cljs/knoxx/backend/extern/fastify.cljs
@@ -90,6 +90,18 @@
   [request]
   (or (aget request "hostname") "localhost"))
 
+(defn request-remote-address
+  "The peer address Fastify saw, as a string, or nil.
+
+   request.ip is Fastify's own resolution and is preferred; the raw socket is
+   the fallback for a request that never went through Fastify's ip getter, such
+   as one built by a test or replayed onto the raw server."
+  [request]
+  (let [ip (or (aget request "ip")
+               (some-> request (aget "raw") (aget "socket") (aget "remoteAddress"))
+               (some-> request (aget "socket") (aget "remoteAddress")))]
+    (when (string? ip) ip)))
+
 (defn reply-header!
   [reply name value]
   (.header reply name value))

--- a/backend/src/cljs/knoxx/backend/extern/node_env.cljs
+++ b/backend/src/cljs/knoxx/backend/extern/node_env.cljs
@@ -1,0 +1,23 @@
+(ns knoxx.backend.extern.node-env
+  "The process environment boundary.
+
+  `js/process.env` is a JavaScript object and reading it needs `aget`, which the
+  style guide confines to `extern.*`. This adapter owns that read and hands back
+  a CLJS scalar, so infrastructure code asking whether a variable is set never
+  touches interop to find out.
+
+  Sibling to `extern.node-fs`, which owns `node:fs` for the same reason. It is
+  deliberately read-only: nothing in Knoxx should be mutating its own
+  environment at runtime, and an adapter that cannot write is a boundary that
+  cannot be misused."
+  (:require [clojure.string :as str]))
+
+(defn variable
+  "The trimmed value of environment variable `name`, or nil.
+
+   Nil for absent, empty and whitespace-only alike. That collapse is deliberate:
+   every caller here treats a blank variable as unset — a deployment that writes
+   `FOO=` means the same thing as one that omits `FOO`, and a sentinel of spaces
+   should never be mistaken for a configured secret."
+  [name]
+  (some-> (aget js/process.env name) str str/trim not-empty))

--- a/backend/src/cljs/knoxx/backend/infra/auth/method_config.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/auth/method_config.cljs
@@ -14,15 +14,20 @@
   (:require [clojure.string :as str]
             [knoxx.backend.domain.contracts.loader :as contracts]
             [knoxx.backend.extern.fastify :as fastify]
+            [knoxx.backend.extern.node-env :as node-env]
             [knoxx.backend.law.auth-methods :as law]))
 
 (def mcp-surface :mcp)
 
 (def ^:private mcp-contract-id "mcp_http")
 
-(defn- env
-  [k]
-  (some-> (aget js/process.env k) str str/trim not-empty))
+(def ^:private env
+  "Read through the extern adapter that owns `js/process.env`.
+
+   Direct `aget` on `js/process.env` is interop, and the style guide keeps
+   interop inside `extern.*`. `extern.node-env/variable` returns a CLJS scalar,
+   so nothing here has to know the environment is a JavaScript object."
+  node-env/variable)
 
 (defn- production?
   []

--- a/backend/src/cljs/knoxx/backend/infra/auth/method_config.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/auth/method_config.cljs
@@ -1,0 +1,113 @@
+(ns knoxx.backend.infra.auth.method-config
+  "Load the authentication contract for a surface and gather the facts law needs.
+
+   law.auth-methods owns every decision; this namespace owns the effects those
+   decisions need — reading the contract off disk, reading the token out of the
+   environment the contract names, asking Fastify who the peer is — and the
+   shape of the principal a non-OAuth method produces.
+
+   That principal is deliberately indistinguishable downstream from a token
+   record loaded out of Mongo. Nothing after this point knows which method
+   admitted the request, which is the point: an e2e test exercises the shipped
+   serving path rather than a parallel one that could pass while production
+   fails."
+  (:require [clojure.string :as str]
+            [knoxx.backend.domain.contracts.loader :as contracts]
+            [knoxx.backend.extern.fastify :as fastify]
+            [knoxx.backend.law.auth-methods :as law]))
+
+(def mcp-surface :mcp)
+
+(def ^:private mcp-contract-id "mcp_http")
+
+(defn- env
+  [k]
+  (some-> (aget js/process.env k) str str/trim not-empty))
+
+(defn- production?
+  []
+  (= "production" (some-> (env "NODE_ENV") str/lower-case)))
+
+(defn contract-for
+  "The authentication contract for `surface`, or nil.
+
+   A missing or unreadable contract is nil rather than a throw: law refuses on
+   nil, so the surface falls back to OAuth-only. Losing the ability to serve
+   /mcp because a contract file was mid-edit would be a worse failure than
+   ignoring it."
+  [config surface]
+  (when (= mcp-surface surface)
+    (try
+      (contracts/contract-sync config "authentication" mcp-contract-id)
+      (catch :default err
+        (.warn js/console "[knoxx-auth] authentication contract unreadable; OAuth only" err)
+        nil))))
+
+(defn method-enabled?
+  "True when `surface` accepts `method-id` under the current contract."
+  [config surface method-id]
+  (law/method-enabled? (contract-for config surface) surface method-id))
+
+(defn- request-facts
+  [request method-token-env]
+  {:configured-token (some-> method-token-env env)
+   :presented-token  nil
+   :remote-address   (fastify/request-remote-address request)
+   :production?      (production?)})
+
+(defn- token-env-for
+  [contract surface]
+  (some->> (law/enabled-methods contract surface)
+           (some #(when (= :trusted-loopback (:auth-method/id %)) %))
+           :auth-method/token-env))
+
+(defn trusted-loopback-grant
+  "The grant admitting this request under :trusted-loopback, or nil.
+
+   Returns law's decision unchanged. The token is read from whichever env var
+   the contract names, so which secret opens the door is part of the reviewable
+   configuration rather than a constant compiled into this file."
+  [config surface request presented-token]
+  (let [contract (contract-for config surface)]
+    (when-let [token-env (token-env-for contract surface)]
+      (law/trusted-loopback-grant
+       contract surface
+       (assoc (request-facts request token-env) :presented-token presented-token)))))
+
+(defn grant->token-record
+  "A token record for `grant`, shaped like one minted through OAuth.
+
+   `available-tool-names` is the catalog this request could reach; a :all grant
+   resolves to it. The result still passes through granted-tools, which
+   intersects it with what the resolved membership may use — so this widens
+   consent, never authorization.
+
+   membershipId is absent rather than blank: the context resolves by email
+   here, and a blank id would be sent as a membership that matches nothing.
+   actorId is present only when the contract names one, so a method that grants
+   no actor produces a record call-actor-id treats as carrying none — and
+   credential-backed tools then fail for want of an actor instead of borrowing
+   whichever actor the membership happens to hold."
+  [grant available-tool-names]
+  (let [granted (if (= :all (:tools grant))
+                  (vec available-tool-names)
+                  (filterv (set available-tool-names) (:tools grant)))]
+    (clj->js (cond-> {:accessToken "authentication-contract"
+                      :clientId    "knoxx-authentication-contract"
+                      :userEmail   (:user-email grant)
+                      :tools       granted}
+               (:org-slug grant) (assoc :orgSlug (:org-slug grant))
+               (:actor-id grant) (assoc :actorId (:actor-id grant))))))
+
+(defn announce!
+  "Log once, at startup, whenever a surface accepts anything but OAuth.
+
+   A silently-open authentication method is a bug even when every guard around
+   it holds, and the contract is a file somebody has to think to open."
+  [config surface]
+  (doseq [method (law/enabled-methods (contract-for config surface) surface)
+          :when (not= :oauth-bearer (:auth-method/id method))]
+    (.warn js/console
+           (str "[knoxx-auth] surface " surface " accepts " (:auth-method/id method)
+                " — see contracts/authentication/" mcp-contract-id ".edn"
+                (when-let [e (:auth-method/token-env method)] (str " (token from " e ")"))))))

--- a/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
+++ b/backend/src/cljs/knoxx/backend/infra/routes/mcp.cljs
@@ -6,6 +6,7 @@
             [knoxx.backend.shape.app-shapes :refer [route!]]
             [knoxx.backend.infra.actor.acting :as actor-acting]
             [knoxx.backend.infra.auth.authz :as authz]
+            [knoxx.backend.infra.auth.method-config :as auth-methods]
             [knoxx.backend.infra.auth.session :as auth-session]
             [knoxx.backend.infra.db.policy :as db-policy]
             [knoxx.backend.infra.routes.mcp.consent :as consent]
@@ -627,6 +628,26 @@
     (transport/ensure-streamable-accept! request)
     (transport/handle-request! transport raw-req raw-res (aget request "body"))))
 
+(defn- ^:async resolve-post-token-record!
+  "The token record this POST acts under, or nil to refuse it.
+
+   Which methods may answer here is the authentication contract's decision, not
+   this route's. :trusted-loopback is consulted first and only ever answers for
+   a request auth-methods already accepted under the guards the contract
+   declares; when no contract enables it, the call is a nil and the bearer
+   falls through to the OAuth store exactly as before.
+
+   A grant becomes an ordinary token record, so everything downstream — context
+   resolution, granted-tools, actor scoping, the transport — cannot tell which
+   method admitted the caller."
+  [request runtime config bearer]
+  (when-not (str/blank? bearer)
+    (if-let [grant (auth-methods/trusted-loopback-grant
+                    config auth-methods/mcp-surface request bearer)]
+      (auth-methods/grant->token-record
+       grant (tool-name-set (available-tools runtime config nil)))
+      (await (load-token-record! bearer)))))
+
 (defroute mcp-handle-post! [base config runtime code-ttl token-ttl policy-db McpServer StreamableHTTPServerTransport z] "POST" "/mcp" []
   (let [^js request request
         ^js reply reply]
@@ -635,8 +656,7 @@
           ^js raw-res (aget reply "raw")
           bearer      (transport/bearer-token request)]
       (try
-        (let [token-record (when-not (str/blank? bearer)
-                             (await (load-token-record! bearer)))]
+        (let [token-record (await (resolve-post-token-record! request runtime config bearer))]
           (if-not token-record
             (transport/unauthorized! base raw-res)
             (await (serve-mcp-post!
@@ -689,5 +709,6 @@
               :z                             z
               :code-ttl  code-ttl
               :token-ttl token-ttl}]
+    (auth-methods/announce! config auth-methods/mcp-surface)
     (doseq [register! route-registrars]
       (register! app runtime config deps))))

--- a/backend/src/cljs/knoxx/backend/law/auth_methods.cljs
+++ b/backend/src/cljs/knoxx/backend/law/auth_methods.cljs
@@ -1,0 +1,111 @@
+(ns knoxx.backend.law.auth-methods
+  "Which authentication method, if any, admits a request to a surface.
+
+   The contract under contracts/authentication/ says what is allowed; this
+   namespace decides whether a particular request satisfies it. Both halves are
+   data-in, data-out: no env, no socket, no clock. infra.auth.method-config
+   reads those and hands the facts in.
+
+   Fail closed everywhere. An absent contract, an unparseable one, a method
+   with no grant, a method whose guards are not satisfied — every one of them
+   is a refusal, because the failure mode on the other side is an open MCP
+   surface that nobody reading the repository can see is open."
+  (:require [clojure.string :as str]))
+
+(def loopback-addresses
+  "Addresses that mean the caller shares this machine.
+
+   ::ffff:127.0.0.1 is the IPv4-mapped form Node reports on a dual-stack
+   listener; omitting it would refuse the ordinary `curl localhost` case."
+  #{"127.0.0.1" "::1" "::ffff:127.0.0.1" "localhost"})
+
+(def default-min-token-length
+  "Floor for a shared-secret token when the contract names none.
+
+   A one-character token turns a trusted method into something a stray
+   Authorization header reaches by accident."
+  8)
+
+(defn loopback-address?
+  "True when `address` names this machine."
+  [address]
+  (contains? loopback-addresses (-> (str (or address "")) str/trim str/lower-case)))
+
+(defn- enabled?
+  [method]
+  (true? (:auth-method/enabled method)))
+
+(defn methods-for-surface
+  "Every method the contract declares for `surface`, enabled or not."
+  [contract surface]
+  (if (= surface (:auth/surface contract))
+    (vec (:auth/methods contract))
+    []))
+
+(defn enabled-methods
+  "The methods `surface` currently accepts."
+  [contract surface]
+  (filterv enabled? (methods-for-surface contract surface)))
+
+(defn method-enabled?
+  "True when `surface` accepts `method-id`."
+  [contract surface method-id]
+  (boolean (some #(= method-id (:auth-method/id %)) (enabled-methods contract surface))))
+
+(defn- normalize-grant-tools
+  [tools]
+  (cond
+    (= :all tools) :all
+    (sequential? tools) (into [] (comp (map str) (map str/trim) (remove str/blank?)) tools)
+    :else nil))
+
+(defn grant-of
+  "The principal a method hands to a request it accepts, or nil.
+
+   nil for a method that grants nothing. A method that authenticates callers
+   and names no identity would resolve a blank membership — a valid credential
+   carrying no authorization — so it is treated as misconfigured rather than
+   permissive."
+  [method]
+  (let [grants (:auth-method/grants method)
+        email  (some-> (:grant/user-email grants) str str/trim not-empty)
+        tools  (normalize-grant-tools (:grant/tools grants))]
+    (when (and email tools)
+      (cond-> {:user-email email :tools tools}
+        (some-> (:grant/org-slug grants) str str/trim not-empty)
+        (assoc :org-slug (str/trim (:grant/org-slug grants)))
+        (some-> (:grant/actor-id grants) str str/trim not-empty)
+        (assoc :actor-id (str/trim (:grant/actor-id grants)))))))
+
+(defn- token-satisfied?
+  [method {:keys [configured-token presented-token]}]
+  (let [minimum   (or (:auth-method/min-token-length method) default-min-token-length)
+        configured (str/trim (str (or configured-token "")))
+        presented  (str/trim (str (or presented-token "")))]
+    (and (>= (count configured) minimum)
+         (= configured presented))))
+
+(defn- guards-satisfied?
+  [method {:keys [remote-address production?] :as request}]
+  (and (or (not (:auth-method/require-non-production method))
+           (not production?))
+       (or (not (:auth-method/require-loopback method))
+           (loopback-address? remote-address))
+       (token-satisfied? method request)))
+
+(defn trusted-loopback-grant
+  "The grant admitting this request under :trusted-loopback, or nil.
+
+   `request` carries {:configured-token :presented-token :remote-address
+   :production?}. Every guard the method declares must hold, and the method
+   must be enabled on this surface at all.
+
+   Compared with `=` rather than a constant-time equality: a method that
+   requires loopback is already refused for anyone not on this machine, and a
+   party who can time responses on our own loopback interface can read the
+   token's source directly."
+  [contract surface request]
+  (when-let [method (->> (enabled-methods contract surface)
+                         (some #(when (= :trusted-loopback (:auth-method/id %)) %)))]
+    (when (guards-satisfied? method request)
+      (grant-of method))))

--- a/backend/src/cljs/knoxx/backend/law/contracts.cljs
+++ b/backend/src/cljs/knoxx/backend/law/contracts.cljs
@@ -142,6 +142,46 @@
    [:policy/required {:optional true} [:vector PolicyCheck]]
    [:policy/checked-by {:optional true} keyword?]])
 
+(def AuthenticationMethod
+  "One way a surface may authenticate a caller.
+
+   :auth-method/grants is what the method hands to the request when it accepts:
+   the identity calls resolve under and the tools they may reach. A method that
+   accepts callers but grants nothing is a configuration mistake rather than a
+   safe default, so a grant is required of anything enabled."
+  [:map {:closed false}
+   [:auth-method/id [:enum :oauth-bearer :trusted-loopback]]
+   [:auth-method/enabled {:optional true} boolean?]
+   [:auth-method/doc {:optional true} string?]
+   ;; Only meaningful for :trusted-loopback. Named rather than assumed, so a
+   ;; reader of the contract can see that the guard exists and is on.
+   [:auth-method/require-loopback {:optional true} boolean?]
+   [:auth-method/require-non-production {:optional true} boolean?]
+   [:auth-method/token-env {:optional true} string?]
+   [:auth-method/min-token-length {:optional true} [:int {:min 1}]]
+   [:auth-method/grants {:optional true}
+    [:map {:closed false}
+     [:grant/user-email {:optional true} string?]
+     [:grant/org-slug {:optional true} string?]
+     [:grant/actor-id {:optional true} string?]
+     ;; :all is the only wildcard, and it is still intersected with what the
+     ;; resolved membership can reach — a grant is not an authorization.
+     [:grant/tools {:optional true} [:or [:= :all] [:vector string?]]]]]])
+
+(def AuthenticationContract
+  "Which authentication methods a surface accepts.
+
+   Exists so the answer is reviewable data rather than a scattering of env
+   reads: before this, whether an unauthenticated local caller could reach /mcp
+   was a property of process environment, invisible to anyone reading the
+   repository. A surface with no contract accepts only :oauth-bearer."
+  [:map {:closed false}
+   [:contract/kind [:= :authentication]]
+   [:contract/id ContractId]
+   [:contract/doc {:optional true} string?]
+   [:auth/surface [:enum :mcp]]
+   [:auth/methods [:vector AuthenticationMethod]]])
+
 (def ModelFamilyContract
   [:map {:closed false}
    [:model-family/id string?]
@@ -390,6 +430,7 @@
   [value]
   (case (:contract/kind value)
     :policy "policies"
+    :authentication "authentication"
     :sub-agent "sub_agents"
     :action "actions"
     :pipeline "pipelines"
@@ -438,6 +479,7 @@
     "roles" RoleContract
     "capabilities" CapabilityContract
     "policies" PolicyContract
+    "authentication" AuthenticationContract
     "generators" GeneratorContract
     "schedules" ScheduleContract
     "source_modes" SourceModeContract

--- a/backend/test/cljs/knoxx/backend/extern_node_env_test.cljs
+++ b/backend/test/cljs/knoxx/backend/extern_node_env_test.cljs
@@ -1,0 +1,44 @@
+(ns knoxx.backend.extern-node-env-test
+  "Regression coverage for the process-environment conversion.
+
+  Required of a new extern adapter by AGENTS.md: the point of the boundary is
+  that a JavaScript value becomes a CLJS scalar, so the conversion itself is
+  what gets pinned."
+  (:require [cljs.test :refer [deftest is testing]]
+            [knoxx.backend.extern.node-env :as node-env]))
+
+(defn- with-env
+  "Set `name` to `value` for the duration of `f`, restoring whatever was there.
+
+   `js-delete` rather than assigning nil: assigning nil to process.env produces
+   the STRING \"null\", which is exactly the kind of JavaScript truth this
+   adapter exists to keep out of the rest of the codebase."
+  [name value f]
+  (let [previous (aget js/process.env name)]
+    (try
+      (if (nil? value)
+        (js-delete js/process.env name)
+        (aset js/process.env name value))
+      (f)
+      (finally
+        (if (nil? previous)
+          (js-delete js/process.env name)
+          (aset js/process.env name previous))))))
+
+(deftest variable-returns-a-cljs-scalar-or-nil
+  (testing "a set variable comes back as a trimmed string"
+    (with-env "KNOXX_TEST_NODE_ENV" "  a-value  "
+      #(is (= "a-value" (node-env/variable "KNOXX_TEST_NODE_ENV")))))
+
+  (testing "absent, empty and whitespace-only all collapse to nil"
+    ;; The collapse every caller depends on: a deployment writing FOO= means the
+    ;; same as one omitting FOO, and a sentinel of spaces is not a secret.
+    (with-env "KNOXX_TEST_NODE_ENV" nil
+      #(is (nil? (node-env/variable "KNOXX_TEST_NODE_ENV"))))
+    (with-env "KNOXX_TEST_NODE_ENV" ""
+      #(is (nil? (node-env/variable "KNOXX_TEST_NODE_ENV"))))
+    (with-env "KNOXX_TEST_NODE_ENV" "   \t "
+      #(is (nil? (node-env/variable "KNOXX_TEST_NODE_ENV")))))
+
+  (testing "a name that was never set is nil rather than an error"
+    (is (nil? (node-env/variable "KNOXX_TEST_NAME_THAT_IS_NOT_SET")))))

--- a/backend/test/cljs/knoxx/backend/law/auth_methods_test.cljs
+++ b/backend/test/cljs/knoxx/backend/law/auth_methods_test.cljs
@@ -1,0 +1,154 @@
+(ns knoxx.backend.law.auth-methods-test
+  "Every way the authentication contract must refuse.
+
+   The e2e suite proves the rule works over a socket; these prove it refuses,
+   one reason per test, without needing a server. A rule that decides whether
+   an unauthenticated caller reaches the tool surface deserves both."
+  (:require [cljs.test :refer [deftest is testing]]
+            [knoxx.backend.law.auth-methods :as law]))
+
+(def ^:private token "e2e-loopback-token")
+
+(defn- contract
+  "The e2e-shaped contract, with `overrides` merged into its loopback method."
+  ([] (contract {}))
+  ([overrides]
+   {:contract/kind :authentication
+    :contract/id "mcp_http"
+    :auth/surface :mcp
+    :auth/methods
+    [{:auth-method/id :oauth-bearer :auth-method/enabled true}
+     (merge {:auth-method/id :trusted-loopback
+             :auth-method/enabled true
+             :auth-method/require-loopback true
+             :auth-method/require-non-production true
+             :auth-method/token-env "KNOXX_E2E_LOOPBACK_TOKEN"
+             :auth-method/min-token-length 8
+             :auth-method/grants {:grant/user-email "system-admin@open-hax.local"
+                                  :grant/actor-id "e2e_actor"
+                                  :grant/tools :all}}
+            overrides)]}))
+
+(defn- request
+  [overrides]
+  (merge {:configured-token token
+          :presented-token  token
+          :remote-address   "127.0.0.1"
+          :production?      false}
+         overrides))
+
+(deftest loopback-address?-test
+  (testing "every form Node reports for this machine"
+    (is (law/loopback-address? "127.0.0.1"))
+    (is (law/loopback-address? "::1"))
+    (is (law/loopback-address? "::ffff:127.0.0.1"))
+    (is (law/loopback-address? "localhost"))
+    (is (law/loopback-address? "  127.0.0.1  ") "whitespace is not a distinct address")
+    (is (law/loopback-address? "LOCALHOST") "case is not a distinct address"))
+
+  (testing "anything else is a remote peer"
+    (is (not (law/loopback-address? "10.0.0.4")))
+    (is (not (law/loopback-address? "127.0.0.1.evil.example")))
+    (is (not (law/loopback-address? "::ffff:10.0.0.4")))
+    (is (not (law/loopback-address? nil)))
+    (is (not (law/loopback-address? "")))))
+
+(deftest enabled-methods-test
+  (testing "a disabled method is not accepted"
+    (let [c (contract {:auth-method/enabled false})]
+      (is (law/method-enabled? c :mcp :oauth-bearer))
+      (is (not (law/method-enabled? c :mcp :trusted-loopback)))))
+
+  (testing "a method with no :auth-method/enabled key is not accepted"
+    (let [c (contract {:auth-method/enabled nil})]
+      (is (not (law/method-enabled? c :mcp :trusted-loopback))
+          "absence must not read as permission")))
+
+  (testing "a contract for another surface says nothing about this one"
+    (let [c (assoc (contract) :auth/surface :something-else)]
+      (is (empty? (law/enabled-methods c :mcp)))
+      (is (not (law/method-enabled? c :mcp :oauth-bearer)))))
+
+  (testing "no contract at all accepts nothing"
+    (is (empty? (law/enabled-methods nil :mcp)))
+    (is (not (law/method-enabled? nil :mcp :oauth-bearer)))))
+
+(deftest grant-of-test
+  (testing "a grant names an identity and a tool set"
+    (let [grant (law/grant-of (second (:auth/methods (contract))))]
+      (is (= "system-admin@open-hax.local" (:user-email grant)))
+      (is (= "e2e_actor" (:actor-id grant)))
+      (is (= :all (:tools grant)))))
+
+  (testing "a method granting no email grants nothing"
+    (is (nil? (law/grant-of {:auth-method/grants {:grant/tools :all}}))
+        "a blank identity is a valid bearer carrying no authorization"))
+
+  (testing "a method granting no tools grants nothing"
+    (is (nil? (law/grant-of {:auth-method/grants {:grant/user-email "a@b.c"}}))))
+
+  (testing "a method with no grants at all grants nothing"
+    (is (nil? (law/grant-of {:auth-method/id :trusted-loopback}))))
+
+  (testing "an explicit tool list is normalized, not passed through"
+    (is (= ["semantic_query" "graph_query"]
+           (:tools (law/grant-of {:auth-method/grants
+                                  {:grant/user-email "a@b.c"
+                                   :grant/tools ["semantic_query" "  " "graph_query"]}}))))))
+
+(deftest trusted-loopback-admits-a-satisfied-request-test
+  (is (some? (law/trusted-loopback-grant (contract) :mcp (request {}))))
+  (is (some? (law/trusted-loopback-grant (contract) :mcp (request {:remote-address "::1"}))))
+  (is (some? (law/trusted-loopback-grant (contract) :mcp
+                                         (request {:presented-token (str "  " token "  ")})))
+      "surrounding whitespace does not change the credential"))
+
+(deftest trusted-loopback-refuses-off-loopback-test
+  (testing "a remote caller is refused even holding the token"
+    (is (nil? (law/trusted-loopback-grant (contract) :mcp (request {:remote-address "10.0.0.4"}))))
+    (is (nil? (law/trusted-loopback-grant (contract) :mcp (request {:remote-address nil}))))
+    (is (nil? (law/trusted-loopback-grant (contract) :mcp (request {:remote-address ""})))))
+
+  (testing "a method that does not require loopback admits a remote caller"
+    (is (some? (law/trusted-loopback-grant (contract {:auth-method/require-loopback false})
+                                           :mcp (request {:remote-address "10.0.0.4"})))
+        (str "the guard is the contract's to declare — this is why the shipped "
+             "contract sets it, and why the e2e one does too"))))
+
+(deftest trusted-loopback-refuses-in-production-test
+  (is (nil? (law/trusted-loopback-grant (contract) :mcp (request {:production? true}))))
+  (is (some? (law/trusted-loopback-grant (contract {:auth-method/require-non-production false})
+                                          :mcp (request {:production? true})))
+      "a contract may opt out, but must say so explicitly"))
+
+(deftest trusted-loopback-refuses-bad-tokens-test
+  (testing "an unconfigured process cannot be admitted"
+    (is (nil? (law/trusted-loopback-grant (contract) :mcp
+                                          (request {:configured-token nil :presented-token nil}))))
+    (is (nil? (law/trusted-loopback-grant (contract) :mcp
+                                          (request {:configured-token "" :presented-token ""})))
+        "a blank config must not match a blank Authorization header"))
+
+  (testing "a configured token under the contract's floor is refused"
+    (is (nil? (law/trusted-loopback-grant (contract) :mcp
+                                          (request {:configured-token "short"
+                                                    :presented-token "short"})))))
+
+  (testing "a mismatched or partial token is refused"
+    (is (nil? (law/trusted-loopback-grant (contract) :mcp (request {:presented-token nil}))))
+    (is (nil? (law/trusted-loopback-grant (contract) :mcp (request {:presented-token ""}))))
+    (is (nil? (law/trusted-loopback-grant (contract) :mcp
+                                          (request {:presented-token (subs token 0 8)})))
+        "a prefix is not a match")
+    (is (nil? (law/trusted-loopback-grant (contract) :mcp
+                                          (request {:presented-token (str token "x")}))))))
+
+(deftest trusted-loopback-refuses-a-disabled-or-absent-method-test
+  (is (nil? (law/trusted-loopback-grant (contract {:auth-method/enabled false}) :mcp (request {})))
+      "disabled is refused even when every guard is satisfied")
+  (is (nil? (law/trusted-loopback-grant nil :mcp (request {})))
+      "no contract is refused")
+  (is (nil? (law/trusted-loopback-grant {:auth/surface :mcp :auth/methods []} :mcp (request {})))
+      "a contract declaring no methods is refused")
+  (is (nil? (law/trusted-loopback-grant (contract {:auth-method/grants nil}) :mcp (request {})))
+      "an enabled method that grants nothing is refused rather than permissive"))

--- a/contracts/AGENTS.md
+++ b/contracts/AGENTS.md
@@ -80,6 +80,7 @@ contracts/
   roles/          Role resources — role slug to capabilities/permissions
   capabilities/   Capability resources — capability id to tool/action surfaces
   policies/       Policy resources — invariants, guardrails, and denials
+  authentication/ Authentication resources — which methods a surface accepts
   generators/     Generator resources — event-producing provenance/adapters
   schedules/      Schedule resources — temporal rules that emit synthetic events
   actions/        Action resources — registered behavior and schemas

--- a/contracts/authentication/mcp_http.edn
+++ b/contracts/authentication/mcp_http.edn
@@ -1,0 +1,55 @@
+;; Which authentication methods the MCP Streamable HTTP surface accepts.
+;;
+;; This file is the whole answer. Before it existed, whether an unauthenticated
+;; local caller could reach /mcp was a property of process environment —
+;; invisible to anyone reading the repository, and impossible to assert on in a
+;; test. Adding a method here is a reviewable change; setting an env var was not.
+;;
+;; A method absent from this list is refused. So is a method present but not
+;; :auth-method/enabled, and so is an enabled method that grants no identity.
+{:contract/kind :authentication
+ :contract/id "mcp_http"
+ :contract/doc "Authentication methods accepted by POST /mcp."
+ :auth/surface :mcp
+
+ :auth/methods
+ [{:auth-method/id :oauth-bearer
+   :auth-method/enabled true
+   :auth-method/doc
+   "The shipped path: a token minted through /api/mcp/oauth/authorize and its
+    consent page, carrying the tools the user ticked and the actor they saw."}
+
+  ;; Permitted by contract, inert without a secret.
+  ;;
+  ;; Read :auth-method/enabled as "this deployment may use this method", not as
+  ;; "this method is live". law.auth-methods refuses unless a token of at least
+  ;; :min-token-length is configured in the named variable, so an image
+  ;; deployed without KNOXX_MCP_LOOPBACK_TOKEN has no second way in. Leaving
+  ;; that variable unset is the off switch, and it is off by default.
+  ;;
+  ;; :require-non-production is deliberately false, unlike everything else
+  ;; here. The post-deploy gate in services/knoxx/verify.sh must verify the
+  ;; production MCP surface, and it runs inside the backend container via
+  ;; `docker compose exec` — so it is on 127.0.0.1, which :require-loopback
+  ;; still enforces. The backend port is not published to the host, so nothing
+  ;; off-box can present this token even if it learned it.
+  ;;
+  ;; It is not an authorization bypass. The grant below is intersected with
+  ;; what the resolved membership can reach, so a tool deploy_verifier's roles
+  ;; deny stays denied.
+  {:auth-method/id :trusted-loopback
+   :auth-method/enabled true
+   :auth-method/doc
+   "The post-deploy verification gate, and local development. Inert unless
+    KNOXX_MCP_LOOPBACK_TOKEN is set on the backend process."
+   :auth-method/require-loopback true
+   :auth-method/require-non-production false
+   :auth-method/token-env "KNOXX_MCP_LOOPBACK_TOKEN"
+   :auth-method/min-token-length 16
+   :auth-method/grants
+   {:grant/user-email "system-admin@open-hax.local"
+    ;; The actor verification runs as. Naming one is what lets the gate reach
+    ;; credential-backed tools at all; leaving it out would make every Discord
+    ;; and Bluesky check refuse for want of an actor.
+    :grant/actor-id "deploy_verifier"
+    :grant/tools :all}}]}


### PR DESCRIPTION
The authentication half of #224, rebased onto current `main` and separated from the CLJS e2e suite that PR also carries.

#224 has been open since 2026-08-09 and is now 206 commits behind with five conflicting files. The two halves are independent, and only this one is load-bearing for a deploy — so this lands on its own.

## What it does

Which methods `POST /mcp` accepts is now `contracts/authentication/mcp_http.edn` rather than an environment variable nobody can see. `law.auth-methods` decides; `infra.auth.method-config` reads env and sockets. Everything fails closed: no contract, method absent, not enabled, no grant, or a guard unsatisfied are each a refusal. `:trusted-loopback` is permitted by contract but inert without a secret of at least `:min-token-length` in the named variable, so an image deployed without one has no second way in.

## Why now — this is currently breaking a deploy

`open-hax/services` already ships this contract in its deployed set. The running image cannot parse the class, so `domain.contracts.loader` throws `Unknown contract class: authentication`, the resource is recorded invalid with a nil kind, and the publication surfaces fail closed on **any** invalid resource — correctly, since an unparseable file cannot be proven irrelevant to publication.

The result: a file about MCP authentication made `/api/publications/documents` and `/api/publications/gardens` answer `invalid publication resources`. That has been worked around by removing the contract from the deployed set; **this PR is what lets it come back.**

## Two deliberate departures from #224

**The e2e suite is not here.** `backend/test/e2e/**`, the `:e2e` shadow build, the CI wiring, `docs/mcp-local-testing.md` and the `test-mcp.mjs` deletion are a separate concern that needs Docker in CI. They can land on their own without blocking a contract that unblocks a deploy. `infra.db.policy/get-actor-credential!`'s context dispatch is left behind for the same reason — it is a seam that harness needs, not something this contract uses.

**`normalize-contract-class` keeps its `case`** and simply gains the class. #224 rewrote it into a data table, which is a fine cleanup and is exactly why the file conflicted — but `main` has since added `documents`, `gardens` and `publications`, which that table predates and would have silently dropped. Two lines instead of forty, and no chance of losing a class in the merge.

## Verification

Run against a live instance on the real deployed contract set, with the authentication contract restored exactly as services shipped it:

- `/api/publications/documents` → **200** (was `invalid publication resources`)
- `[knoxx-auth] surface :mcp accepts :trusted-loopback — see contracts/authentication/mcp_http.edn`
- **0** `Unknown contract class` errors

Gates: **1244 tests / 4685 assertions, 0 failures**; server build **0 warnings**.

## Reviewer notes

- The 25 changed lines in `infra/routes/mcp.cljs` are the part with the least independent coverage — `auth_methods_test.cljs` covers the law, not the route wiring.
- `extern/fastify/request-remote-address` is included because `:auth-method/require-loopback` needs the peer address; it is the only piece of #224's extern changes this half depends on.
- **Follow-up required on merge:** re-add `contracts/knoxx/authentication/mcp_http.edn` to `open-hax/services`, and only then provision `KNOXX_MCP_LOOPBACK_TOKEN` as a real 16+ character secret. Provisioning it first flips `KNOXX_EXPECT_MCP_VERIFY=true` and fails the deploy on a method the backend does not implement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication contract support for MCP HTTP requests.
  * Added OAuth bearer authentication and optional trusted loopback token authentication.
  * Trusted loopback access now requires a valid local address and sufficiently long configured token.
  * Authentication grants are converted into tool access records for authorized requests.

* **Documentation**
  * Documented authentication contracts in the contract authoring guide.

* **Tests**
  * Added coverage for authentication methods, loopback validation, token requirements, and refusal scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->