### PR TITLE
CI: bind eta-mu review to the exact pull-request head

### DIFF
--- a/.github/workflows/eta-mu-review.yml
+++ b/.github/workflows/eta-mu-review.yml
@@ -18,6 +18,7 @@ jobs:
     # completed invocation omitted review_submit.
     uses: open-hax/eta-mu/.github/workflows/opencode-code-review.yml@e8eea02d31030215984375980b765803fc72d80d
     with:
+      pr_head_sha: ${{ github.event.pull_request.head.sha }}
       setup_eta_mu_toolchain: false
       evidence_gates_script: |
         run_gate diff_stat git diff --stat "${PR_BASE_SHA}...HEAD"


### PR DESCRIPTION
## Signal

Repair the reusable-workflow caller contract introduced when #296 repinned Knoxx to eta-mu's durable recovery provider.

## Failure evidence

The first #296 exact-head review run (`33557148807`) terminated with `startup_failure` and created zero jobs. The referenced eta-mu workflow was resolved correctly, but its `workflow_call` contract requires the immutable `pr_head_sha` input. Knoxx's caller omitted it, so GitHub rejected the call before checkout, deterministic gates, model execution, or publication.

That failure is configuration evidence, not a model verdict and not a code-review result.

## Repair

Pass exactly:

```yaml
pr_head_sha: ${{ github.event.pull_request.head.sha }}
```

The called workflow independently checks that this supplied commit equals the event's pull-request head, exists as a commit, is the executed checkout, and remains clean before evidence gates run.

## Scope

One required reusable-workflow input. The eta-mu provider revision, permissions, secrets, triggers, and Knoxx `diff_stat` evidence gate are unchanged.

## Regression contract

This PR is complete only when the eta-mu reusable workflow creates jobs instead of failing at plan time, verifies the exact PR head, retains invocation response/stderr/recovery artifacts, and reaches a truthful terminal outcome. `knoxx-ci` remains independently required.

Related: #294, #296, open-hax/eta-mu#297, open-hax/eta-mu#324.