### PR TITLE
fix(publication): name the route, so a listing is not eighteen untitled links

### DIFF
--- a/backend/src/cljs/knoxx/backend/law/publication.cljs
+++ b/backend/src/cljs/knoxx/backend/law/publication.cljs
@@ -129,7 +129,8 @@
    [:publication/state PublicationState]
    [:publication/path PublicationPath]
    [:translation/review [:enum :none :required]]
-   [:document/source-locale Locale]])
+   [:document/source-locale Locale]
+   [:document/title string?]])
 
 ;; ── Projection views ───────────────────────────────────────────────────────
 
@@ -195,13 +196,20 @@
    resources))
 
 (defn hydrate-publication-intent
-  "Copy the referenced document's validated source locale onto intent, so
-   translation laws never guess `:en`. Throws rather than defaulting a locale
-   when the document reference is dangling."
+  "Copy the referenced document's validated source locale and title onto
+   intent, so translation laws never guess `:en` and the manifest can name a
+   route without a second document lookup at the effect boundary. Throws rather
+   than defaulting a locale when the document reference is dangling.
+
+   Both are copied from the document AFTER reference validation rather than
+   duplicated as resource truth, so neither can drift from the document that
+   owns it."
   [resource-index intent]
   (let [document (get-in resource-index [:documents (:publication/document intent)])]
     (assert-valid! (:publication/document intent) Document document)
-    (assoc intent :document/source-locale (:document/source-locale document))))
+    (assoc intent
+           :document/source-locale (:document/source-locale document)
+           :document/title (:document/title document))))
 
 (def reconcilable-publication-states
   "Desired states that may take part in reconciliation. `:published` reconciles

--- a/backend/src/cljs/knoxx/backend/law/publication_manifest.cljc
+++ b/backend/src/cljs/knoxx/backend/law/publication_manifest.cljc
@@ -195,16 +195,28 @@
 
     `:route/media-type` and `:route/encoding` are copied VERBATIM from the
     validated artifact — no derivation, no defaulting. `:route/artifact` is
-    the relative artifact PATH, never the artifact value."
+    the relative artifact PATH, never the artifact value.
+
+    `:route/title` comes from the hydrated intent's `:document/title`, which
+    `law.publication/hydrate-publication-intent` copies off the referenced
+    Document after validating it. It is what a reader's listing renders; the
+    contract has always declared the key optional and nothing populated it, so
+    every published route listed as untitled."
   [intent artifact]
-  {:route/path (:publication/path intent)
+  (cond-> {:route/path (:publication/path intent)
    :route/locale (:publication/locale intent)
    :route/document (document-path-segment (:publication/document intent))
    :route/revision (:artifact/revision artifact)
    :route/artifact (artifact-relative-path intent artifact)
    :route/media-type (:artifact/media-type artifact)
    :route/encoding (:artifact/encoding artifact)
-   :publication/id (:publication/id intent)})
+   :publication/id (:publication/id intent)}
+
+    ;; Optional, and omitted rather than blank. A reader's listing falls back to
+    ;; the document id when there is no title, which is a worse label than a
+    ;; real one and a better one than an empty string.
+    (nonblank-string? (:document/title intent))
+    (assoc :route/title (:document/title intent))))
 
 (defn find-route
   "The route materialized for `publication-id`, or nil. Keyed on publication

--- a/backend/test/cljs/knoxx/backend/law/publication_manifest_test.cljs
+++ b/backend/test/cljs/knoxx/backend/law/publication_manifest_test.cljs
@@ -14,7 +14,8 @@
    :publication/state :published
    :publication/path "/es/notes/hello"
    :translation/review :required
-   :document/source-locale :en})
+   :document/source-locale :en
+   :document/title "Probe"})
 
 (def ^:private artifact
   {:artifact/content "<!doctype html><p>Hola</p>"
@@ -64,6 +65,26 @@
                     (str/split #"/"))))))
 
 ;; ── routes ─────────────────────────────────────────────────────────────────
+
+(deftest route-carries-the-document-title
+  (testing "`:route/title` is what a reader's listing renders. The contract has
+            always declared the key and nothing populated it, so every
+            published route listed as untitled."
+    (is (= "Probe" (:route/title (manifest/route-for-artifact intent artifact)))))
+
+  (testing "omitted rather than blank when the document has no usable title —
+            a reader falls back to the document id, which is a worse label than
+            a real title and a better one than an empty string"
+    (doseq [empty-ish [nil "" "   "]]
+      (is (not (contains? (manifest/route-for-artifact
+                           (assoc intent :document/title empty-ish) artifact)
+                          :route/title))
+          (str "a title of " (pr-str empty-ish) " must not reach the manifest"))))
+
+  (testing "a titled route still satisfies the manifest contract"
+    (is (some? (manifest/assert-manifest!
+                (manifest/upsert-route (manifest/empty-manifest)
+                                       (manifest/route-for-artifact intent artifact)))))))
 
 (deftest route-carries-artifact-values-verbatim
   (let [route (manifest/route-for-artifact intent artifact)]


### PR DESCRIPTION
`:route/title` has been in the manifest contract since the contract existed, and **nothing ever set it**.

The website reads it — `domain.published/listing` returns it as `:listing/title`, and `sections.published/PublishedListing` renders it, falling back to a "untitled" string when absent. So every published route has always listed as untitled. With one published document that was invisible. `open-hax/services#57` adds eighteen more, which turns it into a pile of identical links.

## The title was already there

`route-for-artifact` receives the **hydrated** intent. `hydrate-publication-intent` was copying only `:document/source-locale` off the referenced `Document`. It now copies `:document/title` as well, for the reason the locale is copied and for the same stated benefit: taken from the document *after* reference validation rather than duplicated as resource truth, so it cannot drift from the document that owns it.

Both are now declared on the `PublicationIntent` schema, which is what that schema is for.

## Why this is low risk

- `:document/title` is **required** on `Document` (`[:document/title string?]`), so a well-formed resource graph always has one — no new failure mode.
- Neither `PublicationIntentResource` nor `PublicationIntent` is a closed map, so carrying an extra key breaks no existing validation.
- `:route/title` was already `{:optional true}` in `ManifestRoute` and already in the website reader's `known-route-keys`. Both sides were waiting for it.

## Emitted conditionally, on purpose

`nil`, `""` and `"   "` all omit the key rather than emitting a blank. A reader with no title falls back to the document id — a worse label than a real title, a better one than an empty string.

## Tests

`route-carries-the-document-title` pins all three: the title reaches the route, blank-ish titles are omitted, and a titled route still satisfies `assert-manifest!`.

**1274 tests, 4884 assertions, 0 failures.**

## Note

Merging this does not ship it. `Deploy Stack` in `open-hax/services` builds `knoxx_ref=main`, so this reaches production on the next labelled services deploy.

## Known limitation

One title per document means a Japanese listing shows the English title until titles themselves become translatable. That is a larger change — the title is document identity today, not localized content — and is deliberately not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Publication routes now include the associated document title when available.
  - Blank or missing document titles are omitted from route details.

- **Bug Fixes**
  - Improved handling of publication references while preserving validation for missing documents.

- **Tests**
  - Added coverage confirming titled routes meet manifest requirements and blank titles are excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->