### PR TITLE
CI: preserve eta-mu review failure evidence

### DIFF
--- a/.github/workflows/eta-mu-review.yml
+++ b/.github/workflows/eta-mu-review.yml
@@ -13,7 +13,10 @@ permissions:
 jobs:
   review:
     name: Evidence-first review (eta-mu)
-    uses: open-hax/eta-mu/.github/workflows/opencode-code-review.yml@2b918cdab2ebd30e745bb8fa86d077d7a3af0030
+    # eta-mu#304: preserve response/stderr and recovery metadata for every
+    # invocation, then allow one bounded corrective attempt only when a
+    # completed invocation omitted review_submit.
+    uses: open-hax/eta-mu/.github/workflows/opencode-code-review.yml@e8eea02d31030215984375980b765803fc72d80d
     with:
       setup_eta_mu_toolchain: false
       evidence_gates_script: |


### PR DESCRIPTION
## Signal

Repin Knoxx's reusable eta-mu evidence review from the pre-recovery provider `2b918cdab2ebd30e745bb8fa86d077d7a3af0030` to the reviewed merge of `open-hax/eta-mu#304`, `e8eea02d31030215984375980b765803fc72d80d`.

## Observed failure

On Knoxx PR #294, workflow run `33556192336` produced clean deterministic evidence and passed the deterministic publisher tests, then the single MiMo process exited 1. The caller's old provider retained an empty stdout artifact but wrote stderr only to `$RUNNER_TEMP`, so the diagnostic vanished and publication was skipped. That run is an unavailable model review, not a code verdict.

## Recovered contract

The pinned eta-mu revision:

- preserves separate response and stderr files for every invocation;
- records exit code, submission state, and rejected invocation metadata in `recovery.json`;
- finalizes both child-process streams on success, non-zero exit, and spawn failure;
- permits exactly one corrective invocation only when a completed first attempt omitted `review_submit`;
- rejects non-zero exits, malformed submissions, repeated omissions, and rejected invocations before publication;
- keeps publication deterministic and separate from model execution.

## Scope

One reusable-workflow pin plus an explanatory comment. Permissions, secrets, triggers, and the deterministic `diff_stat` gate are unchanged.

## Verification

Hosted exact-head workflow results on `71710f38354dccedd2939ba61a39af25f09c66cc` are required. No result from the failed #294 review is promoted to pass.

Related: open-hax/eta-mu#270, open-hax/eta-mu#297, open-hax/knoxx#294.