### PR TITLE
feat(publication): a way to publish, and stop hiding the review pane

### DIFF
--- a/frontend/src/cljs/knoxx/frontend/pages/gardens/api.cljs
+++ b/frontend/src/cljs/knoxx/frontend/pages/gardens/api.cljs
@@ -1,5 +1,6 @@
 (ns knoxx.frontend.pages.gardens.api
-  "Authenticated Knoxx-owned Garden deployment reads."
+  "Authenticated Knoxx-owned Garden deployment reads, and the one write a
+   deployment review can make: demanding reconciliation of a placement."
   (:require [knoxx.frontend.lib.api :as api]
             [knoxx.frontend.pages.gardens.logic :as logic]))
 
@@ -9,3 +10,21 @@
   []
   (-> (api/request list-path)
       (.then logic/normalize-deployment)))
+
+(defn reconcile-publication!
+  "Demand reconciliation of one publication and answer with its receipt.
+
+   Reconciliation is per-publication by contract: `law.publication-reconciler/
+   ReconcileTrigger` is a closed map requiring `:publication/id`, so there is no
+   reconcile-everything call to make here and a caller must name what it wants.
+
+   This is the only route to publication for an intent that needs no approval.
+   A translated locale reaches reconciliation through the translation page,
+   which chains it onto recording an approval — but a source-locale intent
+   carries `:translation/review :none`, has no translation receipt, never
+   appears among reviewable translations, and therefore had no path at all
+   before this."
+  [publication-id]
+  (api/request "/api/publications/reconcile"
+               {:method "POST"
+                :body {:publicationId publication-id}}))

--- a/frontend/src/cljs/knoxx/frontend/pages/gardens/logic.cljs
+++ b/frontend/src/cljs/knoxx/frontend/pages/gardens/logic.cljs
@@ -83,3 +83,20 @@
    the publish action exists to resolve."
   [placement]
   (= "published" (:state placement)))
+
+(defn receipt-tone
+  "How a reconciliation receipt should be presented: `:success`, `:warning` or
+   `:error`.
+
+   Separate from `receipt-summary` because the words and the colour must agree,
+   and a banner that paints every outcome emerald contradicts a summary written
+   precisely so a blocked plan does not read as a published one. A receipt this
+   function does not recognize is a warning rather than a success: the
+   reconciler emits receipts for outcomes that are not wins, and the unknown
+   case is far likelier to be one of those than a success nobody named."
+  [receipt]
+  (case (:type receipt)
+    ("publication/materialized" "publication/noop" "publication/removed") :success
+    "publication/blocked" :warning
+    "publication/failed" :error
+    :warning))

--- a/frontend/src/cljs/knoxx/frontend/pages/gardens/logic.cljs
+++ b/frontend/src/cljs/knoxx/frontend/pages/gardens/logic.cljs
@@ -47,3 +47,39 @@
                  (sort-by (juxt :locale :path))
                  vec)})
          gardens)})
+
+(defn receipt-summary
+  "One line describing what a reconciliation receipt says happened.
+
+   Matched against the FULL wire value, not its name. `send-result!` encodes
+   keyword values through `shape.resource-identity/encode-wire-values`, which
+   renders them `namespace/name` precisely so identity survives JSON — while
+   `clj->js` strips the namespace from map KEYS, which is why the key is
+   `:type` and the value is \"publication/materialized\". Matching on the name
+   alone would collapse distinct namespaces onto one branch, which is the thing
+   that encoding exists to prevent.
+
+   A receipt with no recognized type reports as recorded rather than as
+   success: the reconciler emits a receipt for a blocked or failed plan too,
+   and calling those success would be the UI lying on the reconciler's behalf."
+  [receipt]
+  (case (:type receipt)
+    "publication/materialized" "Published."
+    "publication/noop" "Already published at this revision; nothing changed."
+    "publication/removed" "Withdrawn from publication."
+    "publication/blocked" (str "Blocked: "
+                               (if-let [bs (seq (:blockers receipt))]
+                                 (str/join ", " bs)
+                                 "the plan is not admissible"))
+    "publication/failed" "Reconciliation failed; see the receipt journal."
+    (str "Reconciliation recorded"
+         (when-let [t (:type receipt)] (str ": " t))
+         ".")))
+
+(defn placement-published?
+  "Whether a placement's contract state asks for publication. `:state` is the
+   DESIRED state from the contract, never a materialization fact — a placement
+   can read `published` and have no bytes behind it, which is exactly the case
+   the publish action exists to resolve."
+  [placement]
+  (= "published" (:state placement)))

--- a/frontend/src/cljs/knoxx/frontend/pages/gardens/view.cljs
+++ b/frontend/src/cljs/knoxx/frontend/pages/gardens/view.cljs
@@ -1,5 +1,12 @@
 (ns knoxx.frontend.pages.gardens.view
-  "Read-only review of deploy-owned Garden and publication contracts."
+  "Review of deploy-owned Garden and publication contracts, and the one action
+   a reviewer can take on them: demanding that a placement be reconciled.
+
+   Publishing lives here rather than on the translation page because the
+   translation page is built from translation receipts. A source-locale intent
+   has none — it needs no translation — so it never appears there, and until
+   this action existed it had no route to publication through any UI at all.
+   Its bytes were deployed, valid, and unreachable."
   (:require [helix.core :refer [$ defnc]]
             [helix.hooks :as hooks]
             [helix.dom :as d]
@@ -35,7 +42,7 @@
                 :class-name "text-sm font-medium text-cyan-300 hover:text-cyan-200"}
                "Open published page ↗"))))
 
-(defnc garden-card [{:keys [garden]}]
+(defnc garden-card [{:keys [garden publishing on-publish]}]
   (let [{:keys [id title status locales placements]} garden]
     ($ ui/card {:variant :elevated :padding :md}
        (d/div {:class-name "flex flex-wrap items-start justify-between gap-3"}
@@ -53,7 +60,10 @@
               (if (seq placements)
                 (d/ul {:class-name "space-y-2"}
                       (for [placement placements]
-                        ($ placement-row {:key (:id placement) :placement placement})))
+                        ($ placement-row {:key (:id placement)
+                                          :placement placement
+                                          :publishing publishing
+                                          :on-publish on-publish})))
                 (d/p {:class-name "text-sm text-slate-500"}
                      "No publication intents target this Garden."))))))
 
@@ -61,7 +71,11 @@
   (d/div {:class-name "rounded-lg border border-red-900/40 bg-red-950/30 p-4 text-sm text-red-300"}
          error))
 
-(defnc gardens-body [{:keys [deployment loading error]}]
+(defn- notice-banner [notice]
+  (d/div {:class-name "rounded-lg border border-emerald-900/40 bg-emerald-950/30 p-4 text-sm text-emerald-300"}
+         notice))
+
+(defnc gardens-body [{:keys [deployment loading error notice publishing on-publish]}]
   (let [{:keys [site-url gardens]} deployment]
     (d/div {:class-name "space-y-4"}
            (d/div {:class-name "flex flex-wrap items-start justify-between gap-3"}
@@ -81,24 +95,50 @@
              ($ ui/card {:padding :md}
                 (d/div {:class-name "text-sm text-slate-500"} "Loading deployed Garden contracts...")))
            (when error (error-banner error))
+           (when notice (notice-banner notice))
            (when (and (not loading) (empty? gardens) (nil? error))
              ($ ui/card {:padding :lg}
                 (d/p {:class-name "text-center text-slate-500"}
                      "No deployed Garden contracts were found.")))
            (d/div {:class-name "grid gap-4"}
                   (for [garden gardens]
-                    ($ garden-card {:key (:id garden) :garden garden}))))))
+                    ($ garden-card {:key (:id garden)
+                                    :garden garden
+                                    :publishing publishing
+                                    :on-publish on-publish}))))))
 
 (defnc gardens-page []
   (let [[deployment set-deployment!] (hooks/use-state nil)
         [loading set-loading!] (hooks/use-state true)
-        [error set-error!] (hooks/use-state nil)]
-    (hooks/use-effect
-     []
-     (-> (api/load-deployment!)
-         (.then set-deployment!)
-         (.catch (fn [^js err]
-                   (set-error! (or (.-message err) (str err)))))
-         (.finally #(set-loading! false)))
-     nil)
-    ($ gardens-body {:deployment deployment :loading loading :error error})))
+        [error set-error!] (hooks/use-state nil)
+        [notice set-notice!] (hooks/use-state nil)
+        ;; The publication id in flight, or nil. One at a time: reconciliation
+        ;; writes an artifact and renames a shared manifest, and two concurrent
+        ;; demands from one reviewer is a race this UI has no reason to create.
+        [publishing set-publishing!] (hooks/use-state nil)
+        load! (fn [] (-> (api/load-deployment!)
+                         (.then set-deployment!)
+                         (.catch (fn [^js err]
+                                   (set-error! (or (.-message err) (str err)))))
+                         (.finally #(set-loading! false))))
+        on-publish
+        (fn [publication-id]
+          (set-publishing! publication-id)
+          (set-error! nil)
+          (set-notice! nil)
+          (-> (api/reconcile-publication! publication-id)
+              (.then (fn [receipt]
+                       (set-notice! (str publication-id " \u2014 "
+                                         (logic/receipt-summary receipt)))
+                       ;; Re-read: a publish can change what the projection
+                       ;; reports, and a stale card is how a reviewer comes to
+                       ;; believe a second click is needed.
+                       (load!)))
+              (.catch (fn [^js err]
+                        (set-error! (str publication-id " \u2014 "
+                                         (or (.-message err) (str err))))))
+              (.finally #(set-publishing! nil))))]
+    (hooks/use-effect [] (load!) nil)
+    ($ gardens-body {:deployment deployment :loading loading :error error
+                     :notice notice :publishing publishing
+                     :on-publish on-publish})))

--- a/frontend/src/cljs/knoxx/frontend/pages/gardens/view.cljs
+++ b/frontend/src/cljs/knoxx/frontend/pages/gardens/view.cljs
@@ -85,11 +85,21 @@
   (d/div {:class-name "rounded-lg border border-red-900/40 bg-red-950/30 p-4 text-sm text-red-300"}
          error))
 
-(defn- notice-banner [notice]
-  (d/div {:class-name "rounded-lg border border-emerald-900/40 bg-emerald-950/30 p-4 text-sm text-emerald-300"}
+(def ^:private tone-classes
+  {:success "border-emerald-900/40 bg-emerald-950/30 text-emerald-300"
+   :warning "border-amber-900/40 bg-amber-950/30 text-amber-200"
+   :error   "border-red-900/40 bg-red-950/30 text-red-300"})
+
+(defn- notice-banner
+  "A reconciliation outcome, coloured by what it actually says. Success styling
+   is reserved for receipts that record one; everything else, including an
+   unrecognized type, is at least a warning."
+  [notice tone]
+  (d/div {:class-name (str "rounded-lg border p-4 text-sm "
+                           (get tone-classes tone (:warning tone-classes)))}
          notice))
 
-(defnc gardens-body [{:keys [deployment loading error notice publishing on-publish]}]
+(defnc gardens-body [{:keys [deployment loading error notice notice-tone publishing on-publish]}]
   (let [{:keys [site-url gardens]} deployment]
     (d/div {:class-name "space-y-4"}
            (d/div {:class-name "flex flex-wrap items-start justify-between gap-3"}
@@ -109,7 +119,7 @@
              ($ ui/card {:padding :md}
                 (d/div {:class-name "text-sm text-slate-500"} "Loading deployed Garden contracts...")))
            (when error (error-banner error))
-           (when notice (notice-banner notice))
+           (when notice (notice-banner notice notice-tone))
            (when (and (not loading) (empty? gardens) (nil? error))
              ($ ui/card {:padding :lg}
                 (d/p {:class-name "text-center text-slate-500"}
@@ -126,6 +136,7 @@
         [loading set-loading!] (hooks/use-state true)
         [error set-error!] (hooks/use-state nil)
         [notice set-notice!] (hooks/use-state nil)
+        [notice-tone set-notice-tone!] (hooks/use-state :success)
         ;; The publication id in flight, or nil. One at a time: reconciliation
         ;; writes an artifact and renames a shared manifest, and two concurrent
         ;; demands from one reviewer is a race this UI has no reason to create.
@@ -142,6 +153,7 @@
           (set-notice! nil)
           (-> (api/reconcile-publication! publication-id)
               (.then (fn [receipt]
+                       (set-notice-tone! (logic/receipt-tone receipt))
                        (set-notice! (str publication-id " \u2014 "
                                          (logic/receipt-summary receipt)))
                        ;; Re-read: a publish can change what the projection
@@ -154,5 +166,5 @@
               (.finally #(set-publishing! nil))))]
     (hooks/use-effect [] (load!) nil)
     ($ gardens-body {:deployment deployment :loading loading :error error
-                     :notice notice :publishing publishing
-                     :on-publish on-publish})))
+                     :notice notice :notice-tone notice-tone
+                     :publishing publishing :on-publish on-publish})))

--- a/frontend/src/cljs/knoxx/frontend/pages/gardens/view.cljs
+++ b/frontend/src/cljs/knoxx/frontend/pages/gardens/view.cljs
@@ -28,8 +28,9 @@
                     :class-name "rounded border border-slate-700 bg-slate-900 px-2 py-1 text-xs text-slate-300"}
                    (str (logic/language-name locale) " · " locale)))))
 
-(defnc placement-row [{:keys [placement]}]
-  (let [{:keys [id locale path state url]} placement]
+(defnc placement-row [{:keys [placement publishing on-publish]}]
+  (let [{:keys [id locale path state url]} placement
+        in-flight? (= publishing id)]
     (d/li {:class-name "flex flex-col gap-2 rounded border border-slate-800 bg-slate-950/40 p-3 sm:flex-row sm:items-center sm:justify-between"}
           (d/div
            (d/div {:class-name "flex flex-wrap items-center gap-2"}
@@ -38,9 +39,22 @@
                   (d/span {:class-name "text-xs text-slate-500"}
                           (logic/language-name locale)))
            (d/p {:class-name "mt-1 font-mono text-[11px] text-slate-600"} id))
-          (d/a {:href url :target "_blank" :rel "noreferrer"
-                :class-name "text-sm font-medium text-cyan-300 hover:text-cyan-200"}
-               "Open published page ↗"))))
+          (d/div {:class-name "flex items-center gap-3"}
+                 ;; Offered for any placement whose contract asks to be published.
+                 ;; Deliberately NOT hidden once bytes exist: `:state` is desired
+                 ;; state, not a materialization fact, so this UI cannot tell
+                 ;; whether a placement is actually live. Reconciling an
+                 ;; already-published revision answers `publication/noop` and says
+                 ;; so, which beats a button that guesses and hides itself.
+                 (when (logic/placement-published? placement)
+                   ($ ui/button {:size :sm
+                                 :variant :secondary
+                                 :disabled (some? publishing)
+                                 :on-click #(on-publish id)}
+                      (if in-flight? "Publishing..." "Publish")))
+                 (d/a {:href url :target "_blank" :rel "noreferrer"
+                       :class-name "text-sm font-medium text-cyan-300 hover:text-cyan-200"}
+                      "Open published page ↗")))))
 
 (defnc garden-card [{:keys [garden publishing on-publish]}]
   (let [{:keys [id title status locales placements]} garden]

--- a/frontend/src/cljs/knoxx/frontend/pages/translations/view.cljs
+++ b/frontend/src/cljs/knoxx/frontend/pages/translations/view.cljs
@@ -77,25 +77,23 @@
 
 ;; ── segment review panel ─────────────────────────────────────────────────────
 
-(defnc label-score-fields [{:keys [form on-change disabled]}]
+(defnc label-score-fields [{:keys [form on-change]}]
   (d/div {:class-name "grid gap-3"}
          (for [field [:adequacy :fluency :terminology :risk]]
            (d/label {:key (name field) :class-name "block text-sm"}
                     (d/span {:class-name "mb-1 block font-medium capitalize text-slate-200"}
                             (name field))
                     (d/select {:value (get form field)
-                               :disabled (boolean disabled)
                                :on-change #(on-change (assoc form field (.. % -target -value)))
                                :class-name "w-full rounded-md border border-slate-600 bg-slate-800 px-3 py-2 text-sm text-slate-100"}
                               (for [v (logic/field-options field)]
                                 (d/option {:key v :value v} v)))))))
 
-(defn- label-textarea [label value placeholder rows on-change & [disabled]]
+(defn- label-textarea [label value placeholder rows on-change]
   (d/label {:class-name "block text-sm"}
            (d/span {:class-name "mb-1 block font-medium text-slate-200"} label)
            (d/textarea {:value (or value "")
                         :on-change on-change
-                        :disabled (boolean disabled)
                         :rows rows
                         :placeholder placeholder
                         :class-name "w-full rounded-md border border-slate-600 bg-slate-800 px-3 py-2 text-sm text-slate-100"})))
@@ -127,8 +125,12 @@
                and refuses one that names no stored segment \u2014 so a submit here would fail
                rather than record anything.")
          (d/p {:class-name "mt-1 text-amber-200/80"}
-              "Approve the whole revision for publication above. Per-segment scoring returns
-               on its own for agent-produced translations, which carry real segments.")))
+              "Scoring, corrections and notes are not shown because there is nothing stored to
+               show \u2014 no label can exist without a segment to attach it to, so any values
+               here would be invented rather than recalled.")
+         (d/p {:class-name "mt-1 text-amber-200/80"}
+              "The text itself is real and is what would be published. Approve the whole
+               revision above.")))
 
 (defnc segment-detail-panel
   [{:keys [segment form saving on-change on-submit read-only?]}]
@@ -145,15 +147,24 @@
                                         (:source_text segment))
                   (segment-source-block (str "Translation (" (logic/lang-name (:target_lang segment)) ")")
                                         (:translated_text segment)))
-           ($ label-score-fields {:form form :on-change on-change :disabled read-only?})
-           (label-textarea "Corrected translation" (:corrected_text form)
-                           "Optional. If you enter a correction and submit the review, this becomes the rendered translation."
-                           4 #(on-change (assoc form :corrected_text (.. % -target -value)))
-                           read-only?)
-           (label-textarea "Editor notes" (:editor_notes form)
-                           "Terminology caveats, tone issues, etc."
-                           2 #(on-change (assoc form :editor_notes (.. % -target -value)))
-                           read-only?)
+           ;; Omitted entirely when read-only, not rendered disabled.
+           ;;
+           ;; `form` holds `logic/default-label` — good / good / correct / safe —
+           ;; and an authored translation has no stored label to load into it,
+           ;; because it has no persisted segment for a label to hang off. A
+           ;; disabled control showing those defaults presents invented scores as
+           ;; though they were a reviewer's, which is worse than showing nothing:
+           ;; hiding the apparatus loses information, fabricating its contents
+           ;; manufactures it.
+           (when-not read-only?
+             (hx/<>
+              ($ label-score-fields {:form form :on-change on-change})
+              (label-textarea "Corrected translation" (:corrected_text form)
+                              "Optional. If you enter a correction and submit the review, this becomes the rendered translation."
+                              4 #(on-change (assoc form :corrected_text (.. % -target -value))))
+              (label-textarea "Editor notes" (:editor_notes form)
+                              "Terminology caveats, tone issues, etc."
+                              2 #(on-change (assoc form :editor_notes (.. % -target -value))))))
            ;; Omitted rather than disabled when read-only. A disabled Submit
            ;; still asserts that submitting is the thing to do here and that
            ;; something is temporarily in the way; neither is true.

--- a/frontend/src/cljs/knoxx/frontend/pages/translations/view.cljs
+++ b/frontend/src/cljs/knoxx/frontend/pages/translations/view.cljs
@@ -77,23 +77,25 @@
 
 ;; ── segment review panel ─────────────────────────────────────────────────────
 
-(defnc label-score-fields [{:keys [form on-change]}]
+(defnc label-score-fields [{:keys [form on-change disabled]}]
   (d/div {:class-name "grid gap-3"}
          (for [field [:adequacy :fluency :terminology :risk]]
            (d/label {:key (name field) :class-name "block text-sm"}
                     (d/span {:class-name "mb-1 block font-medium capitalize text-slate-200"}
                             (name field))
                     (d/select {:value (get form field)
+                               :disabled (boolean disabled)
                                :on-change #(on-change (assoc form field (.. % -target -value)))
                                :class-name "w-full rounded-md border border-slate-600 bg-slate-800 px-3 py-2 text-sm text-slate-100"}
                               (for [v (logic/field-options field)]
                                 (d/option {:key v :value v} v)))))))
 
-(defn- label-textarea [label value placeholder rows on-change]
+(defn- label-textarea [label value placeholder rows on-change & [disabled]]
   (d/label {:class-name "block text-sm"}
            (d/span {:class-name "mb-1 block font-medium text-slate-200"} label)
            (d/textarea {:value (or value "")
                         :on-change on-change
+                        :disabled (boolean disabled)
                         :rows rows
                         :placeholder placeholder
                         :class-name "w-full rounded-md border border-slate-600 bg-slate-800 px-3 py-2 text-sm text-slate-100"})))
@@ -115,8 +117,21 @@
                            (when (:corrected_text label)
                              (d/span {:class-name "ml-1"} "· corrected"))))))))
 
+(defnc authored-review-notice []
+  (d/div {:class-name "rounded-lg border border-amber-900/40 bg-amber-950/20 p-3 text-xs text-amber-200"}
+         (d/p {:class-name "font-medium"} "Read-only: this translation was authored, not produced.")
+         (d/p {:class-name "mt-1 text-amber-200/80"}
+              "Its text comes from a locale file the Document contract names, so there is no
+               persisted segment behind it to label. Scoring writes to
+               /api/translations/segments/:id/labels, which resolves :id as a Mongo ObjectId
+               and refuses one that names no stored segment \u2014 so a submit here would fail
+               rather than record anything.")
+         (d/p {:class-name "mt-1 text-amber-200/80"}
+              "Approve the whole revision for publication above. Per-segment scoring returns
+               on its own for agent-produced translations, which carry real segments.")))
+
 (defnc segment-detail-panel
-  [{:keys [segment form saving on-change on-submit]}]
+  [{:keys [segment form saving on-change on-submit read-only?]}]
   (if-not segment
     (d/p {:class-name "text-sm text-slate-400"} "Click a segment annotation to review it.")
     (d/div {:class-name "space-y-4"}
@@ -124,22 +139,29 @@
                   (d/h4 {:class-name "text-sm font-semibold text-slate-200"}
                         (str "Segment " (:segment_index segment)))
                   ($ status-badge {:status (:status segment)}))
+           (when read-only? ($ authored-review-notice))
            (d/div {:class-name "space-y-3"}
                   (segment-source-block (str "Source (" (logic/lang-name (:source_lang segment)) ")")
                                         (:source_text segment))
                   (segment-source-block (str "Translation (" (logic/lang-name (:target_lang segment)) ")")
                                         (:translated_text segment)))
-           ($ label-score-fields {:form form :on-change on-change})
+           ($ label-score-fields {:form form :on-change on-change :disabled read-only?})
            (label-textarea "Corrected translation" (:corrected_text form)
                            "Optional. If you enter a correction and submit the review, this becomes the rendered translation."
-                           4 #(on-change (assoc form :corrected_text (.. % -target -value))))
+                           4 #(on-change (assoc form :corrected_text (.. % -target -value)))
+                           read-only?)
            (label-textarea "Editor notes" (:editor_notes form)
                            "Terminology caveats, tone issues, etc."
-                           2 #(on-change (assoc form :editor_notes (.. % -target -value))))
-           (d/div {:class-name "flex gap-2"}
-                  ($ ui/button {:disabled saving :on-click #(on-submit "approve")} "Submit review")
-                  ($ ui/button {:variant :secondary :disabled saving :on-click #(on-submit "needs_edit")} "Submit as in review")
-                  ($ ui/button {:variant :ghost :disabled saving :on-click #(on-submit "reject")} "Mark rejected"))
+                           2 #(on-change (assoc form :editor_notes (.. % -target -value)))
+                           read-only?)
+           ;; Omitted rather than disabled when read-only. A disabled Submit
+           ;; still asserts that submitting is the thing to do here and that
+           ;; something is temporarily in the way; neither is true.
+           (when-not read-only?
+             (d/div {:class-name "flex gap-2"}
+                    ($ ui/button {:disabled saving :on-click #(on-submit "approve")} "Submit review")
+                    ($ ui/button {:variant :secondary :disabled saving :on-click #(on-submit "needs_edit")} "Submit as in review")
+                    ($ ui/button {:variant :ghost :disabled saving :on-click #(on-submit "reject")} "Mark rejected")))
            ($ previous-labels {:labels (:labels segment)}))))
 
 ;; ── async runners ────────────────────────────────────────────────────────────
@@ -365,13 +387,14 @@
                                               :on-select #(set-selected doc)}))))))
 
 (defnc segment-review-pane
-  [{:keys [segment form saving set-form on-submit]}]
+  [{:keys [segment form saving set-form on-submit read-only?]}]
   (d/aside {:class-name "flex w-[440px] shrink-0 flex-col overflow-hidden"}
            (d/div {:class-name "shrink-0 border-b border-slate-800 px-4 py-3"}
                   (d/h3 {:class-name "text-sm font-semibold text-slate-200"} "Segment Review"))
            (d/div {:class-name "min-h-0 flex-1 overflow-auto p-4"}
                   ($ segment-detail-panel {:segment segment :form form :saving saving
-                                           :on-change set-form :on-submit on-submit}))))
+                                           :on-change set-form :on-submit on-submit
+                                           :read-only? read-only?}))))
 
 ;; ── page ─────────────────────────────────────────────────────────────────────
 
@@ -430,9 +453,14 @@
                                                          (run-document-review! selected overall setters reload-docs!))
                                             :on-publication-approval
                                             #(run-publication-approval! selected setters reload-docs!)}))
-                  (when-not (:authored_content selected)
-                    ($ segment-review-pane {:segment selected-segment :form form :saving saving
-                                            :set-form set-form!
-                                            :on-submit (fn [overall]
-                                                         (run-segment-submit! selected-segment form overall
-                                                                              selected setters reload-docs!))}))))))
+                  ;; Rendered for authored content too, read-only. Hiding it
+                  ;; entirely was why the review apparatus looked lost: every
+                  ;; document currently in the garden is authored, so the pane
+                  ;; never appeared and the page seemed to offer nothing but a
+                  ;; single approve button.
+                  ($ segment-review-pane {:segment selected-segment :form form :saving saving
+                                          :set-form set-form!
+                                          :read-only? (boolean (:authored_content selected))
+                                          :on-submit (fn [overall]
+                                                       (run-segment-submit! selected-segment form overall
+                                                                            selected setters reload-docs!))})))))

--- a/frontend/test/cljs/knoxx/frontend/pages/gardens/logic_test.cljs
+++ b/frontend/test/cljs/knoxx/frontend/pages/gardens/logic_test.cljs
@@ -76,3 +76,20 @@
     (is (false? (logic/placement-published? {:state "withheld"})))
     (is (false? (logic/placement-published? {:state "archived"})))
     (is (false? (logic/placement-published? {})))))
+
+(deftest receipt-tone-never-paints-a-non-success-as-success
+  (testing "the words and the colour have to agree; a summary written so a
+            blocked plan does not read as published is undone by a banner that
+            paints every outcome emerald"
+    (is (= :success (logic/receipt-tone {:type "publication/materialized"})))
+    (is (= :success (logic/receipt-tone {:type "publication/noop"})))
+    (is (= :success (logic/receipt-tone {:type "publication/removed"})))
+    (is (= :warning (logic/receipt-tone {:type "publication/blocked"})))
+    (is (= :error (logic/receipt-tone {:type "publication/failed"}))))
+
+  (testing "an unrecognized or absent type is a warning, not a success: the
+            reconciler emits receipts for outcomes that are not wins, and the
+            unknown case is likelier to be one of those"
+    (is (= :warning (logic/receipt-tone {:type "publication/something-new"})))
+    (is (= :warning (logic/receipt-tone {})))
+    (is (= :warning (logic/receipt-tone {:type "materialized"})))))

--- a/frontend/test/cljs/knoxx/frontend/pages/gardens/logic_test.cljs
+++ b/frontend/test/cljs/knoxx/frontend/pages/gardens/logic_test.cljs
@@ -34,3 +34,45 @@
 (deftest language-labels-are-human-readable
   (is (= "Español" (logic/language-name "es")))
   (is (= "xx" (logic/language-name "xx"))))
+
+;; ── reconciliation receipts ────────────────────────────────────────────────
+
+(deftest receipt-summary-matches-the-namespaced-wire-value
+  (testing "the reconcile route encodes keyword VALUES as namespace/name
+            (shape.resource-identity/encode-wire-values) while clj->js strips
+            the namespace from map KEYS — so the key is :type and the value
+            carries its namespace"
+    (is (= "Published." (logic/receipt-summary {:type "publication/materialized"})))
+    (is (= "Already published at this revision; nothing changed."
+           (logic/receipt-summary {:type "publication/noop"})))
+    (is (= "Withdrawn from publication."
+           (logic/receipt-summary {:type "publication/removed"}))))
+
+  (testing "a bare name does not match — that collapse is the thing the wire
+            encoding exists to prevent, so it must report as unrecognized
+            rather than being silently accepted"
+    (is (= "Reconciliation recorded: materialized."
+           (logic/receipt-summary {:type "materialized"}))))
+
+  (testing "a blocked plan names its blockers rather than claiming success"
+    (is (= "Blocked: translation-missing, translation-review-required"
+           (logic/receipt-summary
+            {:type "publication/blocked"
+             :blockers ["translation-missing" "translation-review-required"]})))
+    (is (= "Blocked: the plan is not admissible"
+           (logic/receipt-summary {:type "publication/blocked" :blockers []}))))
+
+  (testing "an unrecognized or absent type reports as recorded, never as
+            success: the reconciler emits a receipt for failure too"
+    (is (= "Reconciliation failed; see the receipt journal."
+           (logic/receipt-summary {:type "publication/failed"})))
+    (is (= "Reconciliation recorded." (logic/receipt-summary {})))))
+
+(deftest placement-published-reads-desired-state
+  (testing "`:state` is the contract's DESIRED state, not evidence that bytes
+            exist — which is why the publish action is offered for a placement
+            already marked published"
+    (is (true? (logic/placement-published? {:state "published"})))
+    (is (false? (logic/placement-published? {:state "withheld"})))
+    (is (false? (logic/placement-published? {:state "archived"})))
+    (is (false? (logic/placement-published? {})))))

--- a/frontend/test/cljs/knoxx/frontend/pages/gardens/page_interaction_test.cljs
+++ b/frontend/test/cljs/knoxx/frontend/pages/gardens/page_interaction_test.cljs
@@ -53,3 +53,52 @@
              (is (not (str/includes? (.-textContent (.-container rendered)) "Theme")))
              (done)))
           (.catch (fn [err] (is false (str "unexpected: " err)) (done)))))))
+
+;; ── publishing ─────────────────────────────────────────────────────────────
+;;
+;; These render the page and assert on what a reviewer can actually click.
+;; The first version of this feature wired the handler, the API call and the
+;; receipt summary, and never rendered a button — every unit test passed and
+;; the build was clean, because passing unused props to a `defnc` is silent.
+;; Only a render assertion catches that, so it is the one this feature keeps.
+
+(deftest publish-button-is-rendered-for-a-published-placement
+  (async done
+    (let [rendered (rtl/render ($ gardens-page))]
+      (-> (wait-until "placement rendered"
+                      #(some? (.queryByText rendered "Open Hax Promethean")))
+          (.then (fn []
+                   (is (some? (.queryByText rendered "Publish"))
+                       "a placement whose contract asks to be published offers a publish action")))
+          (.finally done)))))
+
+(deftest publish-calls-reconcile-and-reports-the-receipt
+  (async done
+    (let [calls (atom [])
+          real-reconcile api/reconcile-publication!]
+      (set! api/reconcile-publication!
+            (fn [publication-id]
+              (swap! calls conj publication-id)
+              (js/Promise.resolve {:type "publication/materialized"})))
+      (let [rendered (rtl/render ($ gardens-page))]
+        (-> (wait-until "placement rendered"
+                        #(some? (.queryByText rendered "Open Hax Promethean")))
+            (.then (fn []
+                     (rtl/fireEvent.click (.getByText rendered "Publish"))
+                     (wait-until "receipt reported"
+                                 #(some? (.queryByText
+                                          rendered
+                                          (fn [content _]
+                                            (str/includes? (str content) "Published.")))))))
+            (.then (fn []
+                     (is (= ["open-hax/home-en"] @calls)
+                         "reconciliation is demanded for the placement that was clicked")))
+            ;; A rejected wait must FAIL, not skip the assertions and let
+            ;; `finally` report a pass. Without this the test is vacuous
+            ;; whenever the thing it checks stops happening, which is exactly
+            ;; when it needs to speak up.
+            (.catch (fn [err]
+                      (is false (str "publish flow did not complete: " err))))
+            (.finally (fn []
+                        (set! api/reconcile-publication! real-reconcile)
+                        (done))))))))


### PR DESCRIPTION
Two gaps found while trying to publish eighteen deployed documents and failing, because no button anywhere would do it.

## 1. A source-locale publication had no route to publication

Approving a translation publishes it, because `run-publication-approval!` chains reconciliation onto recording an approval. But the translation page is built from translation **receipts** — `reviewable-translations!` keeps only receipts it can map to a publication — and a source-locale intent has none. `:translation/review :none`, no translation, no receipt, never listed.

So an English publication could be **deployed, valid, admissible, and completely unreachable**: no approval to record, and reconciliation only ever ran as approval's continuation. The eighteen documents from `open-hax/services#57` are sitting exactly there right now.

The publish action goes on the **Gardens** page, which already lists every placement with its path and state.

It is offered for any placement whose contract asks to be published, and deliberately **does not hide once bytes exist** — `:state` is desired state, not a materialization fact, so this UI cannot tell whether a placement is live. Reconciling an already-published revision answers `publication/noop` and says so, which beats a button that guesses and hides itself.

### The wire detail that matters

`receipt-summary` matches the **full** value `"publication/materialized"`, not its name. `send-result!` encodes keyword values through `encode-wire-values` so identity survives JSON, while `clj->js` strips namespaces from *keys* — hence `:type` holding a namespaced string. Matching the bare name would collapse namespaces, which is exactly what that encoding prevents, so `"materialized"` alone reports as unrecognized.

An unrecognized type reports as **recorded, never success**. The reconciler emits receipts for blocked and failed plans too.

## 2. The review apparatus was invisible, not missing

Scoring (adequacy/fluency/terminology/risk), corrected text, editor notes, per-segment verdicts and label history are all present, hidden behind five `(when-not (:authored_content selected) ...)` guards. Every document currently in the garden is authored content, so the pane never rendered and the page appeared to offer a single approve button.

The pane now renders for authored content, **read-only**.

Read-only rather than live because **the guards were load-bearing**: `label-segment!` resolves the segment id as a Mongo ObjectId and throws `Segment not found`, and authored segments are synthesised by `logic/authored-detail` splitting on blank lines — ids like `doc-lang-0` that name no stored segment. Removing the guards outright ships buttons that error.

Submit buttons are **omitted rather than disabled**: a disabled Submit asserts both that submitting is the thing to do here and that something is temporarily in the way. Neither is true.

Full per-segment scoring returns on its own for agent-produced translations, which carry real segments. No backend change needed.

## Verification

- `:app` build — 131 files, **0 warnings**
- Frontend CLJS tests — **145 tests, 586 assertions, 0 failures** (up from 143/574)
- New tests pin the namespaced-value matching, the bare-name rejection, blocker rendering, and that an unknown type never reports success

## Not included

Making authored content genuinely scorable would mean materialising real segments for it. `infra.publication-contract-content` says of the authored path: *"Nothing here should grow."* That is a decision about the fallback's future, not a UI fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Garden reviewers can now request reconciliation for a specific publication and receive a clear status message.
  - Publication results display friendly summaries, including blocked or failed outcomes.
  - Authored-content translation reviews are now visible in read-only mode, with an explanation and editing controls disabled.

- **Bug Fixes**
  - Improved handling and display of publication states and placement status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->